### PR TITLE
Fixed: running a build under TeamCity sometimes doesn't use the correct branch name

### DIFF
--- a/Test/Get-WhiskeyBuildMetadata.Tests.ps1
+++ b/Test/Get-WhiskeyBuildMetadata.Tests.ps1
@@ -158,7 +158,7 @@ InModuleScope 'Whiskey' {
         GivenProperty $buildPropertiesPath 'teamcity.configuration.properties.file' $configPropertiesPath
         GivenProperty $buildPropertiesPath 'teamcity.buildType.id' $BuildTypeID
 
-        GivenProperty $configPropertiesPath 'vcsroot.branch' $VcsBranch
+        GivenProperty $configPropertiesPath 'teamcity.build.branch' $VcsBranch
         GivenProperty $configPropertiesPath 'vcsroot.url' $VcsUri
         GivenProperty $configPropertiesPath 'teamcity.serverUrl' $ServerUri
     }

--- a/Whiskey/Functions/Get-WhiskeyBuildMetadata.ps1
+++ b/Whiskey/Functions/Get-WhiskeyBuildMetadata.ps1
@@ -102,7 +102,7 @@ function Get-WhiskeyBuildMetadata
         $buildInfo.JobName = $buildProperties['teamcity.buildType.id']
         
         $configProperties = Import-TeamCityProperty -Path $buildProperties['teamcity.configuration.properties.file']
-        $buildInfo.ScmBranch = $configProperties['vcsroot.branch'] -replace '^refs/heads/',''
+        $buildInfo.ScmBranch = $configProperties['teamcity.build.branch'] -replace '^refs/heads/',''
         $buildInfo.ScmUri = $configProperties['vcsroot.url']
         $buildInfo.BuildServerName = 'TeamCity'
 

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Whiskey.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.19.1'
+    ModuleVersion = '0.19.2'
 
     # ID used to uniquely identify this module
     GUID = '93bd40f1-dee5-45f7-ba98-cb38b7f5b897'
@@ -142,9 +142,7 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-* Fixed: Pipeline task was not running in Clean and Initialize modes, thus no tasks in the sub-pipelines were getting cleaned/initialized.
-* Fixed: Tasks that install NuGet packages fail if NuGet.exe returns multiple versions of the package.
-* Fixed: variables whose value evaluates/converts to `$false` get replaced with an empty string, e.g. `0`.
+* Fixed: running a build under TeamCity sometimes doesn't use the correct branch name if a build is configured to build on multiple branches.
 '@
         } # End of PSData hashtable
 


### PR DESCRIPTION
…ct branch name if a build is configured to build on multiple branches.