### PR TITLE
0.23.0

### DIFF
--- a/Test/New-WhiskeyProGetUniversalPackage.Tests.ps1
+++ b/Test/New-WhiskeyProGetUniversalPackage.Tests.ps1
@@ -10,7 +10,6 @@ $packageVersion = $null
 $buildVersion = $null
 
 $threwException = $false
-$temporaryPackageDir = $null
 $context = $null
 $expandPath = $null
 
@@ -40,7 +39,6 @@ function GivenPackageVersion
 function Init
 {
     $script:threwException = $false
-    $script:temporaryPackageDir = Join-Path -Path $TestDrive.FullName -ChildPath 'TempDir'
     $script:packageVersion = $null
     $script:buildVersion = $null
     $script:context = $null
@@ -746,13 +744,6 @@ function ThenPackageShouldbeBeCompressed
 
 }
 
-function ThenTempDirectoryCleanedUp
-{
-    It 'should clean up the temporary packaging directory' {
-        $temporaryPackageDir | Should -Not -Exist
-    }
-}
-
 Describe 'ProGetUniversalPackage.when packaging everything in a directory' {
     Init
     $dirNames = @( 'dir1', 'dir1\sub' )
@@ -764,7 +755,6 @@ Describe 'ProGetUniversalPackage.when packaging everything in a directory' {
                                             -ThatIncludes '*.html' `
                                             -HasRootItems $dirNames `
                                             -HasFiles 'html.html'
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when packaging root files' {
@@ -776,7 +766,6 @@ Describe 'ProGetUniversalPackage.when packaging root files' {
                                             -WithThirdPartyRootItem $thirdPartyFile `
                                             -HasThirdPartyRootItem $thirdPartyFile `
                                             -HasRootItems $file 
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when packaging whitelisted files in a directory' {
@@ -791,7 +780,6 @@ Describe 'ProGetUniversalPackage.when packaging whitelisted files in a directory
                                             -HasRootItems $dirNames `
                                             -HasFiles 'html.html','style.css' `
                                             -NotHasFiles 'code.cs'
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when packaging multiple directories' {
@@ -806,7 +794,6 @@ Describe 'ProGetUniversalPackage.when packaging multiple directories' {
                                             -HasRootItems $dirNames `
                                             -HasFiles 'html.html' `
                                             -NotHasFiles 'code.cs'
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when whitelist includes items that need to be excluded' {    
@@ -822,7 +809,6 @@ Describe 'ProGetUniversalPackage.when whitelist includes items that need to be e
                                             -HasRootItems 'dir1' `
                                             -HasFiles 'html.html' `
                                             -NotHasFiles 'html2.html','sub' 
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when paths don''t exist' {
@@ -837,7 +823,6 @@ Describe 'ProGetUniversalPackage.when paths don''t exist' {
                                             -ShouldFailWithErrorMessage '(don''t|does not) exist' `
                                             -ShouldNotCreatePackage `
                                             -ErrorAction SilentlyContinue 
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when path contains known directories to exclude' {
@@ -851,7 +836,6 @@ Describe 'ProGetUniversalPackage.when path contains known directories to exclude
                                             -HasRootItems 'dir1' `
                                             -HasFiles 'html.html' `
                                             -NotHasFiles '.git','.hg','obj' 
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when including third-party items' {
@@ -868,7 +852,6 @@ Describe 'ProGetUniversalPackage.when including third-party items' {
                                             -WithThirdPartyRootItem 'thirdparty','thirdpart2' `
                                             -HasThirdPartyRootItem 'thirdparty','thirdpart2' `
                                             -HasThirdPartyFile 'thirdparty.txt' 
-    ThenTempDirectoryCleanedUp
 }
 
 foreach( $parameterName in @( 'Name', 'Description' ) )
@@ -947,7 +930,6 @@ Describe 'ProGetUniversalPackage.when application root isn''t the root of the re
                                             -HasThirdPartyRootItem 'thirdparty','thirdpart2' `
                                             -HasThirdPartyFile 'thirdparty.txt' `
                                             -FromSourceRoot 'app' 
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when custom application root doesn''t exist' {
@@ -1004,7 +986,6 @@ Describe 'ProGetUniversalPackage.when packaging given a full relative path' {
 
     $outputFilePath = Initialize-Test -DirectoryName $directory -FileName $file
     Assert-NewWhiskeyProGetUniversalPackage -ForPath $path -HasRootItems $path
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when packaging given a full relative path with override syntax' {
@@ -1016,7 +997,6 @@ Describe 'ProGetUniversalPackage.when packaging given a full relative path with 
 
     $outputFilePath = Initialize-Test -DirectoryName $directory -FileName $file
     Assert-NewWhiskeyProGetUniversalPackage -ForPath $forPath -HasRootItems $file
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when including third-party items with override syntax' {
@@ -1028,7 +1008,6 @@ Describe 'ProGetUniversalPackage.when including third-party items with override 
     WhenPackaging -Paths 'dir1' -WithWhitelist @('thirdparty.txt') -WithThirdPartyPath @{ 'app\thirdparty' = 'thirdparty' },$thirdPartyDictionary
     ThenTaskSucceeds
     ThenPackageShouldInclude 'dir1\thirdparty.txt', 'thirdparty\none of your business','fourthparty\none of your business'
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when package is empty' {
@@ -1036,7 +1015,6 @@ Describe 'ProGetUniversalPackage.when package is empty' {
     GivenARepositoryWIthItems 'file.txt'
     WhenPackaging -WithWhitelist "*.txt"
     ThenPackageShouldInclude
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when path contains wildcards' {
@@ -1044,7 +1022,6 @@ Describe 'ProGetUniversalPackage.when path contains wildcards' {
     GivenARepositoryWIthItems 'one.ps1','two.ps1','three.ps1'
     WhenPackaging -Paths '*.ps1' -WithWhitelist '*.txt'
     ThenPackageShouldInclude 'one.ps1','two.ps1','three.ps1'
-    ThenTempDirectoryCleanedUp
 }
 
 
@@ -1054,7 +1031,6 @@ Describe 'ProGetUniversalPackage.when packaging a directory' {
     WhenPackaging -Paths 'dir1\subdir\' -WithWhitelist "*.txt"
     ThenPackageShouldInclude 'dir1\subdir\file.txt'
     ThenPackageShouldNotInclude ('dir1\{0}' -f $defaultPackageName)
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when packaging a directory with a space' {
@@ -1063,7 +1039,6 @@ Describe 'ProGetUniversalPackage.when packaging a directory with a space' {
     WhenPackaging -Paths 'dir 1\sub dir' -WithWhitelist "*.txt"
     ThenPackageShouldInclude 'dir 1\sub dir\file.txt'
     ThenPackageShouldNotInclude ('dir 1\{0}' -f $defaultPackageName)
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when packaging a directory with a space and trailing backslash' {
@@ -1072,7 +1047,6 @@ Describe 'ProGetUniversalPackage.when packaging a directory with a space and tra
     WhenPackaging -Paths 'dir 1\sub dir\' -WithWhitelist "*.txt"
     ThenPackageShouldInclude 'dir 1\sub dir\file.txt'
     ThenPackageShouldNotInclude ('dir 1\{0}' -f $defaultPackageName)
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when compressionLevel of 9 is included' {
@@ -1080,7 +1054,6 @@ Describe 'ProGetUniversalPackage.when compressionLevel of 9 is included' {
     GivenARepositoryWIthItems 'one.ps1'
     WhenPackaging -Paths '*.ps1' -WithWhitelist "*.ps1" -CompressionLevel 9
     ThenPackageShouldbeBeCompressed 'one.ps1' -LessThanOrEqualTo 800
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when compressionLevel is not included' {
@@ -1088,7 +1061,6 @@ Describe 'ProGetUniversalPackage.when compressionLevel is not included' {
     GivenARepositoryWIthItems 'one.ps1'
     WhenPackaging -Paths '*.ps1' -WithWhitelist "*.ps1"
     ThenPackageShouldbeBeCompressed 'one.ps1' -GreaterThan 800
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when a bad compressionLevel is included' {
@@ -1103,25 +1075,22 @@ Describe 'ProGetUniversalPackage.when compressionLevel of 7 is included as a str
     GivenARepositoryWIthItems 'one.ps1'
     WhenPackaging -Paths '*.ps1' -WithWhitelist "*.ps1" -CompressionLevel "7"
     ThenPackageShouldbeBeCompressed 'one.ps1' -LessThanOrEqualTo 800
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when package has empty directories' {
     Init
     GivenARepositoryWithItems 'root.ps1','dir1\one.ps1','dir1\emptyDir2\text.txt'
     GivenARepositoryWithItems 'dir1\emptyDir1' -ItemType 'Directory'
-    WhenPackaging -Paths '.' -WithWhitelist '*.ps1'
+    WhenPackaging -Paths '.' -WithWhitelist '*.ps1' -ThatExcludes '.output'
     ThenPackageShouldInclude 'root.ps1','dir1\one.ps1'
     ThenPackageShouldNotInclude 'dir1\emptyDir1', 'dir1\emptyDir2'
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when package has JSON files' {
     Init
     GivenARepositoryWIthItems 'my.json'
-    WhenPackaging -Paths '.' -WithWhitelist '*.json'
+    WhenPackaging -Paths '.' -WithWhitelist '*.json' -ThatExcludes '.output'
     ThenPackageShouldInclude 'my.json','version.json'
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'New-WhiskeyProGetUniversalPackage.when package contains only third-party paths and only files' {
@@ -1130,7 +1099,6 @@ Describe 'New-WhiskeyProGetUniversalPackage.when package contains only third-par
     WhenPackaging -WithThirdPartyPath 'dir' -Paths 'my.json'
     ThenPackageShouldInclude 'version.json','dir\yours.json', 'my.json'
     ThenPackageShouldNotInclude 'my.txt'
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when package includes a directory but whitelist is empty' {
@@ -1153,19 +1121,6 @@ Describe 'ProGetUniversalPackage.when package includes a file and there''s no wh
     ThenPackageShouldInclude 'dir\my.json'
     ThenTaskSucceeds
     ThenPackageShouldNotInclude 'dir\yours.json'
-    ThenTempDirectoryCleanedUp
-}
-
-Describe 'ProGetUniversalPackage.when temporary packing directory contains paths longer than 260 characters' {
-    Init
-    GivenARepositoryWIthItems 'file.txt'
-
-    # create a REALLY long path in the temp directory
-    $longFilePath = Join-Path -Path $temporaryPackageDir -ChildPath ('a' * 248)
-    & robocopy $(Get-BuildRoot) $longFilePath 'file.txt' /create
-
-    WhenPackaging -Paths '.' -WithWhitelist 'file.txt' -SkipExpand
-    ThenTempDirectoryCleanedUp
 }
 
 Describe 'ProGetUniversalPackage.when customizing package version' {

--- a/Test/New-WhiskeyProGetUniversalPackage.Tests.ps1
+++ b/Test/New-WhiskeyProGetUniversalPackage.Tests.ps1
@@ -825,19 +825,6 @@ Describe 'ProGetUniversalPackage.when paths don''t exist' {
                                             -ErrorAction SilentlyContinue 
 }
 
-Describe 'ProGetUniversalPackage.when path contains known directories to exclude' {
-    Init
-    $dirNames = @( 'dir1', 'dir1/.hg', 'dir1/.git', 'dir1/obj', 'dir1/sub/.hg', 'dir1/sub/.git', 'dir1/sub/obj' )
-    $filenames = 'html.html'
-    $outputFilePath = Initialize-Test -DirectoryName $dirNames -FileName $filenames
-    
-    Assert-NewWhiskeyProGetUniversalPackage -ForPath 'dir1' `
-                                            -ThatIncludes '*.html' `
-                                            -HasRootItems 'dir1' `
-                                            -HasFiles 'html.html' `
-                                            -NotHasFiles '.git','.hg','obj' 
-}
-
 Describe 'ProGetUniversalPackage.when including third-party items' {
     Init
     $dirNames = @( 'dir1', 'thirdparty', 'thirdpart2' )

--- a/Test/Resolve-WhiskeyVariable.Tests.ps1
+++ b/Test/Resolve-WhiskeyVariable.Tests.ps1
@@ -288,3 +288,10 @@ Describe 'Resolve-WhiskeyVariable.when property name is variable' {
     WhenResolving @{ '$(COMPUTERNAME)' = 'fubarsnafu' }
     ThenValueIs @{ $env:COMPUTERNAME = 'fubarsnafu' }
 }
+
+Describe 'Resolve-WhiskeyVariable.when value is empty' {
+    Init
+    GivenVariable 'FUBAR' ''
+    WhenResolving 'prefix$(FUBAR)suffix'
+    ThenValueIs 'prefixsuffix'
+}

--- a/Test/Set-WhiskeyVariable.Tests.ps1
+++ b/Test/Set-WhiskeyVariable.Tests.ps1
@@ -116,3 +116,9 @@ Describe 'SetVariable.when running in initialize mode' {
     WhenCallingTask @{ 'InInitializeMode' = 'true' }
     ThenVariable 'InInitializeMode' -Is 'true'
 }
+
+Describe 'SetVariable.when variable value is empty' {
+    Init
+    WhenCallingTask @{ 'Variable1' = '' }
+    ThenVariable 'Variable1' -Is ''
+}

--- a/Whiskey/Functions/Add-WhiskeyVariable.ps1
+++ b/Whiskey/Functions/Add-WhiskeyVariable.ps1
@@ -26,6 +26,7 @@ function Add-WhiskeyVariable
         $Name,
 
         [Parameter(Mandatory=$true)]
+        [AllowEmptyString()]
         [string]
         $Value
     )

--- a/Whiskey/Functions/Invoke-WhiskeyTask.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyTask.ps1
@@ -50,11 +50,20 @@ function Invoke-WhiskeyTask
             $result = 'FAILED'
             try
             {
+                $TaskContext.Temp = Join-Path -Path $TaskContext.OutputDirectory -ChildPath ('Temp.{0}.On{1}.{2}' -f $Name,$EventName,[IO.Path]::GetRandomFileName())
+                if( -not (Test-Path -Path $TaskContext.Temp -PathType Container) )
+                {
+                    New-Item -Path $TaskContext.Temp -ItemType 'Directory' -Force
+                }
                 & $commandName -TaskContext $TaskContext -TaskName $Name -TaskParameter $Property
                 $result = 'COMPLETED'
             }
             finally
             {
+                if( (Test-Path -Path $TaskContext.Temp -PathType Container) )
+                {
+                    Remove-Item -Path $TaskContext.Temp -Recurse -Force -ErrorAction Ignore
+                }
                 $endedAt = Get-Date
                 $duration = $endedAt - $startedAt
                 Write-Verbose ('{0}  {1}  {2} in {3}' -f $prefix,(' ' * ($EventName.Length + 4)),$result,$duration)
@@ -244,11 +253,20 @@ function Invoke-WhiskeyTask
     $result = 'FAILED'
     try
     {
+        $TaskContext.Temp = Join-Path -Path $TaskContext.OutputDirectory -ChildPath ('Temp.{0}.{1}' -f $task.Name,[IO.Path]::GetRandomFileName())
+        if( -not (Test-Path -Path $TaskContext.Temp -PathType Container) )
+        {
+            New-Item -Path $TaskContext.Temp -ItemType 'Directory' -Force | Out-Null
+        }
         & $task.CommandName -TaskContext $TaskContext -TaskParameter $taskProperties
         $result = 'COMPLETED'
     }
     finally
     {
+        if( (Test-Path -Path $TaskContext.Temp -PathType Container) )
+        {
+            Remove-Item -Path $TaskContext.Temp -Recurse -Force -ErrorAction Ignore
+        }
         $endedAt = Get-Date
         $duration = $endedAt - $startedAt
         Write-Verbose ('{0}  {1} in {2}' -f $prefix,$result,$duration)

--- a/Whiskey/Functions/Invoke-WhiskeyTask.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyTask.ps1
@@ -53,7 +53,7 @@ function Invoke-WhiskeyTask
                 $TaskContext.Temp = Join-Path -Path $TaskContext.OutputDirectory -ChildPath ('Temp.{0}.On{1}.{2}' -f $Name,$EventName,[IO.Path]::GetRandomFileName())
                 if( -not (Test-Path -Path $TaskContext.Temp -PathType Container) )
                 {
-                    New-Item -Path $TaskContext.Temp -ItemType 'Directory' -Force
+                    New-Item -Path $TaskContext.Temp -ItemType 'Directory' -Force | Out-Null
                 }
                 & $commandName -TaskContext $TaskContext -TaskName $Name -TaskParameter $Property
                 $result = 'COMPLETED'
@@ -253,7 +253,7 @@ function Invoke-WhiskeyTask
     $result = 'FAILED'
     try
     {
-        $TaskContext.Temp = Join-Path -Path $TaskContext.OutputDirectory -ChildPath ('Temp.{0}.{1}' -f $task.Name,[IO.Path]::GetRandomFileName())
+        $TaskContext.Temp = Join-Path -Path $TaskContext.OutputDirectory -ChildPath ('Temp.{0}.{1}' -f $Name,[IO.Path]::GetRandomFileName())
         if( -not (Test-Path -Path $TaskContext.Temp -PathType Container) )
         {
             New-Item -Path $TaskContext.Temp -ItemType 'Directory' -Force | Out-Null

--- a/Whiskey/Functions/New-WhiskeyContextObject.ps1
+++ b/Whiskey/Functions/New-WhiskeyContextObject.ps1
@@ -10,24 +10,25 @@ function New-WhiskeyContextObject
 
     $context = [pscustomobject]@{
                                     ApiKeys = @{ };
-                                    Environment = '';
-                                    Credentials = @{ }
                                     BuildRoot = '';
-                                    ConfigurationPath = '';
-                                    OutputDirectory = '';
-                                    TaskName = '';
-                                    TaskIndex = -1;
-                                    PipelineName = '';
-                                    TaskDefaults = @{ };
-                                    Version = (New-WhiskeyVersionObject);
-                                    Configuration = @{ };
-                                    DownloadRoot = '';
                                     ByBuildServer = $false;
                                     ByDeveloper = $true;
+                                    BuildMetadata = (New-WhiskeyBuildMetadataObject);
+                                    Configuration = @{ };
+                                    ConfigurationPath = '';
+                                    Credentials = @{ }
+                                    DownloadRoot = '';
+                                    Environment = '';
+                                    OutputDirectory = '';
+                                    PipelineName = '';
                                     Publish = $false;
                                     RunMode = 'Build';
-                                    BuildMetadata = (New-WhiskeyBuildMetadataObject);
+                                    TaskName = '';
+                                    TaskIndex = -1;
+                                    TaskDefaults = @{ };
+                                    Temp = '';
                                     Variables = @{ };
+                                    Version = (New-WhiskeyVersionObject);
                                 }
     $context | Add-Member -MemberType ScriptMethod -Name 'ShouldClean' -Value { return $this.RunMode -eq 'Clean' }
     $context | Add-Member -MemberType ScriptMethod -Name 'ShouldInitialize' -Value { return $this.RunMode -eq 'Initialize' }

--- a/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
+++ b/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
@@ -418,7 +418,7 @@ function New-WhiskeyProGetUniversalPackage
                     $destinationDisplay = $destinationDisplay.Trim('\')
                     if( $AsThirdPartyItem )
                     {
-                        $exclude = @()
+                        $robocopyExclude = @()
                         $whitelist = @( )
                         $operationDescription = 'packaging third-party {0} -> {1}' -f $sourcePath,$destinationDisplay
                     }
@@ -430,13 +430,13 @@ function New-WhiskeyProGetUniversalPackage
                             return
                         }
 
-                        $exclude = & { '.git' ;  '.hg' ; 'obj' ; $exclude ; (Join-Path -Path $destination -ChildPath 'version.json') } 
+                        $robocopyExclude = & { $TaskParameter['Exclude'] ; (Join-Path -Path $destination -ChildPath 'version.json') } 
                         $operationDescription = 'packaging {0} -> {1}' -f $sourcePath,$destinationDisplay
                         $whitelist = & { 'upack.json' ; $TaskParameter['Include'] }
                     }
 
                     Write-Verbose -Message $operationDescription
-                    Invoke-WhiskeyRobocopy -Source $sourcePath.trim("\") -Destination $destination.trim("\") -WhiteList $whitelist -Exclude $exclude | Write-Verbose
+                    Invoke-WhiskeyRobocopy -Source $sourcePath.trim("\") -Destination $destination.trim("\") -WhiteList $whitelist -Exclude $robocopyExclude | Write-Verbose
                 }
             }
         }

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -144,7 +144,7 @@
             ReleaseNotes = @'
 * Fixed: SetVariable task fails when a variable's value is empty.
 * Every task and event handler now gets its own temp directory under `.output` where it can put temporary files. The directory is automatically deleted when the task finishes. Use the `Temp` property on the `$TaskContext` task/event parameter.
-* New-ProGetUniversalPackage task no longer excludes .git, .hg, or obj directories. 
+* ProGetUniversalPackage task no longer excludes .git, .hg, or obj directories. 
 '@
         } # End of PSData hashtable
 

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -143,6 +143,7 @@
             # ReleaseNotes of this module
             ReleaseNotes = @'
 * Fixed: SetVariable task fails when a variable's value is empty.
+* Every task and event handler now gets its own temp directory under `.output` where it can put temporary files. The directory is automatically deleted when the task finishes. Use the `Temp` property on the `$TaskContext` task/event parameter.
 '@
         } # End of PSData hashtable
 

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -144,6 +144,7 @@
             ReleaseNotes = @'
 * Fixed: SetVariable task fails when a variable's value is empty.
 * Every task and event handler now gets its own temp directory under `.output` where it can put temporary files. The directory is automatically deleted when the task finishes. Use the `Temp` property on the `$TaskContext` task/event parameter.
+* New-ProGetUniversalPackage task no longer excludes .git, .hg, or obj directories. 
 '@
         } # End of PSData hashtable
 

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Whiskey.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.22.1'
+    ModuleVersion = '0.23.0'
 
     # ID used to uniquely identify this module
     GUID = '93bd40f1-dee5-45f7-ba98-cb38b7f5b897'
@@ -142,9 +142,7 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-* Fixed: NUnit2 tests fail to run when code coverage is disabled (i.e. they are not run through OpenCover) and the `Include` parameter's value contains a space.
-* Fixed: NUnit2 task's verbose output doesn't align correctly.
-* Fixed: NUnit2 task's verbose output doesn't properly show code coverage filter when there are multiple filters.
+* Fixed: SetVariable task fails when a variable's value is empty.
 '@
         } # End of PSData hashtable
 


### PR DESCRIPTION
Every task now gets its own temp directory under `.output`. This is a better place since virus scan exclusions are usually made on an entire drive/directory and I don't want to fight to exclude the build user's temp directory.

Removed the default .hg, .git, and obj exclusion items so that if/when someone actually wants to include them, they can.