### PR TITLE
Adding support for replacement tokens in .nuspec files

### DIFF
--- a/Test/NuGetPack.Tests.ps1
+++ b/Test/NuGetPack.Tests.ps1
@@ -223,7 +223,7 @@ function ThenPackageNotCreated
     }
 }
 
-Describe 'New-WhiskeyNuGetPackage.when creating a NuGet package with an invalid project' {
+Describe 'NuGetPack.when creating a NuGet package with an invalid project' {
     InitTest
     GivenABuiltLibrary
     GivenPath -Path 'I\do\not\exist.csproj'
@@ -232,7 +232,7 @@ Describe 'New-WhiskeyNuGetPackage.when creating a NuGet package with an invalid 
     ThenTaskThrowsAnException 'does not exist'
 }
 
-Describe 'New-WhiskeyNuGetPackage.when creating a NuGet package' {
+Describe 'NuGetPack.when creating a NuGet package' {
     InitTest
     GivenABuiltLibrary
     WhenRunningNuGetPackTask
@@ -240,7 +240,7 @@ Describe 'New-WhiskeyNuGetPackage.when creating a NuGet package' {
     ThenPackageCreated
 }
 
-Describe 'New-WhiskeyNuGetPackage.when creating a symbols NuGet package' {
+Describe 'NuGetPack.when creating a symbols NuGet package' {
     InitTest
     GivenABuiltLibrary
     WhenRunningNuGetPackTask -Symbols
@@ -248,7 +248,7 @@ Describe 'New-WhiskeyNuGetPackage.when creating a symbols NuGet package' {
     ThenPackageCreated -Symbols
 }
 
-Describe 'New-WhiskeyNuGetPackage.when creating a package built in release mode' {
+Describe 'NuGetPack.when creating a package built in release mode' {
     InitTest
     GivenABuiltLibrary -InReleaseMode
     GivenRunByBuildServer
@@ -257,7 +257,7 @@ Describe 'New-WhiskeyNuGetPackage.when creating a package built in release mode'
     ThenPackageCreated
 }
 
-Describe 'New-WhiskeyNuGetPackage.when creating multiple packages for publishing' {
+Describe 'NuGetPack.when creating multiple packages for publishing' {
     InitTest
     GivenABuiltLibrary
     GivenPath @( $projectName, $projectName )
@@ -266,7 +266,7 @@ Describe 'New-WhiskeyNuGetPackage.when creating multiple packages for publishing
     ThenTaskSucceeds
 }
 
-Describe 'New-WhiskeyNuGetPackage.when creating a package using a specifc version of NuGet' {
+Describe 'NuGetPack.when creating a package using a specifc version of NuGet' {
     InitTest
     GivenABuiltLibrary
     GivenVersion '3.5.0'

--- a/Whiskey/Functions/Install-WhiskeyTool.ps1
+++ b/Whiskey/Functions/Install-WhiskeyTool.ps1
@@ -106,7 +106,7 @@ function Install-WhiskeyTool
 
         $waitedFor = (Get-Date) - $startedWaitingAt
         Write-Debug -Message ('[{0:yyyy-MM-dd HH:mm:ss}]  Process "{1}" obtained mutex "{2}" in {3}.' -f (Get-Date),$PID,$mutexName,$waitedFor)
-        $DebugPreference = 'SilentlyContinue'
+        #$DebugPreference = 'SilentlyContinue'
         $startedUsingAt = Get-Date
 
         if( $PSCmdlet.ParameterSetName -eq 'PowerShell' )
@@ -346,7 +346,7 @@ function Install-WhiskeyTool
     }
     finally
     {
-        $DebugPreference = 'Continue'
+        #$DebugPreference = 'Continue'
         $usedFor = (Get-Date) - $startedUsingAt
         Write-Debug -Message ('[{0:yyyy-MM-dd HH:mm:ss}]  Process "{1}" releasing mutex "{2}" after using it for {3}.' -f (Get-Date),$PID,$mutexName,$usedFor)
         $startedReleasingAt = Get-Date
@@ -356,6 +356,6 @@ function Install-WhiskeyTool
         $installLock = $null
         $releasedDuration = (Get-Date) - $startedReleasingAt
         Write-Debug -Message ('[{0:yyyy-MM-dd HH:mm:ss}]  Process "{1}" released mutex "{2}" in {3}.' -f (Get-Date),$PID,$mutexName,$releasedDuration)
-        $DebugPreference = 'SilentlyContinue'
+        #$DebugPreference = 'SilentlyContinue'
     }
 }

--- a/Whiskey/Functions/Install-WhiskeyTool.ps1
+++ b/Whiskey/Functions/Install-WhiskeyTool.ps1
@@ -89,7 +89,7 @@ function Install-WhiskeyTool
     $startedWaitingAt = Get-Date
     $startedUsingAt = Get-Date
     $installLock = New-Object 'Threading.Mutex' $false,$mutexName
-    $DebugPreference = 'Continue'
+    #$DebugPreference = 'Continue'
     Write-Debug -Message ('[{0:yyyy-MM-dd HH:mm:ss}]  Process "{1}" is waiting for mutex "{2}".' -f (Get-Date),$PID,$mutexName)
 
     try

--- a/Whiskey/Tasks/New-WhiskeyNuGetPackage.ps1
+++ b/Whiskey/Tasks/New-WhiskeyNuGetPackage.ps1
@@ -45,6 +45,23 @@ function New-WhiskeyNuGetPackage
         return
     }
 
+    $properties = $TaskParameter['Properties']
+    $propertiesArgs = @()
+    if( $properties )
+    {
+        if( -not (Get-Member -InputObject $properties -Name 'Keys') )
+        {
+            Stop-WhiskeyTask -TaskContext $TaskContext -PropertyName 'Properties' -Message ('Property is invalid. This property must be a name/value mapping of properties to pass to nuget.exe pack command''s "-Properties" parameter.')
+            return
+        }
+
+        $propertiesArgs = $properties.Keys | 
+                                ForEach-Object {
+                                    '-Properties'
+                                    '{0}={1}' -f $_,$properties[$_]
+                                }
+    }
+
     foreach ($path in $paths)
     {
         $projectName = [IO.Path]::GetFileNameWithoutExtension(($path | Split-Path -Leaf))
@@ -53,7 +70,7 @@ function New-WhiskeyNuGetPackage
         # Create NuGet package
         $configuration = Get-WhiskeyMSBuildConfiguration -Context $TaskContext
 
-        & $nugetPath pack -Version $packageVersion -OutputDirectory $TaskContext.OutputDirectory $symbolsArg -Properties ('Configuration={0}' -f $configuration) $path
+        & $nugetPath pack -Version $packageVersion -OutputDirectory $TaskContext.OutputDirectory $symbolsArg -Properties ('Configuration={0}' -f $configuration) $propertiesArgs $path
 
         # Make sure package was created.
         $filename = '{0}.{1}{2}.nupkg' -f $projectName,$packageVersion,$symbolsFileNameSuffix

--- a/Whiskey/Tasks/New-WhiskeyNuGetPackage.ps1
+++ b/Whiskey/Tasks/New-WhiskeyNuGetPackage.ps1
@@ -64,8 +64,16 @@ function New-WhiskeyNuGetPackage
 
     foreach ($path in $paths)
     {
-        $projectName = [IO.Path]::GetFileNameWithoutExtension(($path | Split-Path -Leaf))
-        $packageVersion = $TaskContext.Version.SemVer1
+        $projectName = $TaskParameter['PackageID']
+        if( -not $projectName )
+        {
+            $projectName = [IO.Path]::GetFileNameWithoutExtension(($path | Split-Path -Leaf))
+        }
+        $packageVersion = $TaskParameter['PackageVersion']
+        if( -not $packageVersion )
+        {
+            $packageVersion = $TaskContext.Version.SemVer1
+        }
                     
         # Create NuGet package
         $configuration = Get-WhiskeyMSBuildConfiguration -Context $TaskContext

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -150,6 +150,8 @@
 # 0.35.0
 
 * Added "Properties" property to "NuGetPack" task so that tokens inside .nuspec files can be replaced. The "Properties" property should be a name/value mapping. Each name/value is passed to nuget.exe pack command's "-Properties" parameter.
+* Added "PackageID" property to "NuGetPack" task to handle situations where a package's ID doesn't match the source .nuspec/.csproj file.
+* Added "PackageVersion" property to "NuGetPack" task to allow customizing the package's version number.
 '@
         } # End of PSData hashtable
 

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Whiskey.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.34.0'
+    ModuleVersion = '0.35.0'
 
     # ID used to uniquely identify this module
     GUID = '93bd40f1-dee5-45f7-ba98-cb38b7f5b897'
@@ -147,14 +147,9 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-# 0.34.0
+# 0.35.0
 
-* Fixed: "Pester3" and "Pester4" tasks overwrite test results when run in parallel.
-* ***Breaking Change***: "Pester4" and "Pester3" tasks XML output file names changed. They used to be named "pester-NUMBER.xml". They now use the pattern "pester+RANDOM_STRING.xml", where "RANDOM_STRING" is a random string of ASCII characters.
-* Added "Exclude" property to "Pester4" task for filtering out tests that match any wildcards in the task's "Path" property.
-* Default "BuildTasks" and "PublishTasks" pipelines have been renamed to "Build" and "Publish". Backwards compatibility with the deprecated "BuildTasks" and "PublishTasks" pipelines will be removed in the next major version of Whiskey.
-* Added "SetVariableFromXML" task that creates Whiskey variables from values in XML files.
-* Added "ManifestProperties" property to "ProGetUniversalPackageTask" for setting custom upack.json metadata.
+* Added "Properties" property to "NuGetPack" task so that tokens inside .nuspec files can be replaced. The "Properties" property should be a name/value mapping. Each name/value is passed to nuget.exe pack command's "-Properties" parameter.
 '@
         } # End of PSData hashtable
 

--- a/Whiskey/en-US/about_Whiskey_NuGetPack_Task.help.txt
+++ b/Whiskey/en-US/about_Whiskey_NuGetPack_Task.help.txt
@@ -1,0 +1,39 @@
+TOPIC
+    about_Whiskey_NuGetPack_Task
+    
+SUMMARY
+    Creates a NuGet package.
+    
+DESCRIPTION
+    The `NuGetPack` task create a NuGet package using the `nuget.exe pack` command. Pass the path to the .nuspec or .csproj file to use to the `Path` property. The package will be saved to Whiskey's output directory. You may use wildcards and/or multiple paths. A package is created for each unique path.
+
+    To create a `Symbols` package, set the `Symbols` property to `true`. This will use the `-Symbols` switch when calling `nuget.exe`.
+
+    By default, this task downloads and uses the latest version of NuGet. To use a specific version of NuGet, set the `Version` property to the version you want to use.
+
+    The task passes the version of the current build to the nuget.exe executable's `-Version` parameter.
+
+PROPERTIES
+    * Path (***mandatory***): the path to the .nuspec or .csproj file to package. Wildcards and multiple paths supported. `nuget.exe pack` is run for each path.
+    * Symbols: whether or not to create a symbols package. If this is `true`, uses the nuget.exe executable's `-Symbols` switch.
+    * Version: the version of nuget.exe to use to publish. The default is to use the latest version of NuGet.
+
+EXAMPLES
+
+    ## Example 1
+
+      Build:
+      - NuGetPack:
+          Path: Whiskey.nuspec
+
+    Demonstrates how to build a NuGet package using a .nuspec file.
+
+
+    ## Example 2
+
+      Build:
+      - NuGetPack:
+          Path: Assembly\Whiskey\Whiskey.csproj
+          Symbols: true
+
+    Demonstrates how to create a symbols package.

--- a/Whiskey/en-US/about_Whiskey_NuGetPack_Task.help.txt
+++ b/Whiskey/en-US/about_Whiskey_NuGetPack_Task.help.txt
@@ -15,11 +15,17 @@ DESCRIPTION
 
     Nuspec files allow token replacements in nodes under its `metadata` element. Tokens follow the pattern `$TOKEN_NAME$`. If elements under the `metadata` element in your .nuspec file contains tokens, you pass the value of those tokens to the `Properties` property.
 
+    Since nuget.exe doesn't return any exit codes that denote success or failure, the task fails if an expected .nupkg was not created in the output directory. It looks for a filename with the same base name as the source file, plus the version, plus a "-symbols" switch (if the "Symbols" property is "true"). If your package's ID doesn't match the source file name (without extension), set the "PackageID" property to your package's ID.
+
+    Use the "PackageVersion" property to customize the version of your package. The default is the `WHISKEY_SEMVER1_VERSION` variable.
+
 PROPERTIES
     * Path (***mandatory***): the path to the .nuspec or .csproj file to package. Wildcards and multiple paths supported. `nuget.exe pack` is run for each path.
     * Symbols: whether or not to create a symbols package. If this is `true`, uses the nuget.exe executable's `-Symbols` switch.
     * Version: the version of nuget.exe to use to publish. The default is to use the latest version of NuGet.
     * Properties: name/value pairs to pass to the pack command's `-Properties` parameter. Each name/value pair is passed as a separate parameter.
+    * PackageID: the package ID. The default is the Path property's file name, without its extension. This property is used to check that the .nupkg file was created by nuget.exe.
+    * PackageVersion: the version of the package to use. The defalt is the value of the `WHISKEY_SEMVER1_VERSION` variable.
 
 EXAMPLES
 

--- a/Whiskey/en-US/about_Whiskey_NuGetPack_Task.help.txt
+++ b/Whiskey/en-US/about_Whiskey_NuGetPack_Task.help.txt
@@ -13,10 +13,13 @@ DESCRIPTION
 
     The task passes the version of the current build to the nuget.exe executable's `-Version` parameter.
 
+    Nuspec files allow token replacements in nodes under its `metadata` element. Tokens follow the pattern `$TOKEN_NAME$`. If elements under the `metadata` element in your .nuspec file contains tokens, you pass the value of those tokens to the `Properties` property.
+
 PROPERTIES
     * Path (***mandatory***): the path to the .nuspec or .csproj file to package. Wildcards and multiple paths supported. `nuget.exe pack` is run for each path.
     * Symbols: whether or not to create a symbols package. If this is `true`, uses the nuget.exe executable's `-Symbols` switch.
     * Version: the version of nuget.exe to use to publish. The default is to use the latest version of NuGet.
+    * Properties: name/value pairs to pass to the pack command's `-Properties` parameter. Each name/value pair is passed as a separate parameter.
 
 EXAMPLES
 
@@ -37,3 +40,15 @@ EXAMPLES
           Symbols: true
 
     Demonstrates how to create a symbols package.
+
+
+    ## Example 3
+
+      Build:
+      - NuGetPack:
+          Path: Assembly\Whiskey\Whiskey.nuspec
+          Properties:
+            ReleaseNotes: Release notes.
+            Tags: "tag1 tag2 tag3"
+
+    Demonstrates how to pass properties to the pack command's `-Properties` parameter. Any $-delimited tokens in element in a .nupsec file under the `metadata` element would get replaced with the values passed here. In this case, token `$ReleaseNotes$` would get replaced with `Release notes.` and token `$Tags$` would get replaced with `tag1 tag2 tag3`.

--- a/whiskey.yml
+++ b/whiskey.yml
@@ -33,7 +33,7 @@ Build:
             - "*\\Test\\Invoke-WhiskeyPester4Task.Tests.ps1"
             - "*\\Test\\Invoke-WhiskeyPowerShell.Tests.ps1"
             - "*\\Test\\Invoke-WhiskeyTask.Tests.ps1"
-            - "*\\Test\\New-WhiskeyNuGetPackage.Tests.ps1"
+            - "*\\Test\\NuGetPack.Tests.ps1"
             - "*\\Test\\Parallel.Tests.ps1"
             - "*\\Test\\Publish-WhiskeyNodeModule.Tests.ps1"
             - "*\\Test\\Publish-WhiskeyNuGetPackage.Tests.ps1"
@@ -50,7 +50,7 @@ Build:
             - Test\Invoke-WhiskeyNpmInstall.Tests.ps1
             - Test\Invoke-WhiskeyPowerShell.Tests.ps1
             - Test\Invoke-WhiskeyTask.Tests.ps1
-            - Test\New-WhiskeyNuGetPackage.Tests.ps1
+            - Test\NuGetPack.Tests.ps1
             - Test\Parallel.Tests.ps1
             - Test\Publish-WhiskeyNodeModule.Tests.ps1
             - Test\Publish-WhiskeyNuGetPackage.Tests.ps1


### PR DESCRIPTION
I need this functionality to get the Carbon module's build process migrated to Whiskey.

* Added "Properties" property to "NuGetPack" task so that tokens inside .nuspec files can be replaced. The "Properties" property should be a name/value mapping. Each name/value is passed to nuget.exe pack command's "-Properties" parameter.
* Added "PackageID" property to "NuGetPack" task to handle situations where a package's ID doesn't match the source .nuspec/.csproj file.
* Added "PackageVersion" property to "NuGetPack" task to allow customizing the package's version number.
