### PR TITLE
Fixed: PowerShell task fails when running scripts with the CmdletBind…

### DIFF
--- a/Test/Invoke-WhiskeyPowerShell.Tests.ps1
+++ b/Test/Invoke-WhiskeyPowerShell.Tests.ps1
@@ -370,3 +370,16 @@ param(
     WhenTheTaskRuns -WithArgument @{ 'SomeBool' = 'true' ; 'SomeOtherBool' = 'false' }
     ThenTheTaskPasses
 }
+
+
+Describe 'Invoke-WhiskeyPowerShell.when script has a common parameter that isn''t an argument' {
+    GivenAScript @"
+Write-Debug 'Fubar'
+"@ -WithParam @"
+[CmdletBinding()]
+param(
+)
+"@
+    WhenTheTaskRuns -WithArgument @{ }
+    ThenTheTaskPasses
+}

--- a/Whiskey/Tasks/Invoke-WhiskeyPowerShell.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyPowerShell.ps1
@@ -75,6 +75,7 @@ function Invoke-WhiskeyPowerShell
         {
             $scriptCommand.Parameters.Values | 
                 Where-Object { $_.ParameterType -eq [switch] } | 
+                Where-Object { $argument.ContainsKey($_.Name) } |
                 ForEach-Object { $argument[$_.Name] = $argument[$_.Name] | ConvertFrom-WhiskeyYamlScalar }
         }
 

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Whiskey.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.20.1'
+    ModuleVersion = '0.20.2'
 
     # ID used to uniquely identify this module
     GUID = '93bd40f1-dee5-45f7-ba98-cb38b7f5b897'
@@ -142,9 +142,7 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-* Fixed: PowerShell task doesn't pass TaskContext to scripts that have a TaskContext parameter.\
-* Pinning Node task to use NSP 2.7.0. Later versions break our automated tests.
-* Pinning NspCheck task to use NSP 2.7.0. Later versions break our automated tests.
+* Fixed: PowerShell task fails when running scripts with the `CmdletBinding` attribute applied and the script uses the `Write-Debug` function (i.e. Verbose and Debug switches always passed to scripts).
 '@
         } # End of PSData hashtable
 


### PR DESCRIPTION
…ing attribute applied and the script uses the Write-Debug function (i.e. Verbose and Debug switches always passed to scripts).