### PR TITLE
(0.30.0) PowerShell and Exec tasks should run in every mode

### DIFF
--- a/Test/Invoke-WhiskeyExec.Tests.ps1
+++ b/Test/Invoke-WhiskeyExec.Tests.ps1
@@ -110,6 +110,14 @@ function GivenTaskDefaultProperty
 
 function WhenRunningExecutable
 {
+    param(
+        [Switch]
+        $InCleanMode,
+
+        [Switch]
+        $InInitializeMode
+    )
+
     $TaskParameter = @{}
 
     if( $path )
@@ -137,7 +145,7 @@ function WhenRunningExecutable
         $TaskParameter[''] = $defaultProperty
     }
 
-    $context = New-WhiskeyTestContext -ForDeveloper -ForBuildRoot (Get-BuildRoot)
+    $context = New-WhiskeyTestContext -ForDeveloper -ForBuildRoot (Get-BuildRoot) -InCleanMode:$InCleanMode -InInitMode:$InInitializeMode
 
     Try 
     {
@@ -455,4 +463,22 @@ Describe 'Invoke-WhiskeyExec.when running executable located by the Path environ
     ThenExecutableRan
     ThenRanInWorkingDirectory '.'
     ThenTaskSuccess
+}
+
+Describe 'Exec.when running in Clean mode' {
+    Init
+    GivenExecutableFile 'executable.bat' 'exit 0'
+    GivenPath 'executable.bat'
+    WhenRunningExecutable -InCleanMode
+    ThenTaskSuccess
+    ThenExecutableRan
+}
+
+Describe 'Exec.when running in Initialize mode' {
+    Init
+    GivenExecutableFile 'executable.bat' 'exit 0'
+    GivenPath 'executable.bat'
+    WhenRunningExecutable -InInitializeMode
+    ThenTaskSuccess
+    ThenExecutableRan
 }

--- a/Test/Invoke-WhiskeyPowerShell.Tests.ps1
+++ b/Test/Invoke-WhiskeyPowerShell.Tests.ps1
@@ -121,16 +121,7 @@ function WhenTheTaskRuns
         $taskParameter['Argument'] = $WithArgument
     }
 
-    $context = New-WhiskeyTestContext -ForDeveloper
-    
-    if( $InCleanMode )
-    {
-        $context.RunMode = 'Clean'
-    }
-    elseif( $InInitMode )
-    {
-        $context.RunMode = 'Initialize'
-    }
+    $context = New-WhiskeyTestContext -ForDeveloper -InCleanMode:$InCleanMode -InInitMode:$InInitMode
     
     $failed = $false
 

--- a/Test/Invoke-WhiskeyPowerShell.Tests.ps1
+++ b/Test/Invoke-WhiskeyPowerShell.Tests.ps1
@@ -95,9 +95,14 @@ function WhenTheTaskRuns
 {
     [CmdletBinding()]
     param(
-
         [object]
-        $WithArgument
+        $WithArgument,
+
+        [Switch]
+        $InCleanMode,
+
+        [Switch]
+        $InInitMode
     )
 
     $taskParameter = @{
@@ -117,6 +122,15 @@ function WhenTheTaskRuns
     }
 
     $context = New-WhiskeyTestContext -ForDeveloper
+    
+    if( $InCleanMode )
+    {
+        $context.RunMode = 'Clean'
+    }
+    elseif( $InInitMode )
+    {
+        $context.RunMode = 'Initialize'
+    }
     
     $failed = $false
 
@@ -371,4 +385,24 @@ param(
 "@
     WhenTheTaskRuns -WithArgument @{ }
     ThenTheTaskPasses
+}
+
+Describe 'PowerShell.when run in Clean mode' {
+    GivenAScript @'
+New-Item -Path 'clean' -itemType 'File'
+'@
+    WhenTheTaskRuns -InCleanMode
+    It ('should run the script') {
+        ThenFile -Path 'clean'
+    }
+}
+
+Describe 'PowerShell.when run in Initialize mode' {
+    GivenAScript @'
+New-Item -Path 'init' -itemType 'File'
+'@
+    WhenTheTaskRuns -InInitMode
+    It ('should run the script') {
+        ThenFile -Path 'init'
+    }
 }

--- a/Test/Invoke-WhiskeyPowerShell.Tests.ps1
+++ b/Test/Invoke-WhiskeyPowerShell.Tests.ps1
@@ -379,21 +379,15 @@ param(
 }
 
 Describe 'PowerShell.when run in Clean mode' {
-    GivenAScript @'
-New-Item -Path 'clean' -itemType 'File'
-'@
+    GivenAScript
     WhenTheTaskRuns -InCleanMode
-    It ('should run the script') {
-        ThenFile -Path 'clean'
-    }
+    ThenTheTaskPasses
+    ThenTheScriptRan
 }
 
 Describe 'PowerShell.when run in Initialize mode' {
-    GivenAScript @'
-New-Item -Path 'init' -itemType 'File'
-'@
+    GivenAScript 
     WhenTheTaskRuns -InInitMode
-    It ('should run the script') {
-        ThenFile -Path 'init'
-    }
+    ThenTheTaskPasses
+    ThenTheScriptRan
 }

--- a/Test/WhiskeyTest.psm1
+++ b/Test/WhiskeyTest.psm1
@@ -254,7 +254,13 @@ function New-WhiskeyTestContext
         $DownloadRoot,
 
         [Switch]
-        $IgnoreExistingOutputDirectory
+        $IgnoreExistingOutputDirectory,
+
+        [Switch]
+        $InCleanMode,
+
+        [Switch]
+        $InInitMode
     )
 
     Set-StrictMode -Version 'Latest'
@@ -300,6 +306,15 @@ function New-WhiskeyTestContext
     $context.ConfigurationPath = $ConfigurationPath
     $context.DownloadRoot = $context.BuildRoot
     $context.Configuration = $configData
+
+    if( $InCleanMode )
+    {
+        $context.RunMode = 'Clean'
+    }
+    elseif( $InInitMode )
+    {
+        $context.RunMode = 'Initialize'
+    }
 
     if( -not $ForOutputDirectory )
     {

--- a/Whiskey/Tasks/Invoke-WhiskeyExec.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyExec.ps1
@@ -71,7 +71,7 @@ function Invoke-WhiskeyExec
             - /C
             - init.bat
 
-    Demonstrates how to run an executable except when the build is cleaning. If you have am executable you want to use to initialize your build environment, it should run during the build and initialize modes. Set the `ExceptDuring` property to `Clean` to make that happen.
+    Demonstrates how to run an executable except when the build is cleaning. If you have an executable you want to use to initialize your build environment, it should run during the build and initialize modes. Set the `ExceptDuring` property to `Clean` to make that happen.
 
     ### Example 5
 

--- a/Whiskey/Tasks/Invoke-WhiskeyExec.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyExec.ps1
@@ -15,6 +15,8 @@ function Invoke-WhiskeyExec
 
     By default, the executable is run from your `whiskey.yml` file's directory (i.e. the build root). Change the working directory with the `WorkingDirectory` property.
 
+    The "Exec" task runs in all modes: during initialization, build, and clean modes. If you want executable to only run in one mode, use the `OnlyDuring` property to specify the only mode you want it to run in or the `ExceptDuring` property to specify the run mode you don't want it to run in. 
+
     # Properties
 
     * `Path` (*mandatory*): the path to the executable to run. This can be the name of an executable if it is in your PATH environment variable, a path relative to the `whiskey.yml` file, or an absolute path.
@@ -26,29 +28,29 @@ function Invoke-WhiskeyExec
 
     ## Example 1
 
-            BuildTasks:
-            - Exec:
-                Path: cmd.exe
-                Argument:
-                - /C
-                - dir C:\
+        BuildTasks:
+        - Exec:
+            Path: cmd.exe
+            Argument:
+            - /C
+            - dir C:\
 
     This example demonstrates how to call an executable whose arguments have to be quoted a specific way. In this case, we're using `cmd.exe` to get a directory listing of the `C:\` directory. This example will run `cmd.exe /C dir C:\.
 
     ## Example 2
 
-            BuildTasks:
-            - Exec:
-                Path: robocopy.exe
-                Argument:
-                - C:\Source
-                - C:\Destination
-                - /MIR    
-                SuccessExitCode:
-                - 10
-                - 12
-                - <8
-                - >=28
+        BuildTasks:
+        - Exec:
+            Path: robocopy.exe
+            Argument:
+            - C:\Source
+            - C:\Destination
+            - /MIR    
+            SuccessExitCode:
+            - 10
+            - 12
+            - <8
+            - >=28
 
     This example demonstrates how to configure the `Exec` task to fail when an executable can return multiple success exit codes. In this case, `robocopy.exe` can return any value less than 8, greater than or equal to 28, 10, or 12, to report a successful copy.
 
@@ -58,10 +60,33 @@ function Invoke-WhiskeyExec
             - Exec: robocopy.exe "C:\Source Folder" C:\Destination Folder '/MIR'
 
     This example demonstrates the single line syntax for defining the `Exec` task. Everything before the first delimiter is used as the executable's `Path` (robocopy.exe). 'C:\Source Folder', 'C:\Destination', 'Folder' and '/MIR' will be passed as 4 separate arguments.
-    #>      
 
+    ### Example 4
+
+        BuildTasks:
+        - Exec:
+            ExceptDuring: Clean
+            Path: cmd.exe
+            Argument:
+            - /C
+            - init.bat
+
+    Demonstrates how to run an executable except when the build is cleaning. If you have am executable you want to use to initialize your build environment, it should run during the build and initialize modes. Set the `ExceptDuring` property to `Clean` to make that happen.
+
+    ### Example 5
+
+        BuildTasks:
+        - Exec:
+            OnlyDuring: Clean
+            Path: cmd.exe
+            Argument:
+            - /C
+            - clean.bat
+
+    Demonstrates how to run an executable in a specific mode. In this example, the cmd.exe executable will only run the clean.bat script when the build is cleaning.
+    #>      
     [CmdletBinding()]
-    [Whiskey.Task("Exec")]
+    [Whiskey.Task("Exec",SupportsClean=$true,SupportsInitialize=$true)]
     param(
         [Parameter(Mandatory=$true)]
         [object]

--- a/Whiskey/Tasks/Invoke-WhiskeyPowerShell.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyPowerShell.ps1
@@ -1,7 +1,66 @@
 
 function Invoke-WhiskeyPowerShell
 {
-    [Whiskey.Task("PowerShell")]
+    <#
+    .SYNOPSIS
+    Executes PowerShell tasks.
+
+    .DESCRIPTION
+    The PowerShell tasks runs PowerShell scripts. You specify the scripts to run via the `Path` property. Paths must be relative to the whiskey.yml file. Pass arguments to the scripts with the `Argument` property, which is a hash table of parameter names and values. PowerShell scripts are run in new, background processes.
+
+    The PowerShell task runs your script in *all* build modes: during builds, during initialization, and during clean. If you want your script to only run in one mode, use the global `OnlyDuring` property to specify the mode you want it to run in or the `ExceptDuring` property to specify the run mode you don't want it to run in.
+
+    The PowerShell task will fail a build if the script it runs returns a non-zero exit code or sets the `$?` variable to `$false`.
+
+    To receive the current build context as a parameter to your PowerShell script, add a `$TaskContext` parameter, e.g.
+
+        param(
+            [object]
+            $TaskContext
+        )
+
+    This is *not* recommended.
+
+    ## Properties
+    * **Path** (mandatory): the paths to the PowerShell scripts to run. Paths must be relative to the  whiskey.yml file. Script arguments are not supported.
+    * **WorkingDirectory**: the directory from which the scripts should be run. This path can be absolute. The default is the  whiskey.yml file's directory.
+    * **Argument**: a hash table of name/value pairs that are passed to your script as arguments. The hash table is actually splatted when passed to your script.
+
+    ## Examples
+
+    ### Example 1
+
+        BuildTasks:
+        - PowerShell:
+            Path: init.ps1
+            Argument:
+                Environment: "Dev"
+                Verbose: true
+
+    Demonstrates how to run a PowerShell script during your build. In this case, Whiskey will run `.\init.ps1 -Environment "Dev" -Verbose`.
+
+    ### Example 2
+
+        BuildTasks:
+        - PowerShell:
+            ExceptDuring: Clean
+            Path: init.ps1
+            Argument:
+                Environment: "Dev"
+                Verbose: true
+
+    Demonstrates how to run a PowerShell script except when it is cleaning. If you have a script you want to use to initialize your build environment, it should run during the build and initialize modes. Set the `ExceptDuring` property to `Clean` to make that happen.
+
+    ### Example 3
+
+        BuildTasks:
+        - PowerShell:
+            OnlyDuring: Clean
+            Path: clean.ps1
+
+    Demonstrates how to run a PowerShell script only when running in clean mode. 
+    #>
+    [Whiskey.Task("PowerShell",SupportsClean=$true,SupportsInitialize=$true)]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
@@ -16,17 +75,17 @@ function Invoke-WhiskeyPowerShell
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
     
-    if( -not ($TaskParameter.ContainsKey('Path')))
-        {
-            Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Element ''Path'' is mandatory. It should be one or more paths, which should be a list of PowerShell Scripts to run, e.g. 
+    if( -not ($TaskParameter.ContainsKey('Path')) )
+    {
+        Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Element ''Path'' is mandatory. It should be one or more paths, which should be a list of PowerShell Scripts to run, e.g. 
         
-            BuildTasks:
-            - PowerShell:
-                Path:
-                - myscript.ps1
-                - myotherscript.ps1
-                WorkingDirectory: bin')
-        }
+        BuildTasks:
+        - PowerShell:
+            Path:
+            - myscript.ps1
+            - myotherscript.ps1
+            WorkingDirectory: bin')
+    }
     
     $path = $TaskParameter['Path'] | Resolve-WhiskeyTaskPath -TaskContext $TaskContext -PropertyName 'Path'
 

--- a/Whiskey/Tasks/Invoke-WhiskeyPowerShell.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyPowerShell.ps1
@@ -8,7 +8,7 @@ function Invoke-WhiskeyPowerShell
     .DESCRIPTION
     The PowerShell tasks runs PowerShell scripts. You specify the scripts to run via the `Path` property. Paths must be relative to the whiskey.yml file. Pass arguments to the scripts with the `Argument` property, which is a hash table of parameter names and values. PowerShell scripts are run in new, background processes.
 
-    The PowerShell task runs your script in *all* build modes: during builds, during initialization, and during clean. If you want your script to only run in one mode, use the global `OnlyDuring` property to specify the mode you want it to run in or the `ExceptDuring` property to specify the run mode you don't want it to run in.
+    The PowerShell task runs your script in *all* build modes: during builds, during initialization, and during clean. If you want your script to only run in one mode, use the `OnlyDuring` property to specify the mode you want it to run in or the `ExceptDuring` property to specify the run mode you don't want it to run in.
 
     The PowerShell task will fail a build if the script it runs returns a non-zero exit code or sets the `$?` variable to `$false`.
 

--- a/Whiskey/Tasks/Invoke-WhiskeyPowerShell.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyPowerShell.ps1
@@ -6,7 +6,7 @@ function Invoke-WhiskeyPowerShell
     Executes PowerShell tasks.
 
     .DESCRIPTION
-    The PowerShell tasks runs PowerShell scripts. You specify the scripts to run via the `Path` property. Paths must be relative to the whiskey.yml file. Pass arguments to the scripts with the `Argument` property, which is a hash table of parameter names and values. PowerShell scripts are run in new, background processes.
+    The PowerShell task runs PowerShell scripts. You specify the scripts to run via the `Path` property. Paths must be relative to the whiskey.yml file. Pass arguments to the scripts with the `Argument` property, which is a hash table of parameter names and values. PowerShell scripts are run in new, background processes.
 
     The PowerShell task runs your script in *all* build modes: during builds, during initialization, and during clean. If you want your script to only run in one mode, use the `OnlyDuring` property to specify the mode you want it to run in or the `ExceptDuring` property to specify the run mode you don't want it to run in.
 
@@ -23,7 +23,6 @@ function Invoke-WhiskeyPowerShell
 
     ## Properties
     * **Path** (mandatory): the paths to the PowerShell scripts to run. Paths must be relative to the  whiskey.yml file. Script arguments are not supported.
-    * **WorkingDirectory**: the directory from which the scripts should be run. This path can be absolute. The default is the  whiskey.yml file's directory.
     * **Argument**: a hash table of name/value pairs that are passed to your script as arguments. The hash table is actually splatted when passed to your script.
 
     ## Examples

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -144,7 +144,7 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-* The `PowerShell` task now runs in every mode: initialize, build, and clean. If you want a task to only run during a subset of these modes, use the `OnlyDuring` and `ExceptDuring` task properties.
+* ***BREAKING CHANGE***: The "PowerShell" and "Exec" tasks now run in every mode: initialize, build, and clean. If you want them to only run during a subset of these modes, use the `OnlyDuring` or `ExceptDuring` task properties.
 '@
         } # End of PSData hashtable
 

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Whiskey.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.29.1'
+    ModuleVersion = '0.30.0'
 
     # ID used to uniquely identify this module
     GUID = '93bd40f1-dee5-45f7-ba98-cb38b7f5b897'
@@ -144,7 +144,7 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-* Fixed: `New-WhiskeySemanticVersion` could not read `Version` property from .csproj files if they contained a default xml namespace.
+* The `PowerShell` task now runs in every mode: initialize, build, and clean. If you want a task to only run during a subset of these modes, use the `OnlyDuring` and `ExceptDuring` task properties.
 '@
         } # End of PSData hashtable
 


### PR DESCRIPTION
Currently, the PowerShell and Exec tasks can't be used to do things in clean and initialize modes. :( This pull request updates those tasks to run in all modes. 