### PR TITLE
Hotfix/resolve nuget version

### DIFF
--- a/Test/Resolve-WhiskeyNuGetPackageVersion.Tests.ps1
+++ b/Test/Resolve-WhiskeyNuGetPackageVersion.Tests.ps1
@@ -1,0 +1,128 @@
+Set-StrictMode -Version 'Latest'
+
+& (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-WhiskeyTest.ps1' -Resolve)
+
+$NuGetPackageName = $null
+$output = $null
+$version = $null
+
+function Init
+{
+    $Global:Error.Clear()
+    $Script:NuGetPackageName = $null
+    $Script:output = $null
+    $Script:version = $null
+}
+
+function GivenNuGetPackageName
+{
+    param(
+        $Name
+    )
+
+    $Script:NuGetPackageName = $Name
+}
+
+function GivenVersion
+{
+    param(
+        $Version
+    )
+
+    $Script:version = $Version
+    Mock -CommandName 'Invoke-Command' -ModuleName 'Whiskey' -ParameterFilter { $ScriptBlock.ToString() -match 'list' }
+}
+
+function WhenResolvingNuGetPackageVersion
+{
+    [CmdletBinding()]
+    param()
+
+    $Script:output = Resolve-WhiskeyNuGetPackageVersion -NuGetPackageName $NuGetPackageName -Version $Version
+}
+
+function ThenErrorMessage
+{
+    param(
+        $Message
+    )
+
+    It ('should write error message /{0}/' -f $Message) {
+        $Global:Error | Should -Match $Message
+    }
+}
+
+function ThenNoErrorsWritten
+{
+    It 'should not write any errors' {
+        $Global:Error | Should -BeNullOrEmpty
+    }
+}
+
+function ThenReturnedNothing
+{
+    It 'should not return anything' {
+        $output | Should -BeNullOrEmpty
+    }
+}
+
+function ThenReturnedVersion
+{
+    param(
+        $Version
+    )
+
+    It ('should return version number ''{0}''' -f $Version) {
+        $output | Should -Be $Version
+    }
+}
+
+function ThenReturnedValidSemanticVersion
+{
+    It 'should return a valid semantic version number' {
+        $output | Should -Match '^\d+\.\d+\.\d+.*'
+    }
+}
+
+function ThenShouldNotRunNuget
+{
+    It 'should not run Nuget' {
+        Assert-MockCalled -CommandName 'Invoke-Command' -ModuleName 'Whiskey' -ParameterFilter { $ScriptBlock.ToString() -match 'list' } -Times 0
+    }
+}
+
+Describe 'Resolve-WhiskeyNuGetPackageVersion.when given only a package name' {
+    Init
+    GivenNuGetPackageName 'NuGet.CommandLine'
+    WhenResolvingNuGetPackageVersion
+    ThenReturnedValidSemanticVersion
+    ThenNoErrorsWritten
+}
+
+Describe 'Resolve-WhiskeyNuGetPackageVersion.when given a package name and Version number 1.2.3' {
+    Init
+    GivenNuGetPackageName 'NuGet.CommandLine'
+    GivenVersion '1.2.3'
+    WhenResolvingNuGetPackageVersion
+    ThenShouldNotRunNuget
+    ThenReturnedVersion '1.2.3'
+    ThenNoErrorsWritten
+}
+
+Describe 'Resolve-WhiskeyNuGetPackageVersion.when given a package name and Version number that contains a wildcard' {
+    Init
+    GivenNuGetPackageName 'NuGet.CommandLine'
+    GivenVersion '1.*'
+    WhenResolvingNuGetPackageVersion -ErrorAction SilentlyContinue
+    ThenShouldNotRunNuget
+    ThenErrorMessage 'Wildcards are not allowed for NuGet packages yet because of a bug'
+    ThenReturnedNothing
+}
+
+Describe 'Resolve-WhiskeyNuGetPackageVersion.when package does not exist' {
+    Init
+    GivenNuGetPackageName 'somenonexistentpackage'
+    WhenResolvingNuGetPackageVersion -ErrorAction SilentlyContinue
+    ThenErrorMessage 'Unable to find latest version of package'
+    ThenReturnedNothing
+}

--- a/Whiskey/Functions/Resolve-WhiskeyNuGetPackageVersion.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyNuGetPackageVersion.ps1
@@ -2,7 +2,7 @@ function Resolve-WhiskeyNuGetPackageVersion
 {
     [CmdletBinding()]
     param(
-        
+
         [Parameter(Mandatory=$true)]
         [string]
         # The name of the NuGet package to download.
@@ -22,12 +22,15 @@ function Resolve-WhiskeyNuGetPackageVersion
     if( -not $Version )
     {
         Set-Item -Path 'env:EnableNuGetPackageRestore' -Value 'true'
-        $Version = Invoke-Command -NoNewScope -ScriptBlock {
-            & $NugetPath list ('packageid:{0}' -f $NuGetPackageName) |
-                Where-Object { $_ -match $NuGetPackageName } |
-                Where-Object { $_ -match ' (\d+\.\d+\.\d+.*)' } |
-                ForEach-Object { $Matches[1] }
+        $NuGetPackage = Invoke-Command -NoNewScope -ScriptBlock {
+            & $NugetPath list ('packageid:{0}' -f $NuGetPackageName)
         }
+        $Version = $NuGetPackage |
+            Where-Object { $_ -match $NuGetPackageName } |
+            Where-Object { $_ -match ' (\d+\.\d+\.\d+.*)' } |
+            ForEach-Object { $Matches[1] } |
+            Select-Object -First 1
+
         if( -not $Version )
         {
             Write-Error ("Unable to find latest version of package '{0}'." -f $NuGetPackageName)

--- a/Whiskey/Functions/Resolve-WhiskeyNuGetPackageVersion.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyNuGetPackageVersion.ps1
@@ -22,10 +22,12 @@ function Resolve-WhiskeyNuGetPackageVersion
     if( -not $Version )
     {
         Set-Item -Path 'env:EnableNuGetPackageRestore' -Value 'true'
-        $Version = & $NugetPath list ('packageid:{0}' -f $NuGetPackageName) |
-                        Where-Object { $_ -match $NuGetPackageName } |
-                        Where-Object { $_ -match ' (\d+\.\d+\.\d+.*)' } |
-                        ForEach-Object { $Matches[1] }
+        $Version = Invoke-Command -NoNewScope -ScriptBlock {
+            & $NugetPath list ('packageid:{0}' -f $NuGetPackageName) |
+                Where-Object { $_ -match $NuGetPackageName } |
+                Where-Object { $_ -match ' (\d+\.\d+\.\d+.*)' } |
+                ForEach-Object { $Matches[1] }
+        }
         if( -not $Version )
         {
             Write-Error ("Unable to find latest version of package '{0}'." -f $NuGetPackageName)

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -143,6 +143,7 @@
             # ReleaseNotes of this module
             ReleaseNotes = @'
 * Fixed: Pipeline task was not running in Clean and Initialize modes, thus no tasks in the sub-pipelines were getting cleaned/initialized.
+* Fixed: Resolve-WhiskeyNuGetPackageVersion fails if NuGet.exe returns multiple versions.
 '@
         } # End of PSData hashtable
 


### PR DESCRIPTION
Fixed: Resolve-WhiskeyNuGetPackageVersion fails if NuGet.exe returns multiple versions
