### PR TITLE
Feature/rename default pipelines

### DIFF
--- a/Test/Assemblies/NUnit2PassingTest/whiskey.yml
+++ b/Test/Assemblies/NUnit2PassingTest/whiskey.yml
@@ -1,4 +1,4 @@
-BuildTasks:
+Build:
 - Version: "4.5.6-rc1"
 
 - MSBuild:

--- a/Test/Assemblies/whiskey.nunit2.yml
+++ b/Test/Assemblies/whiskey.nunit2.yml
@@ -1,5 +1,5 @@
 
-BuildTasks:
+Build:
 - MSBuild:
     Path:
     - NUnit2FailingTest\*.sln

--- a/Test/Assemblies/whiskey.nunit3.yml
+++ b/Test/Assemblies/whiskey.nunit3.yml
@@ -1,5 +1,5 @@
 
-BuildTasks:
+Build:
 - MSBuild:
     Path:
     - NUnit3FailingTest\*.sln

--- a/Test/Assemblies/whiskey.yml
+++ b/Test/Assemblies/whiskey.yml
@@ -1,3 +1,3 @@
-BuildTasks:
+Build:
 - Version: 1.2.3-rc.1+build
 

--- a/Test/Invoke-WhiskeyBuild.Tests.ps1
+++ b/Test/Invoke-WhiskeyBuild.Tests.ps1
@@ -11,6 +11,7 @@ $publishingTasks = $null
 $buildPipelineFails = $false
 $buildPipelineName = 'Build'
 $publishPipelineFails = $false
+$publishPipelineName = 'Publish'
 
 function Init
 {
@@ -22,6 +23,7 @@ function Init
     $script:buildPipelineFails = $false
     $script:buildPipelineName = 'Build'
     $script:publishPipelineFails = $false
+    $script:publishPipelineName = 'Publish'
 }
 
 function Assert-ContextPassedTo
@@ -87,6 +89,15 @@ function GivenPublishing
 function GivenPublishingPipelineFails
 {
     $script:publishPipelineFails = $true
+}
+
+function GivenPublishPipelineName
+{
+    param(
+        $Name
+    )
+
+    $script:publishPipelineName = $Name
 }
 
 function GivenPublishingPipelineSucceeds
@@ -213,12 +224,12 @@ function ThenContextPassedWhenSettingBuildStatus
 
 function ThenPublishPipelineRan
 {
-    ThenPipelineRan -Name 'PublishTasks' -Times 1
+    ThenPipelineRan -Name $publishPipelineName -Times 1
 }
 
 function ThenPublishPipelineNotRun
 {
-    ThenPipelineRan -Name 'PublishTasks' -Times 0
+    ThenPipelineRan -Name $publishPipelineName -Times 0
 }
 
 function WhenRunningBuild
@@ -252,9 +263,9 @@ function WhenRunningBuild
             throw ('Build pipeline fails!')
         }
 
-        if( `$Name -eq 'PublishTasks' -and `$publishPipelineFails )
+        if( `$Name -eq "$publishPipelineName" -and `$publishPipelineFails )
         {
-            throw ('PublishTasks pipeline fails!')
+            throw ('Publish pipeline fails!')
         }
 "@))
 
@@ -264,7 +275,7 @@ function WhenRunningBuild
 
     if( $publishingTasks )
     {
-        $config['PublishTasks'] = $publishingTasks
+        $config[$publishPipelineName] = $publishingTasks
     }
 
     $script:context = New-WhiskeyContextObject

--- a/Test/Invoke-WhiskeyExec.Tests.ps1
+++ b/Test/Invoke-WhiskeyExec.Tests.ps1
@@ -452,7 +452,7 @@ Describe 'Invoke-WhiskeyExec.when given bad working directory' {
     GivenPath 'executable.bat'
     GivenWorkingDirectory 'badworkdir'
     WhenRunningExecutable
-    ThenTaskFailedWithMessage 'BuildTasks.+WorkingDirectory.+does not exist.'    
+    ThenTaskFailedWithMessage 'Build.+WorkingDirectory.+does not exist.'    
 }
 
 Describe 'Invoke-WhiskeyExec.when running executable located by the Path environment variable' {

--- a/Test/Invoke-WhiskeyPipeline.Tests.ps1
+++ b/Test/Invoke-WhiskeyPipeline.Tests.ps1
@@ -256,11 +256,11 @@ function WhenRunningPipeline
 
 Describe 'Invoke-WhiskeyPipeline.when running an unknown task' {
     GivenWhiskeyYmlBuildFile -Yaml @'
-BuildTasks:
+Build:
     - FubarSnafu:
         Path: whiskey.yml
 '@
-    WhenRunningPipeline 'BuildTasks' -ErrorAction SilentlyContinue
+    WhenRunningPipeline 'Build' -ErrorAction SilentlyContinue
     ThenPipelineFailed
     ThenThrewException 'not\ exist'
 }
@@ -269,14 +269,14 @@ Describe 'Invoke-WhiskeyPipeline.when a task fails' {
     $project = 'project.csproj'
     $assembly = 'assembly.dll'
     GivenWhiskeyYmlBuildFile -Yaml @'
-BuildTasks:
+Build:
 - PowerShell:
     Path: idonotexist.ps1
 - NUnit2:
     Path: assembly.dll
 '@
     GivenFailingMSBuildProject $project
-    WhenRunningPipeline 'BuildTasks' -ErrorAction SilentlyContinue
+    WhenRunningPipeline 'Build' -ErrorAction SilentlyContinue
     ThenPipelineFailed
     ThenDotNetProjectsCompilationFailed -ConfigurationPath $whiskeyYmlPath -ProjectName $project
     ThenNUnitTestsNotRun
@@ -284,12 +284,12 @@ BuildTasks:
 
 Describe 'Invoke-WhiskeyPipeline.when task has no properties' {
     GivenWhiskeyYmlBuildFile @"
-BuildTasks:
+Build:
 - PublishNodeModule
 - PublishNodeModule:
 "@
     Mock -CommandName 'Publish-WhiskeyNodeModule' -Verifiable -ModuleName 'Whiskey'
-    WhenRunningPipeline 'BuildTasks'
+    WhenRunningPipeline 'Build'
     ThenPipelineSucceeded
     
     It 'should still call the task' {
@@ -299,11 +299,11 @@ BuildTasks:
 
 Describe 'Invoke-WhiskeyPipeline.when task has a default property' {
     GivenWhiskeyYmlBuildFile @"
-BuildTasks:
+Build:
 - Exec: This is a default property
 "@
     Mock -CommandName 'Invoke-WhiskeyExec' -ModuleName 'Whiskey' -ParameterFilter { $TaskParameter[''] -eq 'This is a default property' }
-    WhenRunningPipeline 'BuildTasks'
+    WhenRunningPipeline 'Build'
     ThenPipelineSucceeded
 
     It 'should call the task with the default property' {
@@ -313,11 +313,11 @@ BuildTasks:
 
 Describe 'Invoke-WhiskeyPipeline.when task has a default property with quoted arguments' {
     GivenWhiskeyYmlBuildFile @"
-BuildTasks:
+Build:
 - Exec: robocopy.exe "C:\Source File" 'C:\Destination\File' /MIR
 "@
     Mock -CommandName 'Invoke-WhiskeyExec' -ModuleName 'Whiskey' -ParameterFilter { $TaskParameter[''] -eq 'robocopy.exe "C:\Source File" ''C:\Destination\File'' /MIR' }
-    WhenRunningPipeline 'BuildTasks'
+    WhenRunningPipeline 'Build'
     ThenPipelineSucceeded
 
     It 'should call the task with the default property' {
@@ -327,11 +327,11 @@ BuildTasks:
 
 Describe 'Invoke-WhiskeyPipeline.when task has a default property when entire string is quoted' {
     GivenWhiskeyYmlBuildFile @"
-BuildTasks:
+Build:
 - Exec: 'robocopy.exe "C:\Source File" C:\Destination\File /MIR'
 "@
     Mock -CommandName 'Invoke-WhiskeyExec' -ModuleName 'Whiskey' -ParameterFilter { $TaskParameter[''] -eq 'robocopy.exe "C:\Source File" C:\Destination\File /MIR' }
-    WhenRunningPipeline 'BuildTasks'
+    WhenRunningPipeline 'Build'
     ThenPipelineSucceeded
 
     It 'should call the task with the default property' {
@@ -342,46 +342,46 @@ BuildTasks:
 Describe 'Invoke-WhiskeyPipeline.when pipeline does not exist' {
     GivenWhiskeyYmlBuildFile @"
 "@
-    WhenRunningPipeline 'BuildTasks' -ErrorAction SilentlyContinue
+    WhenRunningPipeline 'Build' -ErrorAction SilentlyContinue
     ThenPipelineFailed
-    ThenThrewException 'Pipeline\ ''BuildTasks''\ does\ not\ exist'
+    ThenThrewException 'Pipeline\ ''Build''\ does\ not\ exist'
 }
 
 Describe 'Invoke-WhiskeyPipeline.when pipeline is empty and not a YAML object' {
     GivenWhiskeyYmlBuildFile @"
-BuildTasks
+Build
 "@
-    WhenRunningPipeline 'BuildTasks' 
+    WhenRunningPipeline 'Build' 
     ThenPipelineSucceeded
     ThenShouldWarn 'doesn''t\ have\ any\ tasks'
 }
 
 Describe 'Invoke-WhiskeyPipeline.when pipeline is empty and is a YAML object' {
     GivenWhiskeyYmlBuildFile @"
-BuildTasks:
+Build:
 "@
-    WhenRunningPipeline 'BuildTasks' 
+    WhenRunningPipeline 'Build' 
     ThenPipelineSucceeded
     ThenShouldWarn 'doesn''t\ have\ any\ tasks'
 }
 
 Describe 'Invoke-WhiskeyPipeline.when there are registered event handlers' {
     GivenWhiskeyYmlBuildFile @"
-BuildTasks:
+Build:
 - PowerShell:
     Path: somefile.ps1
 "@
     GivenPlugins
     Mock -CommandName 'Invoke-WhiskeyPowerShell' -ModuleName 'Whiskey'
 
-    WhenRunningPipeline 'BuildTasks'
+    WhenRunningPipeline 'Build'
     ThenPipelineSucceeded
     ThenPluginsRan -ForTaskNamed 'PowerShell' -WithParameter @{ 'Path' = 'somefile.ps1' }
 }
 
 Describe 'Invoke-WhiskeyPipeline.when there are task-specific registered event handlers' {
     GivenWhiskeyYmlBuildFile @"
-BuildTasks:
+Build:
 - PowerShell:
     Path: somefile.ps1
 - MSBuild:
@@ -391,7 +391,7 @@ BuildTasks:
     Mock -CommandName 'Invoke-WhiskeyPowerShell' -ModuleName 'Whiskey'
     Mock -CommandName 'Invoke-WhiskeyMSBuild' -ModuleName 'Whiskey'
 
-    WhenRunningPipeline 'BuildTasks'
+    WhenRunningPipeline 'Build'
     ThenPipelineSucceeded
     ThenPluginsRan -ForTaskNamed 'PowerShell' -WithParameter @{ 'Path' = 'somefile.ps1' }
     ThenPluginsRan -ForTaskNamed 'MSBuild' -Times 0
@@ -432,7 +432,7 @@ foreach( $task in $tasks )
 
         Mock -CommandName $functionName -ModuleName 'Whiskey'
 
-        $pipelineName = 'BuildTasks'
+        $pipelineName = 'Build'
         $whiskeyYml = (@'
 {0}:
 - {1}:

--- a/Test/Invoke-WhiskeyPipelineTask.Tests.ps1
+++ b/Test/Invoke-WhiskeyPipelineTask.Tests.ps1
@@ -144,7 +144,7 @@ Describe 'Pipeline.when running another pipeline' {
     Path: whiskey.yml
     DestinationDirectory: $(WHISKEY_PIPELINE_NAME)
 '@
-    GivenPipeline 'BuildTasks' @'
+    GivenPipeline 'Build' @'
 - Pipeline:
     Name: Fubar
 - CopyFile:
@@ -153,7 +153,7 @@ Describe 'Pipeline.when running another pipeline' {
 '@
     WhenRunningTask
     ThenPipelineRun 'Fubar' -BecauseFileExists 'Fubar\whiskey.yml'
-    ThenPipelineRun 'BuildTasks' -BecauseFileExists 'BuildTasks\whiskey.yml'
+    ThenPipelineRun 'Build' -BecauseFileExists 'Build\whiskey.yml'
 }
 
 Describe 'Pipeline.when running multiple pipelines' {
@@ -169,7 +169,7 @@ Describe 'Pipeline.when running multiple pipelines' {
     DestinationDirectory: $(WHISKEY_PIPELINE_NAME)
 '@
 
-    GivenPipeline 'BuildTasks' @'
+    GivenPipeline 'Build' @'
 - Pipeline:
     Name: 
     - Fubar
@@ -181,12 +181,12 @@ Describe 'Pipeline.when running multiple pipelines' {
     WhenRunningTask
     ThenPipelineRun 'Fubar' -BecauseFileExists 'Fubar\whiskey.yml'
     ThenPipelineRun 'Snafu' -BecauseFileExists 'Snafu\whiskey.yml'
-    ThenPipelineRun 'BuildTasks' -BecauseFileExists 'BuildTasks\whiskey.yml'
+    ThenPipelineRun 'Build' -BecauseFileExists 'Build\whiskey.yml'
 }
 
 Describe 'Pipeline.when Name property is missing' {
     Init
-    GivenPipeline 'BuildTasks' @'
+    GivenPipeline 'Build' @'
 - Pipeline
 '@
     WhenRunningTask -ErrorAction SilentlyContinue
@@ -195,7 +195,7 @@ Describe 'Pipeline.when Name property is missing' {
 
 Describe 'Pipeline.when Name property doesn''t have a value' {
     Init
-    GivenPipeline 'BuildTasks' @'
+    GivenPipeline 'Build' @'
 - Pipeline:
     Name: 
 '@
@@ -211,7 +211,7 @@ Describe 'Pipeline.when running in Clean mode' {
     Name: Whiskey
     Version: 0.18.0
 '@
-    GivenPipeline 'BuildTasks' @'
+    GivenPipeline 'Build' @'
 - Pipeline:
     Name: Fubar
 '@
@@ -227,7 +227,7 @@ Describe 'Pipeline.when running in Initialize mode' {
     Name: Whiskey
     Version: 0.18.0
 '@
-    GivenPipeline 'BuildTasks' @'
+    GivenPipeline 'Build' @'
 - Pipeline:
     Name: Fubar
 '@

--- a/Test/Invoke-WhiskeyTask.Tests.ps1
+++ b/Test/Invoke-WhiskeyTask.Tests.ps1
@@ -890,7 +890,7 @@ Describe 'Invoke-WhiskeyTask.when WorkingDirectory property is invalid' {
     GivenRunByDeveloper
     Mock -CommandName 'Invoke-WhiskeyPowerShell' -ModuleName 'Whiskey'
     WhenRunningTask 'PowerShell' -Parameter @{ 'WorkingDirectory' = 'Invalid/Directory' } -ErrorAction SilentlyContinue
-    ThenThrewException 'BuildTasks.+WorkingDirectory.+does not exist.'
+    ThenThrewException 'Build.+WorkingDirectory.+does not exist.'
     ThenTaskNotRun 'Invoke-WhiskeyPowerShell' 
 }
 

--- a/Test/New-WhiskeyContext.Tests.ps1
+++ b/Test/New-WhiskeyContext.Tests.ps1
@@ -718,6 +718,15 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
         WhenCreatingContext -ThenCreationFailsWithErrorMessage 'contains\ both\ "Build"\ and\ the\ deprecated\ "BuildTasks"\ pipelines' -ErrorAction SilentlyContinue
     }
 
+    Describe 'New-WhiskeyContext.when both Publish and PublishTasks pipelines exists' {
+        Init
+        GivenConfiguration @{
+            Publish = @();
+            PublishTasks = @();
+        }
+        WhenCreatingContext -ThenCreationFailsWithErrorMessage 'contains\ both\ "Publish"\ and\ the\ deprecated\ "PublishTasks"\ pipelines' -ErrorAction SilentlyContinue
+    }
+
     Describe 'New-WhiskeyContext.when BuildTasks pipeline exists' {
         Init
         GivenConfiguration @{
@@ -727,5 +736,19 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
         }
         WhenCreatingContext
         ThenWarning 'The\ default\ "BuildTasks"\ pipeline\ has\ been\ renamed\ to\ "Build"'
+    }
+
+    Describe 'New-WhiskeyContext.when PublishTasks pipeline exists' {
+        Init
+        GivenConfiguration @{
+            Build = @(
+                @{ Version = '1.0.0' }
+            );
+            PublishTasks = @(
+                'NuGetPush'
+            );
+        }
+        WhenCreatingContext
+        ThenWarning 'The\ default\ "PublishTasks"\ pipeline\ has\ been\ renamed\ to\ "Publish"'
     }
 }

--- a/Test/New-WhiskeyContext.Tests.ps1
+++ b/Test/New-WhiskeyContext.Tests.ps1
@@ -11,6 +11,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     $context = $null
     $path = "bad"
     $runMode = $null
+    $warningMessage = $null
 
     function Assert-Context
     {
@@ -150,7 +151,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
         {
             $Configuration['PublishOn'] = $PublishingOn
         }
-    
+
         $buildInfo = New-WhiskeyBuildMetadataObject
         $buildInfo.BuildNumber = $BuildNumber
 
@@ -196,6 +197,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
         $script:configurationPath = ''
         $script:context = $null
         $script:path = "bad"
+        $script:warningMessage = $null
     }
 
     function ThenSemVer1Is
@@ -278,7 +280,8 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
             $threwException = $false
             try
             {
-                $script:context = New-WhiskeyContext -Environment $Environment -ConfigurationPath $script:ConfigurationPath @optionalArgs
+                $script:context = New-WhiskeyContext -Environment $Environment -ConfigurationPath $script:ConfigurationPath @optionalArgs -WarningVariable newWhiskeyContextWarning
+                $script:warningMessage = $newWhiskeyContextWarning
                 if( $RunBy )
                 {
                     $script:context.RunBy = $RunBy
@@ -296,7 +299,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
             catch
             {
                 $threwException = $true
-                $_ | Write-Error 
+                $_ | Write-Error
             }
 
             if( $ThenCreationFailsWithErrorMessage )
@@ -433,6 +436,17 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
         }
     }
 
+    function ThenWarning
+    {
+        param(
+            $Message
+        )
+
+        It 'should write warning message' {
+            $script:warningMessage | Should -Match $Message
+        }
+    }
+
     Describe 'New-WhiskeyContext.when run by a developer for an application' {
         Init
         GivenConfiguration
@@ -459,8 +473,8 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     Describe 'New-WhiskeyContext.when run by developer for a library' {
         Init
         GivenConfiguration
-        WhenCreatingContext 
-        ThenDeveloperContextCreated 
+        WhenCreatingContext
+        ThenDeveloperContextCreated
         ThenDoesNotPublish
     }
 
@@ -537,7 +551,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     Describe 'New-WhiskeyContext.when building on hot fix branch' {
         Init
         GivenConfiguration -ForBuildServer -OnBranch 'hotfix/snafu'
-        WhenCreatingContext 
+        WhenCreatingContext
         ThenBuildServerContextCreated
         ThenDoesNotPublish
     }
@@ -560,21 +574,21 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
 
     Describe 'New-WhiskeyContext.when publishing on multiple branches and building on one of them' {
         Init
-        GivenConfiguration -OnBranch 'fubarsnafu' -ForBuildServer -PublishingOn @( 'feature/3.0', 'fubar*' ) 
+        GivenConfiguration -OnBranch 'fubarsnafu' -ForBuildServer -PublishingOn @( 'feature/3.0', 'fubar*' )
         WhenCreatingContext
         ThenPublishes
     }
 
     Describe 'New-WhiskeyContext.when publishing on multiple branches and not building on one of them' {
         Init
-        GivenConfiguration -OnBranch 'some-issue-master' -ForBuildServer -PublishingOn @( 'feature/3.0', 'master' ) 
+        GivenConfiguration -OnBranch 'some-issue-master' -ForBuildServer -PublishingOn @( 'feature/3.0', 'master' )
         WhenCreatingContext
         ThenDoesNotPublish
     }
 
     Describe 'New-WhiskeyContext.when configuration is just a property name' {
         Init
-        GivenWhiskeyYml 'BuildTasks'
+        GivenWhiskeyYml 'Build'
         WhenCreatingContext
     }
 
@@ -603,10 +617,10 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
         ThenShouldCleanIs $false
         ThenShouldInitializeIs $false
     }
-    
+
     Describe 'New-WhiskeyContext.when Version property is used' {
         Init
-        GivenConfiguration @{ 'BuildTasks' = @(@{ 'Exec' = 'cmd /C echo' }) ; 'Version' = '1.2.3-rc.1+fubar.snafu' }
+        GivenConfiguration @{ 'Build' = @(@{ 'Exec' = 'cmd /C echo' }) ; 'Version' = '1.2.3-rc.1+fubar.snafu' }
         WhenCreatingContext -RunBy 'BuildServer'
         # Run a build to ensure the Version task is in the build tasks.
         Invoke-WhiskeyBuild -Context $script:context
@@ -631,7 +645,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
         Init
         GivenConfiguration @{
                                 Version = '4.5.6';
-                                BuildTasks = @(
+                                Build = @(
                                                 @{
                                                     Version = @{
                                                                     Version = '1.2.3'
@@ -653,7 +667,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
                             PrereleaseMap = @(
                                                 @{ 'develop' = 'beta' },
                                                 @{ 'feature/*' = 'alpha' }
-                                            ); 
+                                            );
                         }
         WhenCreatingContext -RunBy 'BuildServer'
         $script:context.BuildMetadata.ScmBranch = 'feature/snafu'
@@ -669,7 +683,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     Describe 'New-WhiskeyContext.when there are no Version, VersionFrom or PrereleaseMap properties' {
         Init
         GivenConfiguration -BuildNumber 50 `
-                           -Configuration @{ 'BuildTasks' = @( @{ 'Exec' = 'cmd /C echo' } ) } `
+                           -Configuration @{ 'Build' = @( @{ 'Exec' = 'cmd /C echo' } ) } `
                            -ForBuildServer
         WhenCreatingContext
         # Run a build to ensure the Version task is in the build tasks.
@@ -684,7 +698,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     Describe 'New-WhiskeyContext.when there are no Version, VersionFrom or PrereleaseMap properties and being run by a developer' {
         Init
         GivenConfiguration -BuildNumber 50 `
-                           -Configuration @{ 'BuildTasks' = @( @{ 'Exec' = 'cmd /C echo' } ) }
+                           -Configuration @{ 'Build' = @( @{ 'Exec' = 'cmd /C echo' } ) }
         WhenCreatingContext
         # Run a build to ensure the Version task is in the build tasks.
         Invoke-WhiskeyBuild -Context $script:context
@@ -693,5 +707,25 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
         ThenSemVer1Is $expectedVersion
         ThenSemVer2Is $expectedVersion
         ThenSemVer2NoBuildMetadataIs $expectedVersion
+    }
+
+    Describe 'New-WhiskeyContext.when both Build and BuildTasks pipelines exists' {
+        Init
+        GivenConfiguration @{
+            Build = @()
+            BuildTasks = @()
+        }
+        WhenCreatingContext -ThenCreationFailsWithErrorMessage 'contains\ both\ "Build"\ and\ the\ deprecated\ "BuildTasks"\ pipelines' -ErrorAction SilentlyContinue
+    }
+
+    Describe 'New-WhiskeyContext.when BuildTasks pipeline exists' {
+        Init
+        GivenConfiguration @{
+            BuildTasks = @(
+                @{ Version = '1.0.0' }
+            )
+        }
+        WhenCreatingContext
+        ThenWarning 'The\ default\ "BuildTasks"\ pipeline\ has\ been\ renamed\ to\ "Build"'
     }
 }

--- a/Test/Parallel.Tests.ps1
+++ b/Test/Parallel.Tests.ps1
@@ -283,7 +283,7 @@ if( $cred.GetNetworkCredential().Password -ne 'cred' )
 exit 0
 '@
     $yaml = @'
-BuildTasks:
+Build:
 - TaskDefaults:
     PowerShell:
         Path: one.ps1

--- a/Test/Pester/whiskey.failing.yml
+++ b/Test/Pester/whiskey.failing.yml
@@ -1,4 +1,4 @@
-BuildTasks:
+Build:
 - Pester3:
     Version: 3.4.3
     Path: 

--- a/Test/Pester/whiskey.passing.yml
+++ b/Test/Pester/whiskey.passing.yml
@@ -1,4 +1,4 @@
-BuildTasks:
+Build:
 - Pester4:
     Path: PassingTests
     DescribeDurationReportCount: 10

--- a/Test/WhiskeyTest.psm1
+++ b/Test/WhiskeyTest.psm1
@@ -297,7 +297,7 @@ function New-WhiskeyTestContext
 
             if( $ForTaskName )
             {
-                $configData['BuildTasks'] = @( @{ $ForTaskName = $TaskParameter } )
+                $configData['Build'] = @( @{ $ForTaskName = $TaskParameter } )
             }
 
             $configData | ConvertTo-Yaml | Set-Content -Path $ConfigurationPath

--- a/Whiskey/Functions/Add-WhiskeyApiKey.ps1
+++ b/Whiskey/Functions/Add-WhiskeyApiKey.ps1
@@ -10,7 +10,7 @@ function Add-WhiskeyApiKey
 
     For example, if you are publishing a PowerShell module, your `whiskey.yml` file will look something like this:
 
-        PublishTasks:
+        Publish:
         - PublishPowerShellModule:
             RepositoryName: PSGallery
             Path: Whiskey

--- a/Whiskey/Functions/Add-WhiskeyCredential.ps1
+++ b/Whiskey/Functions/Add-WhiskeyCredential.ps1
@@ -10,7 +10,7 @@ function Add-WhiskeyCredential
 
     For example, if you are publishing a ProGet universal pakcage, your `whiskey.yml` file will look something like this:
 
-        PublishTasks:
+        Publish:
         - PublishProGetUniversalPackage:
             Uri: https://proget.example.com
             FeedName: 'upack'

--- a/Whiskey/Functions/ConvertTo-WhiskeyTask.ps1
+++ b/Whiskey/Functions/ConvertTo-WhiskeyTask.ps1
@@ -55,7 +55,7 @@ function ConvertTo-WhiskeyTask
                 ForEach-Object { '    {0}' -f $_ }
     Write-Error -Message ('Invalid task YAML:{0} {0}{1}{0}A task must have a name followed by optional parameters, e.g.
  
-    BuildTasks:
+    Build:
     - Task1
     - Task2:
         Parameter1: Value1

--- a/Whiskey/Functions/Invoke-WhiskeyBuild.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyBuild.ps1
@@ -13,7 +13,7 @@ function Invoke-WhiskeyBuild
 
     Builds can run in three modes: `Build`, `Clean`, and `Initialize`. The default behavior is `Build` mode.
 
-    In `Build` mode, each task in the `Build` pipeline is run. If you're on a publishing branch, and being run on a build server, each task in the `PublishTasks` pipeline is also run.
+    In `Build` mode, each task in the `Build` pipeline is run. If you're on a publishing branch, and being run on a build server, each task in the `Publish` pipeline is also run.
 
     In `Clean` mode, each task that supports clean mode is run. In this mode, tasks clean up any build artifacts they create. Tasks opt-in to this mode. If a task isn't cleaning up, it should be updated to support clean mode.
 
@@ -21,7 +21,7 @@ function Invoke-WhiskeyBuild
 
     (Task authors should see the `about_Whiskey_Writing_Tasks` for information about how to opt-in to `Clean` and `Initialize` mode.)
 
-    Your `whiskey.yml` file can contain multiple pipelines (see `about_Whiskey.yml` for information about `whiskey.yml syntax). Usually, there is a pipeline for each application you want to build. To build specific pipelines, pass the pipeline names to the `PipelineName` parameter. Just those pipeline will be run. The `PublishTasks` pipeline will *not* run unless it is one of the names you pass to the `PipelineName` parameter.
+    Your `whiskey.yml` file can contain multiple pipelines (see `about_Whiskey.yml` for information about `whiskey.yml syntax). Usually, there is a pipeline for each application you want to build. To build specific pipelines, pass the pipeline names to the `PipelineName` parameter. Just those pipeline will be run. The `Publish` pipeline will *not* run unless it is one of the names you pass to the `PipelineName` parameter.
 
     .LINK
     about_Whiskey.yml
@@ -35,17 +35,17 @@ function Invoke-WhiskeyBuild
     .EXAMPLE
     Invoke-WhiskeyBuild -Context $context
 
-    Demonstrates how to run a complete build. In this example, the `Build` pipeline is run, and, if running on a build server and on a publishing branch, the `PublishTasks` pipeline is run.
+    Demonstrates how to run a complete build. In this example, the `Build` pipeline is run, and, if running on a build server and on a publishing branch, the `Publish` pipeline is run.
 
     .EXAMPLE
     Invoke-WhiskeyBuild -Context $context -Clean
 
-    Demonstrates how to run a build in `Clean` mode. In this example, each task in the `Build` and `PublishTasks` pipelines that support `Clean` mode is run so they can delete any build output, downloaded depedencies, etc.
+    Demonstrates how to run a build in `Clean` mode. In this example, each task in the `Build` and `Publish` pipelines that support `Clean` mode is run so they can delete any build output, downloaded depedencies, etc.
 
     .EXAMPLE
     Invoke-WhiskeyBuild -Context $context -Initialize
 
-    Demonstrates how to run a build in `Initialize` mode. In this example, each task in the `Build` and `PublishTasks` pipelines that supports `Initialize` mode is run so they can download/install/configure any tools or dependencies.
+    Demonstrates how to run a build in `Initialize` mode. In this example, each task in the `Build` and `Publish` pipelines that supports `Initialize` mode is run so they can download/install/configure any tools or dependencies.
 
     .EXAMPLE
     Invoke-WhiskeyBuild -Context $context -PipelineName 'App1','App2'
@@ -60,9 +60,9 @@ function Invoke-WhiskeyBuild
         $Context,
 
         [string[]]
-        # The name(s) of any pipelines to run. Default behavior is to run the `Build` pipeline and, if on a publishing branch, the `PublishTasks` pipeline.
+        # The name(s) of any pipelines to run. Default behavior is to run the `Build` pipeline and, if on a publishing branch, the `Publish` pipeline.
         #
-        # If you pass a value to this parameter, the `PublishTasks` pipeline is *not* run implicitly. You must pass its name to run it.
+        # If you pass a value to this parameter, the `Publish` pipeline is *not* run implicitly. You must pass its name to run it.
         $PipelineName,
 
         [Parameter(Mandatory=$true,ParameterSetName='Clean')]
@@ -108,11 +108,17 @@ function Invoke-WhiskeyBuild
 
             Invoke-WhiskeyPipeline -Context $Context -Name $buildPipelineName
 
-            Write-Verbose -Message ('Publish?           {0}' -f $Context.Publish)
-            Write-Verbose -Message ('Publish Pipeline?  {0}' -f $config.ContainsKey('PublishTasks'))
-            if( $Context.Publish -and $config.ContainsKey('PublishTasks') )
+            $publishPipelineName = 'Publish'
+            if( $config.ContainsKey('PublishTasks') )
             {
-                Invoke-WhiskeyPipeline -Context $Context -Name 'PublishTasks'
+                $publishPipelineName = 'PublishTasks'
+            }
+
+            Write-Verbose -Message ('Publish?           {0}' -f $Context.Publish)
+            Write-Verbose -Message ('Publish Pipeline?  {0}' -f $config.ContainsKey($publishPipelineName))
+            if( $Context.Publish -and $config.ContainsKey($publishPipelineName) )
+            {
+                Invoke-WhiskeyPipeline -Context $Context -Name $publishPipelineName
             }
         }
 

--- a/Whiskey/Functions/Invoke-WhiskeyPipeline.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyPipeline.ps1
@@ -11,11 +11,11 @@ function Invoke-WhiskeyPipeline
         Build:
         - TaskOne
         - TaskTwo
-        PublishTasks:
+        Publish:
         - TaskOne
         - Task
 
-    Defines two pipelines: `Build` and `PublishTasks`.
+    Defines two pipelines: `Build` and `Publish`.
 
     .EXAMPLE
     Invoke-WhiskeyPipeline -Context $context -Name 'Build'

--- a/Whiskey/Functions/Invoke-WhiskeyPipeline.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyPipeline.ps1
@@ -8,19 +8,19 @@ function Invoke-WhiskeyPipeline
     .DESCRIPTION
     The `Invoke-WhiskeyPipeline` function runs the tasks in a pipeline. Pipelines are properties in a `whiskey.yml` under which one or more tasks are defined. For example, this `whiskey.yml` file:
 
-        BuildTasks:
+        Build:
         - TaskOne
         - TaskTwo
         PublishTasks:
         - TaskOne
         - Task
 
-    Defines two pipelines: `BuildTasks` and `PublishTasks`.
+    Defines two pipelines: `Build` and `PublishTasks`.
 
     .EXAMPLE
-    Invoke-WhiskeyPipeline -Context $context -Name 'BuildTasks'
+    Invoke-WhiskeyPipeline -Context $context -Name 'Build'
 
-    Demonstrates how to run the tasks in a `BuildTasks` pipeline. The `$context` object is created by calling `New-WhiskeyContext`.
+    Demonstrates how to run the tasks in a `Build` pipeline. The `$context` object is created by calling `New-WhiskeyContext`.
     #>
     [CmdletBinding()]
     param(
@@ -31,7 +31,7 @@ function Invoke-WhiskeyPipeline
 
         [Parameter(Mandatory=$true)]
         [string]
-        # The name of pipeline to run, e.g. `BuildTasks` would run all the tasks under a property named `BuildTasks`. Pipelines are properties in your `whiskey.yml` file that are lists of Whiskey tasks to run.
+        # The name of pipeline to run, e.g. `Build` would run all the tasks under a property named `Build`. Pipelines are properties in your `whiskey.yml` file that are lists of Whiskey tasks to run.
         $Name
     )
 

--- a/Whiskey/Functions/New-WhiskeyContext.ps1
+++ b/Whiskey/Functions/New-WhiskeyContext.ps1
@@ -93,6 +93,16 @@ function New-WhiskeyContext
         Write-Warning ('{0}: The default "BuildTasks" pipeline has been renamed to "Build". Backwards compatibility with "BuildTasks" will be removed in the next major version of Whiskey. Rename your "BuildTasks" pipeline to "Build".' -f $ConfigurationPath)
     }
 
+    if( $config.ContainsKey('Publish') -and $config.ContainsKey('PublishTasks') )
+    {
+        throw ('{0}: The configuration file contains both "Publish" and the deprecated "PublishTasks" pipelines. Move all your publish tasks under "Publish" and remove the "PublishTasks" pipeline.' -f $ConfigurationPath)
+    }
+
+    if( $config.ContainsKey('PublishTasks') )
+    {
+        Write-Warning ('{0}: The default "PublishTasks" pipeline has been renamed to "Publish". Backwards compatibility with "PublishTasks" will be removed in the next major version of Whiskey. Rename your "PublishTasks" pipeline to "Publish".' -f $ConfigurationPath)
+    }
+
     $buildRoot = $ConfigurationPath | Split-Path
     if( -not $DownloadRoot )
     {

--- a/Whiskey/Functions/New-WhiskeyContext.ps1
+++ b/Whiskey/Functions/New-WhiskeyContext.ps1
@@ -22,8 +22,8 @@ function New-WhiskeyContext
     * `ByBuildServer`: a flag indicating if the build is being run by a build server.
     * `ByDeveloper`: a flag indicating if the build is being run by a developer.
     * `Environment`: the environment the build is running in.
-    * `OutputDirectory`: a `System.IO.DirectoryInfo` object representing the path to a directory where build output, reports, etc. should be saved. This directory is created for you. 
-    * `ShouldClean`: a flag indicating if the current build is running in clean mode. 
+    * `OutputDirectory`: a `System.IO.DirectoryInfo` object representing the path to a directory where build output, reports, etc. should be saved. This directory is created for you.
+    * `ShouldClean`: a flag indicating if the current build is running in clean mode.
     * `ShouldInitialize`: a flag indicating if the current build is running in initialize mode.
     * `Temp`: the temporary work directory for the current task.
     * `Version`: a `Whiskey.BuildVersion` object representing version being built (see below).
@@ -81,6 +81,18 @@ function New-WhiskeyContext
 
     $config = Import-WhiskeyYaml -Path $ConfigurationPath
 
+    if( $config.ContainsKey('Build') -and $config.ContainsKey('BuildTasks') )
+    {
+        throw ('{0}: The configuration file contains both "Build" and the deprecated "BuildTasks" pipelines. Move all your build tasks under "Build" and remove the "BuildTasks" pipeline.' -f $ConfigurationPath)
+    }
+
+    $buildPipelineName = 'Build'
+    if( $config.ContainsKey('BuildTasks') )
+    {
+        $buildPipelineName = 'BuildTasks'
+        Write-Warning ('{0}: The default "BuildTasks" pipeline has been renamed to "Build". Backwards compatibility with "BuildTasks" will be removed in the next major version of Whiskey. Rename your "BuildTasks" pipeline to "Build".' -f $ConfigurationPath)
+    }
+
     $buildRoot = $ConfigurationPath | Split-Path
     if( -not $DownloadRoot )
     {
@@ -114,47 +126,47 @@ function New-WhiskeyContext
         }
     }
 
-    $versionTaskExists = $config['BuildTasks'] | 
+    $versionTaskExists = $config[$buildPipelineName] |
                             Where-Object { $_ -and ($_ | Get-Member -Name 'Keys') } |
                             Where-Object { $_.Keys | Where-Object { $_ -eq 'Version' } }
     if( -not $versionTaskExists -and ($config.ContainsKey('PrereleaseMap') -or $config.ContainsKey('Version') -or $config.ContainsKey('VersionFrom')) )
     {
         Write-Warning ('{0}: The ''PrereleaseMap'', ''Version'', and ''VersionFrom'' properties are obsolete and will be removed in Whiskey 1.0. They were replaced with the ''Version'' task. Add a ''Version'' task as the first task in your build pipeline. If your current whiskey.yml file looks like this:
-    
+
     Version: 1.2.3
-    
+
     PrereleaseMap:
     - "alpha/*": alpha
     - "release/*": rc
-    
+
 add a Version task to your build pipeline that looks like this:
-    
-    BuildTasks:
+
+    Build:
     - Version:
         Version: 1.2.3
         Prerelease:
         - "alpha/*": alpha.$(WHISKEY_BUILD_NUMBER)
         - "release/*": rc.$(WHISKEY_BUILD_NUMBER)
-    
+
 You must add the ".$(WHISKEY_BUILD_NUMBER)" string to each prerelease version. Whiskey no longer automatically adds a prerelease version number for you.
-    
+
 If you use the "VersionFrom" property, your whiskey.yml file looks something like this:
-    
+
     VersionFrom: Whiskey\Whiskey.psd1
-    
+
 Update it to look like this:
-    
-    BuildTasks:
+
+    Build:
     - Version:
         Path: Whiskey\Whiskey.psd1
- 
+
 Whiskey also no longer automatically adds build metadata to your version number. To preserve Whiskey''s old default build metadata, add a "Build" property to your new "Version" task that looks like this:
- 
-    BuildTasks:
+
+    Build:
     - Version:
         Version: 1.2.3
         Build: $(WHISKEY_SCM_BRANCH).$(WHISKEY_SCM_COMMIT_ID.Substring(0,7))
- 
+
     ' -f $ConfigurationPath)
 
         $versionTask = $null
@@ -176,7 +188,7 @@ Whiskey also no longer automatically adds build metadata to your version number.
 
         if( $config['PrereleaseMap'] )
         {
-            $versionTask['Prerelease'] = $config['PrereleaseMap'] | 
+            $versionTask['Prerelease'] = $config['PrereleaseMap'] |
                                             ForEach-Object {
                                                 if( -not ($_ | Get-Member 'Keys') )
                                                 {
@@ -191,21 +203,21 @@ Whiskey also no longer automatically adds build metadata to your version number.
                                                 }
                                                 $newMap
                                             }
-                                                
+
         }
 
         if( $versionTask )
         {
-            if( -not $config['BuildTasks'] )
+            if( -not $config[$buildPipelineName] )
             {
-                $config['BuildTasks'] = @()
+                $config[$buildPipelineName] = @()
             }
 
-            $config['BuildTasks'] = & {
+            $config[$buildPipelineName] = & {
                                             @{
                                                 Version = $versionTask
                                             }
-                                            $config['BuildTasks']
+                                            $config[$buildPipelineName]
                                     }
         }
     }
@@ -235,7 +247,7 @@ Whiskey also no longer automatically adds build metadata to your version number.
 
     if( $config['Variable'] )
     {
-        Write-Error -Message ('{0}: The ''Variable'' property is no longer supported. Use the `SetVariable` task instead. Move your `Variable` property (and values) into your `BuildTasks` pipeline as the first task. Rename `Variable` to `SetVariable`.' -f $ConfigurationPath) -ErrorAction Stop
+        Write-Error -Message ('{0}: The ''Variable'' property is no longer supported. Use the `SetVariable` task instead. Move your `Variable` property (and values) into your `Build` pipeline as the first task. Rename `Variable` to `SetVariable`.' -f $ConfigurationPath) -ErrorAction Stop
     }
 
     if( $versionTaskExists )
@@ -245,8 +257,8 @@ Whiskey also no longer automatically adds build metadata to your version number.
     else
     {
         Write-Warning ('Whiskey''s default, date-base default version number is OBSOLETE. Beginning with Whiskey 1.0, the default Whiskey version number will be 0.0.0. Use the Version task to set your own custom version. For example, this Version task preserves the existing behavior:
- 
-    BuildTasks
+
+    Build
     - Version:
         Version: $(WHISKEY_BUILD_STARTED_AT.ToString(''yyyy.Mdd'')).$(WHISKEY_BUILD_NUMBER)
         Build: $(WHISKEY_SCM_BRANCH).$(WHISKEY_SCM_COMMIT_ID)

--- a/Whiskey/Functions/Stop-WhiskeyTask.ps1
+++ b/Whiskey/Functions/Stop-WhiskeyTask.ps1
@@ -23,7 +23,7 @@ function Stop-WhiskeyTask
 
     if( -not ($PropertyDescription) )
     {
-        $PropertyDescription = 'BuildTasks[{0}]: {1}' -f $TaskContext.TaskIndex,$TaskContext.TaskName
+        $PropertyDescription = 'Build[{0}]: {1}' -f $TaskContext.TaskIndex,$TaskContext.TaskName
     }
 
     if( $PropertyName )

--- a/Whiskey/Functions/Write-WhiskeyWarning.ps1
+++ b/Whiskey/Functions/Write-WhiskeyWarning.ps1
@@ -15,5 +15,5 @@ function Write-WhiskeyWarning
 
     Set-StrictMode -Version 'Latest'
 
-    Write-Warning -Message ('{0}: BuildTasks[{1}]: {2}: {3}' -f $TaskContext.ConfigurationPath,$TaskContext.TaskIndex,$TaskContext.TaskName,$Message)
+    Write-Warning -Message ('{0}: Build[{1}]: {2}: {3}' -f $TaskContext.ConfigurationPath,$TaskContext.TaskIndex,$TaskContext.TaskName,$Message)
 }

--- a/Whiskey/Tasks/Copy-WhiskeyFile.ps1
+++ b/Whiskey/Tasks/Copy-WhiskeyFile.ps1
@@ -19,7 +19,7 @@ function Copy-WhiskeyFile
     $pathErrorMessage = @'
 'Path' property is missing. Please set it to the list of files to copy, e.g.
 
-BuildTasks:
+Build:
 - CopyFile:
     Path: myfile.txt
     Destination: \\computer\share
@@ -27,7 +27,7 @@ BuildTasks:
     $destDirErrorMessage = @'
 'DestinationDirectory' property is missing. Please set it to the list of target locations to copy to, e.g.
 
-BuildTasks:
+Build:
 - CopyFile:
     Path: myfile.txt
     DestinationDirectory: \\computer\share

--- a/Whiskey/Tasks/Get-WhiskeyPowerShellModule.ps1
+++ b/Whiskey/Tasks/Get-WhiskeyPowerShellModule.ps1
@@ -18,7 +18,7 @@ function Get-WhiskeyPowerShellModule
 
     ## Example 1
 
-        BuildTasks:
+        Build:
         - GetPowerShellModule:
             Name: Whiskey
 
@@ -26,7 +26,7 @@ function Get-WhiskeyPowerShellModule
 
     ## Example 2
 
-        BuildTasks:
+        Build:
         - GetPowerShellModule:
             Name: Whiskey
             Version: "0.14.*"

--- a/Whiskey/Tasks/Invoke-WhiskeyExec.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyExec.ps1
@@ -32,7 +32,7 @@ function Invoke-WhiskeyExec
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Property ''Path'' is mandatory. It should be the Path to the executable you want the Exec task to run, e.g.
         
-            BuildTasks:
+            Build:
             - Exec:
                 Path: cmd.exe
             

--- a/Whiskey/Tasks/Invoke-WhiskeyMSBuild.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyMSBuild.ps1
@@ -44,7 +44,7 @@ function Invoke-WhiskeyMSBuild
 
     ## Examples
 
-        BuildTasks:
+        Build:
         - MSBuild:
             Path: MySolution.sln
 
@@ -75,7 +75,7 @@ function Invoke-WhiskeyMSBuild
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Element ''Path'' is mandatory. It should be one or more paths, relative to your whiskey.yml file, to build with MSBuild.exe, e.g. 
         
-        BuildTasks:
+        Build:
         - MSBuild:
             Path:
             - MySolution.sln

--- a/Whiskey/Tasks/Invoke-WhiskeyNUnit2Task.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyNUnit2Task.ps1
@@ -137,7 +137,7 @@ function Invoke-WhiskeyNUnit2Task
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Element ''Path'' is mandatory. It should be one or more paths, which should be a list of assemblies whose tests to run, e.g. 
         
-        BuildTasks:
+        Build:
         - NUnit2:
             Path:
             - Assembly.dll

--- a/Whiskey/Tasks/Invoke-WhiskeyNUnit3Task.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyNUnit3Task.ps1
@@ -132,7 +132,7 @@ function Invoke-WhiskeyNUnit3Task
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Property ''Path'' is mandatory. It should be one or more paths to the assemblies whose tests should be run, e.g.
 
-            BuildTasks:
+            Build:
             - NUnit3:
                 Path:
                 - Assembly.dll

--- a/Whiskey/Tasks/Invoke-WhiskeyNodeLicenseChecker.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyNodeLicenseChecker.ps1
@@ -21,14 +21,14 @@ function Invoke-WhiskeyNodeLicenseChecker
 
     ## Example 1
 
-        BuildTasks:
+        Build:
         - NodeLicenseChecker
     
     This example will run `license-checker` against the modules listed in the `package.json` file located in the build root.
 
     ## Example 2
 
-        BuildTasks:
+        Build:
         - NodeLicenseChecker:
             Version: 13.0.1
     

--- a/Whiskey/Tasks/Invoke-WhiskeyNodeNspCheck.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyNodeNspCheck.ps1
@@ -24,14 +24,14 @@ function Invoke-WhiskeyNodeNspCheck
 
     ## Example 1
 
-        BuildTasks:
+        Build:
         - NodeNspCheck
     
     This example will run `node.exe nsp check` against the modules listed in the `package.json` file located in the build root.
 
     ## Example 2
 
-        BuildTasks:
+        Build:
         - NodeNspCheck:
             WorkingDirectory: app
     
@@ -39,7 +39,7 @@ function Invoke-WhiskeyNodeNspCheck
 
     ## Example 3
 
-        BuildTasks:
+        Build:
         - NodeNspCheck:
             Version: 2.7.0
     

--- a/Whiskey/Tasks/Invoke-WhiskeyNodeTask.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyNodeTask.ps1
@@ -89,7 +89,7 @@ function Invoke-WhiskeyNodeTask
             Write-WhiskeyWarning -TaskContext $TaskContext -Message (@'
 Property 'NpmScript' is missing or empty. Your build isn''t *doing* anything. The 'NpmScript' property should be a list of one or more npm scripts to run during your build, e.g.
 
-BuildTasks:
+Build:
 - Node:
   NpmScript:
   - build

--- a/Whiskey/Tasks/Invoke-WhiskeyNpmConfig.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyNpmConfig.ps1
@@ -10,7 +10,7 @@ function Invoke-WhiskeyNpmConfig
 
     Set the `Configuration` property to key/value pairs. The keys should be the name of the configuration setting; the value should be its value. For example,
 
-        BuildTasks:
+        Build:
         - NpmConfig:
             Configuration:
                 registry: https://registry.npmjs.org
@@ -26,7 +26,7 @@ function Invoke-WhiskeyNpmConfig
 
     ## Example 1
 
-        BuildTasks:
+        Build:
         - NpmConfig:
             Configuration:
                 registry: https://registry.npmjs.org
@@ -39,7 +39,7 @@ function Invoke-WhiskeyNpmConfig
         
     ## Example 2
 
-        BuildTasks:
+        Build:
         - NpmConfig:
             Configuration:
                 registry: https://registry.npmjs.org
@@ -71,7 +71,7 @@ function Invoke-WhiskeyNpmConfig
     {
         Write-Warning -Message ('Your NpmConfig task isn''t doing anything. Its Configuration property is missing. Please update the NpmConfig task in your whiskey.yml file so that it is actually setting configuration, e.g.
 
-    BuildTasks:
+    Build:
     - NpmConfig:
         Configuration:
             key1: value1
@@ -84,7 +84,7 @@ function Invoke-WhiskeyNpmConfig
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Configuration property is invalid. It must have only key/value pairs, e.g.
     
-    BuildTasks:
+    Build:
     - NpmConfig:
         Configuration:
             key1: value1

--- a/Whiskey/Tasks/Invoke-WhiskeyNpmInstall.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyNpmInstall.ps1
@@ -10,7 +10,7 @@ function Invoke-WhiskeyNpmInstall
     
     You can install a specific package with the `Package` property. It should be a list of package names. You can specify a specific version of the module with this syntax:
 
-        BuildTasks:
+        Build:
         - NpmInstall:
             Package:
             - rimraf: ^2.0.0
@@ -32,14 +32,14 @@ function Invoke-WhiskeyNpmInstall
 
     ## Example 1
 
-        BuildTasks:
+        Build:
         - NpmInstall
 
     This example will install all the Node packages listed in the `package.json` file to the `BUILD_ROOT\node_modules` directory.
 
     ## Example 2
 
-        BuildTasks:
+        Build:
         - NpmInstall:
             Package:
             - gulp
@@ -48,7 +48,7 @@ function Invoke-WhiskeyNpmInstall
 
     ## Example 3
 
-        BuildTasks:
+        Build:
         - NpmInstall:
             WorkingDirectory: app
             Package:

--- a/Whiskey/Tasks/Invoke-WhiskeyNpmPrune.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyNpmPrune.ps1
@@ -23,14 +23,14 @@ function Invoke-WhiskeyNpmPrune
 
     ## Example 1
         
-        BuildTasks:
+        Build:
         - NpmPrune
     
     This example demonstrates running `npm prune` from the same directory as the build's `whiskey.yml` file. The node module's `package.json` file exists in the same directory as the `whiskey.yml` file.
 
     ## Example 2
 
-        BuildTasks:
+        Build:
         - NpmPrune:
             WorkingDirectory: src\node-module-root
 

--- a/Whiskey/Tasks/Invoke-WhiskeyNpmRunScript.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyNpmRunScript.ps1
@@ -22,7 +22,7 @@ function Invoke-WhiskeyNpmRunScript
 
     ## Example 1
 
-        BuildTasks:
+        Build:
         - NpmRunScript:
             Script:
             - build
@@ -32,7 +32,7 @@ function Invoke-WhiskeyNpmRunScript
 
     ## Example 2
 
-        BuildTasks:
+        Build:
         - NpmRunScript:
             Script:
             - test
@@ -61,7 +61,7 @@ function Invoke-WhiskeyNpmRunScript
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message 'Property ''Script'' is mandatory. It should be a list of one or more npm scripts to run during your build, e.g.,
 
-        BuildTasks:
+        Build:
         - NpmRunScript:
             Script:
             - build

--- a/Whiskey/Tasks/Invoke-WhiskeyParallelTask.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyParallelTask.ps1
@@ -21,7 +21,7 @@ function Invoke-WhiskeyParallelTask
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message 'Property "Queues" is mandatory. It should be an array of queues to run. Each queue should contain a "Tasks" property that is an array of task to run, e.g.
  
-    BuildTasks:
+    Build:
     - Parallel:
         Queues:
         - Tasks:
@@ -47,7 +47,7 @@ function Invoke-WhiskeyParallelTask
             {
                 Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Queue[{0}]: Property "Tasks" is mandatory. Each queue should have a "Tasks" property that is an array of Whiskey task to run, e.g.
  
-    BuildTasks:
+    Build:
     - Parallel:
         Queues:
         - Tasks:

--- a/Whiskey/Tasks/Invoke-WhiskeyPester3Task.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyPester3Task.ps1
@@ -53,7 +53,7 @@ function Invoke-WhiskeyPester3Task
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Element ''Path'' is mandatory. It should be one or more paths, which should be a list of Pester Tests to run with Pester3, e.g. 
         
-        BuildTasks:
+        Build:
         - Pester3:
             Path:
             - My.Tests.ps1

--- a/Whiskey/Tasks/Invoke-WhiskeyPester4Task.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyPester4Task.ps1
@@ -53,7 +53,7 @@ function Invoke-WhiskeyPester4Task
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Property "Path" is mandatory. It should be one or more paths, which should be a list of Pester test scripts (e.g. Invoke-WhiskeyPester4Task.Tests.ps1) or directories that contain Pester test scripts, e.g. 
         
-        BuildTasks:
+        Build:
         - Pester4:
             Path:
             - My.Tests.ps1

--- a/Whiskey/Tasks/Invoke-WhiskeyPipelineTask.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyPipelineTask.ps1
@@ -5,9 +5,9 @@
     Runs the tasks in a Whiskey pipeline.
 
     .DESCRIPTION
-    The `Pipeline` task runs pipelines defined in your `whiskey.yml` file. Pipelines are properties that contain a list of tasks. You are required to have a default `BuildTasks` pipeline. Other pipelines exist side-by-side with your `BuildTasks` pipeline, e.g.
+    The `Pipeline` task runs pipelines defined in your `whiskey.yml` file. Pipelines are properties that contain a list of tasks. You are required to have a default `Build` pipeline. Other pipelines exist side-by-side with your `Build` pipeline, e.g.
 
-        BuildTasks:
+        Build:
         - Pipeline:
             Name: BuildASpecificThing
 
@@ -15,7 +15,7 @@
         - MSBuild:
             Path: SpecificThing.sln
 
-    In this example, the default `BuildTasks` pipeline runs the `BuildASpecificThing` pipeline. 
+    In this example, the default `Build` pipeline runs the `BuildASpecificThing` pipeline. 
 
     Use the `Pipeline` task if you want the ability to run parts of your builds in isolation, e.g. if you have multiple applications to build, you can declare a dedicated pipeline for each. Your default build runs them all, but you can run a specific pipeline by passing that pipeline's name to the `Invoke-WhiskeyBuild` function.
 
@@ -27,7 +27,7 @@
 
     ### Example 1
 
-        BuildTasks:
+        Build:
         - Pipeline:
             Name: BuildASpecificThing
 
@@ -35,12 +35,12 @@
         - MSBuild:
             Path SpecificThing.sln
             
-    This example declares two pipelines: `BuildTasks` and `BuildASpecificThing`. The `BuildTasks` pipeline runs the `BuildASpecificThing` pipeline.           
+    This example declares two pipelines: `Build` and `BuildASpecificThing`. The `Build` pipeline runs the `BuildASpecificThing` pipeline.           
 
 
     ### Example 2
 
-        BuildTasks:
+        Build:
         - Pipeline:
             Name: 
             - BuildASpecificThing
@@ -75,7 +75,7 @@
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Name is a mandatory property, but is missing or doesn''t have a value. It should be set to a list of pipeline names you want to run as part of another pipeline, e.g.
         
-    BuildTasks:
+    Build:
     - Pipeline:
         Name:
         - One

--- a/Whiskey/Tasks/Invoke-WhiskeyPowerShell.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyPowerShell.ps1
@@ -29,7 +29,7 @@ function Invoke-WhiskeyPowerShell
 
     ### Example 1
 
-        BuildTasks:
+        Build:
         - PowerShell:
             Path: init.ps1
             Argument:
@@ -40,7 +40,7 @@ function Invoke-WhiskeyPowerShell
 
     ### Example 2
 
-        BuildTasks:
+        Build:
         - PowerShell:
             ExceptDuring: Clean
             Path: init.ps1
@@ -52,7 +52,7 @@ function Invoke-WhiskeyPowerShell
 
     ### Example 3
 
-        BuildTasks:
+        Build:
         - PowerShell:
             OnlyDuring: Clean
             Path: clean.ps1
@@ -78,7 +78,7 @@ function Invoke-WhiskeyPowerShell
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Property ''Path'' is mandatory. It should be one or more paths, which should be a list of PowerShell Scripts to run, e.g. 
         
-        BuildTasks:
+        Build:
         - PowerShell:
             Path:
             - myscript.ps1

--- a/Whiskey/Tasks/New-WhiskeyNuGetPackage.ps1
+++ b/Whiskey/Tasks/New-WhiskeyNuGetPackage.ps1
@@ -20,7 +20,7 @@ function New-WhiskeyNuGetPackage
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Property ''Path'' is mandatory. It should be one or more paths to .csproj or .nuspec files to pack, e.g. 
             
-    BuildTasks:
+    Build:
     - PublishNuGetPackage:
         Path:
         - MyProject.csproj

--- a/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
+++ b/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
@@ -58,7 +58,7 @@ function New-WhiskeyProGetUniversalPackage
 
     ### Example 1
 
-        BuildTasks:
+        Build:
         - ProGetUniversalPackage:
             Name: Example1
             Description: This package demonstrates the YAML for using the ProGetUniversalPackage task.
@@ -96,7 +96,7 @@ function New-WhiskeyProGetUniversalPackage
 
     ### Example 2
 
-        BuildTasks:
+        Build:
         - ProGetUniversalPackage
             Name: Example2
             Description: This package demonstrates the YAML for using the ProGetUniversalPackage task.
@@ -131,7 +131,7 @@ function New-WhiskeyProGetUniversalPackage
 
     ## Example 3
 
-        BuildTasks:
+        Build:
         - ProGetUniversalPackage
             Name: Example3
             Description: This package demonstrates how the `ThirdPartyPath` property works.
@@ -174,7 +174,7 @@ function New-WhiskeyProGetUniversalPackage
 
     ## Example 4
 
-        BuildTasks:
+        Build:
         - ProGetUniversalPackage
             Name: Example4
             Description: This package demonstrates how the customize paths in the package.
@@ -202,7 +202,7 @@ function New-WhiskeyProGetUniversalPackage
 
     ## Example 5
 
-        BuildTasks:
+        Build:
         - ProGetUniversalPackage
             Name: Example5
             Description: Demonstration of the SourceRoot property.

--- a/Whiskey/Tasks/Publish-WhiskeyBBServerTag.ps1
+++ b/Whiskey/Tasks/Publish-WhiskeyBBServerTag.ps1
@@ -16,7 +16,7 @@ function Publish-WhiskeyBBServerTag
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
-    $exampleTask = 'PublishTasks:
+    $exampleTask = 'Publish:
         - PublishBitbucketServerTag:
             CredentialID: BitbucketServerCredential
             Uri: https://bitbucketserver.example.com'
@@ -60,7 +60,7 @@ function Publish-WhiskeyBBServerTag
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -PropertyDescription '' -Message ("Unable to determine the repository where we should create the tag. Either create a `GIT_URL` environment variable that is the URI used to clone your repository, or add your repository''s project and repository keys as `ProjectKey` and `RepositoryKey` properties, respectively, on this task:
         
-        PublishTasks:
+        Publish:
         - PublishBitbucketServerTag:
             CredentialID: $($TaskParameter['CredentialID'])
             Uri: $($TaskParameter['Uri'])

--- a/Whiskey/Tasks/Publish-WhiskeyBuildMasterPackage.ps1
+++ b/Whiskey/Tasks/Publish-WhiskeyBuildMasterPackage.ps1
@@ -27,7 +27,7 @@ function Publish-WhiskeyBuildMasterPackage
 
     ### Example 1
 
-        PublishTasks:
+        Publish:
         - PublishBuildMasterPackage:
             ApplicationName: TestApplication
             ReleaseName: ProdRelease
@@ -38,7 +38,7 @@ function Publish-WhiskeyBuildMasterPackage
 
     ### Example 2
 
-        PublishTasks:
+        Publish:
         - PublishBuildMasterPackage:
             ApplicationName: TestApplication
             ReleaseName: ProdRelease
@@ -51,7 +51,7 @@ function Publish-WhiskeyBuildMasterPackage
 
     ### Example 3
 
-        PublishTasks:
+        Publish:
         - PublishBuildMasterPackage:
             ApplicationName: TestApplication
             ReleaseName: ProdRelease

--- a/Whiskey/Tasks/Publish-WhiskeyNodeModule.ps1
+++ b/Whiskey/Tasks/Publish-WhiskeyNodeModule.ps1
@@ -20,14 +20,14 @@ function Publish-WhiskeyNodeModule
     
     ## Example 1
     
-        BuildTasks:
+        Build:
 	- PublishNodeModule
 
     Demonstrates how to publish the Node module located in the same directory as your whiskey.yml file
     
     ## Example 2
     
-    	BuildTasks:
+    	Build:
 	- PublishNodeModule:
     	    WorkingDirectory: 'app'
 
@@ -60,7 +60,7 @@ function Publish-WhiskeyNodeModule
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message 'Property ''NpmRegistryUri'' is mandatory and must be a URI. It should be the URI to the registry where the module should be published. E.g.,
         
-    BuildTasks:
+    Build:
     - PublishNodeModule:
         NpmRegistryUri: https://registry.npmjs.org/
     '
@@ -78,7 +78,7 @@ function Publish-WhiskeyNodeModule
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Property ''CredentialID'' is mandatory. It should be the ID of the credential to use when publishing to ''{0}'', e.g.
     
-    BuildTasks:
+    Build:
     - PublishNodeModule:
         NpmRegistryUri: {0}
         CredentialID: NpmCredential
@@ -93,7 +93,7 @@ function Publish-WhiskeyNodeModule
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Property ''EmailAddress'' is mandatory. It should be the e-mail address of the user publishing the module, e.g.
     
-    BuildTasks:
+    Build:
     - PublishNodeModule:
         NpmRegistryUri: {0}
         CredentialID: {1}

--- a/Whiskey/Tasks/Publish-WhiskeyNuGetPackage.ps1
+++ b/Whiskey/Tasks/Publish-WhiskeyNuGetPackage.ps1
@@ -49,7 +49,7 @@ function Publish-WhiskeyNuGetPackage
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Property ''Uri'' is mandatory. It should be the URI where NuGet packages should be published, e.g. 
             
-    BuildTasks:
+    Build:
     - PublishNuGetPackage:
         Uri: https://nuget.org
     ')
@@ -60,7 +60,7 @@ function Publish-WhiskeyNuGetPackage
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Property ''ApiKeyID'' is mandatory. It should be the ID/name of the API key to use when publishing NuGet packages to {0}, e.g.:
             
-    BuildTasks:
+    Build:
     - PublishNuGetPackage:
         Uri: {0}
         ApiKeyID: API_KEY_ID

--- a/Whiskey/Tasks/Publish-WhiskeyPowerShellModule.ps1
+++ b/Whiskey/Tasks/Publish-WhiskeyPowerShellModule.ps1
@@ -20,7 +20,7 @@ function Publish-WhiskeyPowerShellModule
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Property ''RepositoryName'' is mandatory. It should be the name of the PowerShell repository you want to publish to, e.g.
             
-        BuildTasks:
+        Build:
         - PublishPowerShellModule:
             Path: mymodule
             RepositoryName: PSGallery
@@ -32,7 +32,7 @@ function Publish-WhiskeyPowerShellModule
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Element ''Path'' is mandatory. It should a path relative to your whiskey.yml file, to the module directory of the module to publish, e.g. 
         
-        BuildTasks:
+        Build:
         - PublishPowerShellModule:
             Path: mymodule
             RepositoryName: PSGallery

--- a/Whiskey/Tasks/Publish-WhiskeyProGetAsset.ps1
+++ b/Whiskey/Tasks/Publish-WhiskeyProGetAsset.ps1
@@ -23,7 +23,7 @@ function Publish-WhiskeyProGetAsset
         ## Examples
         
         ### Example 1
-        BuildTasks:
+        Build:
         - PublishProGetAsset:
             CredentialID: ProGetCredential
             Path: 'path/to/file.txt'
@@ -34,7 +34,7 @@ function Publish-WhiskeyProGetAsset
         Example of adding an asset named `exampleAsset` to ProGet in the `versions` directory.       
 
         ### Example 2
-        BuildTasks:
+        Build:
         - PublishProGetAsset:
             CredentialID: ProGetCredential
             Path: 
@@ -65,7 +65,7 @@ function Publish-WhiskeyProGetAsset
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
     $message = "
-    BuildTasks:
+    Build:
     - PublishProGetAsset:
         CredentialID: ProGetCredential
         Path: 

--- a/Whiskey/Tasks/Publish-WhiskeyProGetUniversalPackage.ps1
+++ b/Whiskey/Tasks/Publish-WhiskeyProGetUniversalPackage.ps1
@@ -25,7 +25,7 @@ function Publish-WhiskeyProGetUniversalPackage
 
     ### Example 1
 
-        PublishTasks:
+        Publish:
         - PublishProGetUniversalPackage:
             Uri: https://proget.example.com
             FeedName: Apps
@@ -59,7 +59,7 @@ function Publish-WhiskeyProGetUniversalPackage
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
-    $exampleTask = 'PublishTasks:
+    $exampleTask = 'Publish:
         - PublishProGetUniversalPackage:
             CredentialID: ProGetCredential
             Uri: https://proget.example.com

--- a/Whiskey/Tasks/Remove-WhiskeyItem.ps1
+++ b/Whiskey/Tasks/Remove-WhiskeyItem.ps1
@@ -16,7 +16,7 @@ function Remove-WhiskeyItem
 
     ### Example 1
 
-    BuildTasks:
+    Build:
     - Delete:
         Path:
         - result.json
@@ -26,7 +26,7 @@ function Remove-WhiskeyItem
 
     ### Example 2
 
-    BuildTasks:
+    Build:
     - Delete:
         Path:
         - Test\bin

--- a/Whiskey/Tasks/Restore-WhiskeyNuGetPackage.ps1
+++ b/Whiskey/Tasks/Restore-WhiskeyNuGetPackage.ps1
@@ -18,7 +18,7 @@ function Restore-WhiskeyNuGetPackage
 
     This demonstrates how to restore the NuGet packages for a Visual Studio solution.
 
-        BuildTasks:
+        Build:
         - NuGetRestore:
             Path: MySolution.sln
 
@@ -26,7 +26,7 @@ function Restore-WhiskeyNuGetPackage
 
     This demonstrates how to pin the task to use a specific version of NuGet, in this case, `4.1.0`. Without the `Version` attribute, the latest version of NuGet is used.
 
-        BuildTasks:
+        Build:
         -NuGetRestore:
             Path: MySolution.sln
             Version: 4.1.0
@@ -35,7 +35,7 @@ function Restore-WhiskeyNuGetPackage
 
     This demonstrates how to pass custom arguments to NuGet.exe with the `Argument` property. In this example, packages will be put in a `packages` directory in the build root (i.e. the same directory as your `whiskey.yml` file).
 
-        BuildTasks:
+        Build:
         -NuGetRestore:
             Path: packages.config
             Argument:

--- a/Whiskey/Tasks/Set-WhiskeyTaskDefaults.ps1
+++ b/Whiskey/Tasks/Set-WhiskeyTaskDefaults.ps1
@@ -11,7 +11,7 @@ function Set-WhiskeyTaskDefaults
     .EXAMPLE
     The following example demonstrates setting default values for the `MSBuild` task `Version` property and the `NuGetPack` task `Symbols` property.
    
-        BuildTasks:
+        Build:
         - TaskDefaults:
             MSBuild:
                 Version: 13.0

--- a/Whiskey/Tasks/Set-WhiskeyVariable.ps1
+++ b/Whiskey/Tasks/Set-WhiskeyVariable.ps1
@@ -9,7 +9,7 @@
 
     All the task's properties are variable names. Each property's value becomes that variables value. You may reference other variables in a value. They will be replaced with values when they are used, not when they are added by this task.
 
-        BuildTasks:
+        Build:
         - SetVariable:
             ReleaseName: 6.8
             BuildMasterPackageName: $(WHISKEY_BUILD_NUMBER)@$(WHISKEY_SCM_BRANCH)

--- a/Whiskey/Tasks/Set-WhiskeyVersion.ps1
+++ b/Whiskey/Tasks/Set-WhiskeyVersion.ps1
@@ -20,7 +20,7 @@
 
     So, if you wanted to publish alpha versions in branches that begin with "feature/" and beta versions on a branch named "develop", your "Prerelease" property would look like this:
 
-        BuildTasks:
+        Build:
         - Version:
             Version: 5.6.3
             Prerelease:
@@ -76,14 +76,14 @@
 
     ## Example 1
 
-        BuildTasks:
+        Build:
         - Version: 5.6.3
 
     Demonstrates the simplest syntax to set the version for the current build. Do this if you want to completely control the version for every build.
 
     ## Example 2
 
-        BuildTasks:
+        Build:
         - Version: 
             Version: 5.6.3
             OnlyBy: BuildServer
@@ -92,7 +92,7 @@
     
     ## Example 3
     
-        BuildTasks:
+        Build:
         - Version: $(WHISKEY_BUILD_STARTED_AT.ToString('yyyy.M.d'))+$(WHISKEY_BUILD_NUMBER).$(WHISKEY_SCM_BRANCH).$(WHISKEY_SCM_COMMIT_ID.Substring(0,7))
 
     Demonstrates how to use a dynamic, date-based version number. In this example, if the current date is 6 Feb. 2018, the current build number is `43`, your current branch is `develop`, and your current commit ID is `c7d950be9982156d5d9aaa1a6c23594eaaba9b27`, your version number would be '2018.2.16+43.develop.c7d950b'.
@@ -101,7 +101,7 @@
 
     ### Example 4
 
-        BuildTasks:
+        Build:
         - Version:
             Path: Whiskey\Whiskey.psd1
             Prerelease: alpha.$(WHISKEY_BUILD_NUMBER)
@@ -111,7 +111,7 @@
 
     ### Example 5
 
-        BuildTasks:
+        Build:
         - Version:
             Path: Assembly\Whiskey.csproj
             Prerelease: 
@@ -127,7 +127,7 @@
 
     ### Example 6
         
-        BuildTasks:
+        Build:
         - Version:
             Version: 4.5.6
         - Version:
@@ -269,13 +269,13 @@
                 {
                     Stop-WhiskeyTask -TaskContext $TaskContext -PropertyName 'Prerelease' -Message ('Unable to find keys in ''[{1}]{0}''. It looks like you''re trying use the Prerelease property to map branches to prerelease versions. If you want a static prerelease version, the syntax should be:
     
-    BuildTasks:
+    Build:
     - Version:
         Prerelease: {0}
         
 If you want certain branches to always have certain prerelease versions, set Prerelease to a list of key/value pairs:
     
-    BuildTasks:
+    Build:
     - Version:
         Prerelease:
         - feature/*: alpha.$(WHISKEY_BUILD_NUMBER)

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -152,6 +152,7 @@
 * Fixed: "Pester3" and "Pester4" tasks overwrite test results when run in parallel.
 * ***Breaking Change***: "Pester4" and "Pester3" tasks XML output file names changed. They used to be named "pester-NUMBER.xml". They now use the pattern "pester+RANDOM_STRING.xml", where "RANDOM_STRING" is a random string of ASCII characters.
 * Added "Exclude" property to "Pester4" task for filtering out tests that match any wildcards in the task's "Path" property.
+* Default "BuildTasks" and "PublishTasks" pipelines have been renamed to "Build" and "Publish". Backwards compatibility with the deprecated "BuildTasks" and "PublishTasks" pipelines will be removed in the next major version of Whiskey.
 '@
         } # End of PSData hashtable
 

--- a/Whiskey/en-US/about_Whiskey.help.txt
+++ b/Whiskey/en-US/about_Whiskey.help.txt
@@ -43,13 +43,13 @@ LONG DESCRIPTION
     ### Overview
 
     A Whiskey build has two phases: building and publishing (i.e. 
-    promoting). These are handled by the `Build` and `PublishTasks` 
+    promoting). These are handled by the `Build` and `Publish` 
     pipelines in your whiskey.yml file. A pipeline is a list of tasks to 
     perform when running that pipeline. Your first pipelines are empty:
 
        Build:
        
-       PublishTasks:
+       Publish:
     
     A pipeline is a list of tasks. Each task has properties that control what
     the task does. In Yaml, you create a list by prefixing each item with 
@@ -98,10 +98,10 @@ LONG DESCRIPTION
 
     The "PublishOn" property is a list of branch names. Wildcards are allowed.
 
-    When publishing, Whiskey runs all the tasks in the "PublishTasks" 
+    When publishing, Whiskey runs all the tasks in the "Publish" 
     pipeline. For example, Whiskey's publish process looks like this:
 
-        PublishTasks:
+        Publish:
         - PublishPowerShellModule:
             RepositoryName: PSGallery
             RepositoryUri: https://powershellgallery.com/

--- a/Whiskey/en-US/about_Whiskey.help.txt
+++ b/Whiskey/en-US/about_Whiskey.help.txt
@@ -43,11 +43,11 @@ LONG DESCRIPTION
     ### Overview
 
     A Whiskey build has two phases: building and publishing (i.e. 
-    promoting). These are handled by the `BuildTasks` and `PublishTasks` 
+    promoting). These are handled by the `Build` and `PublishTasks` 
     pipelines in your whiskey.yml file. A pipeline is a list of tasks to 
     perform when running that pipeline. Your first pipelines are empty:
 
-       BuildTasks:
+       Build:
        
        PublishTasks:
     
@@ -57,7 +57,7 @@ LONG DESCRIPTION
     spaces. If a task has properties, the task name must end with a `:`. For 
     example:
 
-        BuildTasks:
+        Build:
         - TaskOne:
             Property1: Value
             Property2: Value2
@@ -72,11 +72,11 @@ LONG DESCRIPTION
 
     ### Building
 
-    Under the "BuildTasks" pipeline in your whiskey.yml file, add tasks you 
+    Under the "Build" pipeline in your whiskey.yml file, add tasks you 
     want to run when building. For example, Whiskey's build process looks 
     like this:
 
-        BuildTasks:
+        Build:
         - Pester4:
             Path: Test\*.Tests.ps1
 

--- a/Whiskey/en-US/about_Whiskey_DotNetBuild_Task.help.txt
+++ b/Whiskey/en-US/about_Whiskey_DotNetBuild_Task.help.txt
@@ -22,7 +22,7 @@ PROPERTIES
 EXAMPLES
     Example 1
 
-        BuildTasks:
+        Build:
         - DotNetBuild:
             Path:
             - DotNetCoreSolution.sln
@@ -31,7 +31,7 @@ EXAMPLES
 
     Example 2
 
-        BuildTasks:
+        Build:
         - DotNetBuild:
             Path:
             - DotNetCoreSolution.sln
@@ -42,7 +42,7 @@ EXAMPLES
 
     Example 3
 
-        BuildTasks:
+        Build:
         - DotNetBuild:
             Path:
             - src\DotNetStandardLibrary.csproj
@@ -54,7 +54,7 @@ EXAMPLES
 
     Example 4
 
-        BuildTasks:
+        Build:
         - DotNetBuild:
             Path:
             - DotNetCoreSolution.sln

--- a/Whiskey/en-US/about_Whiskey_DotNetPack_Task.help.txt
+++ b/Whiskey/en-US/about_Whiskey_DotNetPack_Task.help.txt
@@ -26,7 +26,7 @@ PROPERTIES
 EXAMPLES
     Example 1
 
-        BuildTasks:
+        Build:
         - DotNetPack:
             Path:
             - DotNetCoreSolution.sln
@@ -35,7 +35,7 @@ EXAMPLES
 
     Example 2
 
-        BuildTasks:
+        Build:
         - DotNetPack:
             Path:
             - DotNetCoreSolution.sln
@@ -46,7 +46,7 @@ EXAMPLES
 
     Example 3
 
-        BuildTasks:
+        Build:
         - DotNetPack:
             Path:
             - src\DotNetStandardLibrary.csproj
@@ -58,7 +58,7 @@ EXAMPLES
 
     Example 4
 
-        BuildTasks:
+        Build:
         - DotNetPack:
             Path:
             - DotNetCoreSolution.sln

--- a/Whiskey/en-US/about_Whiskey_Exec_Task.help.txt
+++ b/Whiskey/en-US/about_Whiskey_Exec_Task.help.txt
@@ -27,7 +27,7 @@ PROPERTIES
 EXAMPLES
     Example 1
 
-        BuildTasks:
+        Build:
         - Exec:
             Path: cmd.exe
             Argument:
@@ -38,7 +38,7 @@ EXAMPLES
 
     Example 2
 
-        BuildTasks:
+        Build:
         - Exec:
             Path: robocopy.exe
             Argument:
@@ -55,14 +55,14 @@ EXAMPLES
 
     Example 3
 
-        BuildTasks:
+        Build:
         - Exec: robocopy.exe "C:\Source Folder" C:\Destination Folder '/MIR'
 
     This example demonstrates the single line syntax for defining the `Exec` task. Everything before the first delimiter is used as the executable's `Path` (robocopy.exe). 'C:\Source Folder', 'C:\Destination', 'Folder' and '/MIR' will be passed as 4 separate arguments.
 
     Example 4
 
-        BuildTasks:
+        Build:
         - Exec:
             ExceptDuring: Clean
             Path: cmd.exe
@@ -74,7 +74,7 @@ EXAMPLES
 
     Example 5
 
-        BuildTasks:
+        Build:
         - Exec:
             OnlyDuring: Clean
             Path: cmd.exe

--- a/Whiskey/en-US/about_Whiskey_NUnit2_Task.help.txt
+++ b/Whiskey/en-US/about_Whiskey_NUnit2_Task.help.txt
@@ -34,7 +34,7 @@ EXAMPLES
 
     ## Example 1
     
-        BuildTasks:
+        Build:
         - NUnit2:
             Path:
             - UnitTests\bin\Whiskey.*.Tests.dll
@@ -44,7 +44,7 @@ EXAMPLES
 
     ## Example 2
     
-        BuildTasks:
+        Build:
         - NUnit2:
             Path:
             - UnitTests\bin\Whiskey.*.Tests.dll
@@ -56,7 +56,7 @@ EXAMPLES
 
     ## Example 3
     
-        BuildTasks:
+        Build:
         - NUnit2:
             Path:
             - UnitTests\bin\Whiskey.*.Tests.dll

--- a/Whiskey/en-US/about_Whiskey_NUnit3_Task.help.txt
+++ b/Whiskey/en-US/about_Whiskey_NUnit3_Task.help.txt
@@ -34,7 +34,7 @@ EXAMPLES
 
     ## Example 1
 
-        BuildTasks:
+        Build:
         - NUnit3:
             Path:
             - RootAssembly.dll
@@ -44,7 +44,7 @@ EXAMPLES
 
     ## Example 2
 
-        BuildTasks:
+        Build:
         - NUnit3:
             Path:
             - Assembly.dll
@@ -55,7 +55,7 @@ EXAMPLES
 
     ## Example 3
 
-        BuildTasks:
+        Build:
         - NUnit3:
             Path:
             - Assembly.dll
@@ -69,7 +69,7 @@ EXAMPLES
 
     ## Example 4
 
-        BuildTasks:
+        Build:
         - NUnit3:
             Path:
             - Assembly.dll

--- a/Whiskey/en-US/about_Whiskey_NuGetPush_Task.help.txt
+++ b/Whiskey/en-US/about_Whiskey_NuGetPush_Task.help.txt
@@ -25,7 +25,7 @@ EXAMPLES
 
   EXAMPLE 1
 
-      BuildTasks:
+      Build:
       - NuGetPush:
           Uri: https://nuget.org/api/v2/package
           ApiKeyID: nuget.org
@@ -36,7 +36,7 @@ EXAMPLES
 
   EXAMPLE 2
 
-      BuildTasks:
+      Build:
       - NuGetPush:
           Uri: https://proget.example.com/nuget/NuGet/
           ApiKeyID: ProGet
@@ -47,7 +47,7 @@ EXAMPLES
 
   EXAMPLE 3
 
-      BuildTasks:
+      Build:
       - NuGetPush:
           Uri: https://nuget.org/api/v2/package
           ApiKeyID: nuget.org
@@ -58,7 +58,7 @@ EXAMPLES
 
   EXAMPLE 4
 
-      BuildTasks:
+      Build:
       - NuGetPush:
           Uri: https://proget.example.com/nuget/NuGet/
           ApiKeyID: ProGet

--- a/Whiskey/en-US/about_Whiskey_Parallel_Task.help.txt
+++ b/Whiskey/en-US/about_Whiskey_Parallel_Task.help.txt
@@ -17,7 +17,7 @@ PROPERTIES
 EXAMPLES
     Example 1
 
-        BuildTasks:
+        Build:
         - Parallel:
             Queues:
             - Tasks:

--- a/Whiskey/en-US/about_Whiskey_Pester3_Task.help.txt
+++ b/Whiskey/en-US/about_Whiskey_Pester3_Task.help.txt
@@ -26,7 +26,7 @@ EXAMPLES
 
 ## Example 1
     
-        BuildTasks:
+        Build:
         - Pester3:
             Path: Test\*.Tests.ps1
 
@@ -34,7 +34,7 @@ EXAMPLES
     
 ## Example 2
  
-        BuildTasks:
+        Build:
         - Pester3:
             Version: 3.4.6
             Path: Test\*.Tests.ps1
@@ -43,7 +43,7 @@ EXAMPLES
 
 ## Example 3
  
-        BuildTasks:
+        Build:
         - Pester3:
             Version: 3.4.*
             Path: Test\*.Tests.ps1

--- a/Whiskey/en-US/about_Whiskey_Pester4_Task.help.txt
+++ b/Whiskey/en-US/about_Whiskey_Pester4_Task.help.txt
@@ -29,7 +29,7 @@ EXAMPLE
 
 ## Example 1
 
-        BuildTasks:
+        Build:
         - Pester4:
             Path: Test\*.ps1
 
@@ -37,7 +37,7 @@ EXAMPLE
 
 ## Example 2
 
-        BuildTasks:
+        Build:
         - Pester4:
             Path: Test\*.ps1
             Version: 4.0.6
@@ -46,7 +46,7 @@ EXAMPLE
 
 ## Example 3
 
-        BuildTasks:
+        Build:
         - Pester4:
             Path: Test\*.ps1
             DescribeDurationReportCount: 20
@@ -56,7 +56,7 @@ EXAMPLE
 
 ## Example 3
 
-        BuildTasks:
+        Build:
         - Pester4:
             Path: Tests\*.Tests.ps1
             Exclude:

--- a/Whiskey/en-US/about_Whiskey_Writing_Tasks.help.txt
+++ b/Whiskey/en-US/about_Whiskey_Writing_Tasks.help.txt
@@ -38,7 +38,7 @@ LONG DESCRIPTION
 
     To use your task in a whiskey.yml file, use the name from the `Whiskey.Task` attribute, e.g.
 
-        BuildTasks:
+        Build:
         - TASK_NAME:
             Property: Value
             Property2:
@@ -102,7 +102,7 @@ LONG DESCRIPTION
 
     A user could use the `NspVersion` property to control what version of Node they want to use:
 
-         BuildTasks:
+         Build:
          - TASK_NAME:
             NspVersion: 8.9.4
 

--- a/Whiskey/whiskey.sample.yml
+++ b/Whiskey/whiskey.sample.yml
@@ -1,9 +1,9 @@
 # The `PublishOn` property is a list of branch names. After a successful build on a 
-# branch that matches any name in this list, the `PublishTasks` pipeline will run. With 
-# an empty `PublishOn` property, your `PublishTasks` pipeline will never run.
+# branch that matches any name in this list, the `Publish` pipeline will run. With 
+# an empty `PublishOn` property, your `Publish` pipeline will never run.
 #
 # Wildcards are supported. For example, if `release/*` is in the list, the 
-# `PublishTasks` pipeline would run on the `release/6.3` branch but not the `release`
+# `Publish` pipeline would run on the `release/6.3` branch but not the `release`
 # branch.
 PublishOn:
  - master
@@ -75,4 +75,4 @@ Build:
 # Publishing branches are configured with the `PublishOn` property.
 #
 # See the documentation for each individual task for YML samples.
-PublishTasks:
+Publish:

--- a/Whiskey/whiskey.sample.yml
+++ b/Whiskey/whiskey.sample.yml
@@ -26,13 +26,13 @@ PublishBuildStatusTo:
 
 # An array of build tasks you want to run during a build, e.g.
 # 
-#     BuildTasks:
+#     Build:
 #     - TASK_NAME:
 #         PROPERTY_ONE: VALUE_ONE
 #         PROPERTY_TWO: VALUE_TWO
 #
 # See the documentation for each individual task for YML samples.
-BuildTasks:
+Build:
 # The Version task sets the current build's version number. You should almost always 
 # have one of these.
 - Version:
@@ -66,7 +66,7 @@ BuildTasks:
 
 # An array of tasks you want to run when publishing, e.g.
 # 
-#     BuildTasks:
+#     Build:
 #     - TASK_NAME:
 #         PROPERTY_ONE: VALUE_ONE
 #         PROPERTY_TWO: VALUE_TWO

--- a/whiskey.yml
+++ b/whiskey.yml
@@ -1,7 +1,7 @@
 PublishOn: 
 - master
 
-BuildTasks:
+Build:
 - TaskDefaults:
     Pester4:
         DescribeDurationReportCount: 20

--- a/whiskey.yml
+++ b/whiskey.yml
@@ -83,7 +83,7 @@ Build:
             - Test\Invoke-WhiskeyNUnit2Task.Tests.ps1
             - Test\Invoke-WhiskeyNUnit3Task.Tests.ps1
 
-PublishTasks:
+Publish:
 - PublishPowerShellModule:
     RepositoryName: PSGallery
     RepositoryUri: https://powershellgallery.com/


### PR DESCRIPTION
* Default "BuildTasks" and "PublishTasks" pipelines have been renamed to "Build" and "Publish". Backwards compatibility with the deprecated "BuildTasks" and "PublishTasks" pipelines will be removed in the next major version of Whiskey.