### PR TITLE
`New-WhiskeySemanticVersion` could not read `Version` property from .…

### DIFF
--- a/Test/New-WhiskeySemanticVersion.Tests.ps1
+++ b/Test/New-WhiskeySemanticVersion.Tests.ps1
@@ -410,3 +410,18 @@ Describe 'New-WhiskeySemanticVersion.when given Path to a ''.csproj'' with a val
     WhenGettingSemanticVersion
     ThenAddedBuildMetadataToSemanticVersionOf '1.2.3'
 }
+
+Describe 'New-WhiskeySemanticVersion.when given Path to a ''.csproj'' with a valid version and a default xml namespace' {
+    Init
+    GivenFile 'dotnetlibrary.csproj' @'
+    <Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+        <PropertyGroup>
+            <Description>Library description</Description>
+            <Version>1.2.3</Version>
+        </PropertyGroup>
+    </Project>
+'@
+    GivenPath 'dotnetlibrary.csproj'
+    WhenGettingSemanticVersion
+    ThenAddedBuildMetadataToSemanticVersionOf '1.2.3'
+}

--- a/Whiskey/Functions/New-WhiskeySemanticVersion.ps1
+++ b/Whiskey/Functions/New-WhiskeySemanticVersion.ps1
@@ -128,11 +128,18 @@ function New-WhiskeySemanticVersion
                 return
             }
 
-            $csprojVersion = $csprojXml.SelectNodes('/Project/PropertyGroup/Version') | Select-Object -ExpandProperty '#text'
+            $xmlns = New-Object System.Xml.XmlNamespaceManager($csprojXml.NameTable)
+            $xmlns.AddNamespace('ns', $csprojXml.DocumentElement.NamespaceURI)
+            $csprojVersionNode = $csprojXml.SelectSingleNode('//ns:Version', $xmlns)
+            $csprojVersion = $null
+            if( $csprojVersionNode )
+            {
+                $csprojVersion = $csprojVersionNode.InnerXml
+            }
 
             if( -not $csprojVersion )
             {
-                Write-Error -Message ('Unable to get the version to build from the csproj file ''{0}'' as it either did''t contain a ''Version'' element or the element text was empty. Please make sure there is a valid ''Version'' element located under ''/Project/PropertyGroup'', e.g.
+                Write-Error -Message ('Unable to get the version to build from the csproj file ''{0}'' as it either didn''t contain a ''Version'' element or the element text was empty. Please make sure there is a valid ''Version'' element located under ''/Project/PropertyGroup'', e.g.
 
                 <Project Sdk="Microsoft.NET.Sdk">
                     <PropertyGroup>

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Whiskey.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.28.0'
+    ModuleVersion = '0.28.1'
 
     # ID used to uniquely identify this module
     GUID = '93bd40f1-dee5-45f7-ba98-cb38b7f5b897'
@@ -144,8 +144,7 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-* Added `Add-WhiskeyTaskDefault` function for adding new task default parameter values to an existing task context object.
-* Added `TaskDefaults` task for setting default values for task properties.
+* Fixed: `New-WhiskeySemanticVersion` could not read `Version` property from .csproj files if they contained a default xml namespace.
 '@
         } # End of PSData hashtable
 


### PR DESCRIPTION
…csproj files if they contained a default xml namespace