### PR TITLE
Fixed: ProGetUniversalPackage task should remove the temporary roboco…

### DIFF
--- a/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
+++ b/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
@@ -84,24 +84,24 @@ function New-WhiskeyProGetUniversalPackage
         $parentPathParam['ParentPath'] = $sourceRoot
     }
 
-    if( -not $manifestProperties.ContainsKey('Name') )
+    if( -not $manifestProperties.ContainsKey('name') )
     {
-        $manifestProperties['Name'] = $name
+        $manifestProperties['name'] = $name
     }
 
-    if( -not $manifestProperties.ContainsKey('Title') )
+    if( -not $manifestProperties.ContainsKey('title') )
     {
-        $manifestProperties['Title'] = $name
+        $manifestProperties['title'] = $name
     }
 
-    if( -not $manifestProperties.ContainsKey('Description') )
+    if( -not $manifestProperties.ContainsKey('description') )
     {
-        $manifestProperties['Description'] = $TaskParameter['Description']
+        $manifestProperties['description'] = $TaskParameter['Description']
     }
 
-    if( -not $manifestProperties.ContainsKey('Version') )
+    if( -not $manifestProperties.ContainsKey('version') )
     {
-        $manifestProperties['Version'] = $version.SemVer2NoBuildMetadata.ToString()
+        $manifestProperties['version'] = $version.SemVer2NoBuildMetadata.ToString()
     }
 
     $tempRoot = $TaskContext.Temp

--- a/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
+++ b/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
@@ -104,7 +104,7 @@ function New-WhiskeyProGetUniversalPackage
         $manifestProperties['version'] = $version.SemVer2NoBuildMetadata.ToString()
     }
 
-    $tempRoot = Join-Path -Path $TaskContext.Temp -ChildPath ('Temp.{0}.upack' -f $name)
+    $tempRoot = Join-Path -Path $TaskContext.Temp -ChildPath 'upack'
     New-Item -Path $tempRoot -ItemType 'Directory' | Out-Null
 
     $tempPackageRoot = Join-Path -Path $tempRoot -ChildPath 'package'

--- a/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
+++ b/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
@@ -228,6 +228,8 @@ function New-WhiskeyProGetUniversalPackage
                         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Robocopy failed with exit code {0}' -f $LASTEXITCODE)
                     }
 
+                    Remove-Item -Path $robocopyOutputPath -Force
+
                     # Get rid of empty directories. Robocopy doesn't sometimes.
                     Get-ChildItem -Path $destination -Directory -Recurse |
                         Where-Object { -not ($_ | Get-ChildItem) } |

--- a/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
+++ b/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
@@ -104,7 +104,9 @@ function New-WhiskeyProGetUniversalPackage
         $manifestProperties['version'] = $version.SemVer2NoBuildMetadata.ToString()
     }
 
-    $tempRoot = $TaskContext.Temp
+    $tempRoot = Join-Path -Path $TaskContext.Temp -ChildPath ('Temp.{0}.upack' -f $name)
+    New-Item -Path $tempRoot -ItemType 'Directory' | Out-Null
+
     $tempPackageRoot = Join-Path -Path $tempRoot -ChildPath 'package'
     New-Item -Path $tempPackageRoot -ItemType 'Directory' | Out-Null
 
@@ -227,8 +229,6 @@ function New-WhiskeyProGetUniversalPackage
 
                         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Robocopy failed with exit code {0}' -f $LASTEXITCODE)
                     }
-
-                    Remove-Item -Path $robocopyOutputPath -Force
 
                     # Get rid of empty directories. Robocopy doesn't sometimes.
                     Get-ChildItem -Path $destination -Directory -Recurse |

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -150,6 +150,7 @@
 # 0.35.0
 
 * Created "SetVariableFromPowerShellDataFile" task for creating variables from values in PowerShell data files (e.g. .psd1 files, module manifests, etc.).
+* Fixed: `ProGetUniversalPackage` task should remove the temporary robocopy output file after it's no longer necessary so it doesn't inadvertently get added to package with a "*.txt" wildcard Include item.
 '@
         } # End of PSData hashtable
 

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -150,7 +150,7 @@
 # 0.35.0
 
 * Created "SetVariableFromPowerShellDataFile" task for creating variables from values in PowerShell data files (e.g. .psd1 files, module manifests, etc.).
-* Fixed: `ProGetUniversalPackage` task now uses a separate package staging directory inside the root task temp directory to prevent any sort of miscellaneous task files from being included in the generated package.
+* Fixed: `ProGetUniversalPackage` task no longer includes robocopy output text files in your package.
 * Fixed: `ProGetUniversalPackage` task was creating upack.json property keys with uppercase letters when they are required to be lowercase.
 '@
         } # End of PSData hashtable

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -150,7 +150,7 @@
 # 0.35.0
 
 * Created "SetVariableFromPowerShellDataFile" task for creating variables from values in PowerShell data files (e.g. .psd1 files, module manifests, etc.).
-* Fixed: `ProGetUniversalPackage` task should remove the temporary robocopy output file after it's no longer necessary so it doesn't inadvertently get added to package with a "*.txt" wildcard Include item.
+* Fixed: `ProGetUniversalPackage` task now uses a separate package staging directory inside the root task temp directory to prevent any sort of miscellaneous task files from being included in the generated package.
 * Fixed: `ProGetUniversalPackage` task was creating upack.json property keys with uppercase letters when they are required to be lowercase.
 '@
         } # End of PSData hashtable

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -151,6 +151,7 @@
 
 * Created "SetVariableFromPowerShellDataFile" task for creating variables from values in PowerShell data files (e.g. .psd1 files, module manifests, etc.).
 * Fixed: `ProGetUniversalPackage` task should remove the temporary robocopy output file after it's no longer necessary so it doesn't inadvertently get added to package with a "*.txt" wildcard Include item.
+* Fixed: `ProGetUniversalPackage` task was creating upack.json property keys with uppercase letters when they are required to be lowercase.
 '@
         } # End of PSData hashtable
 


### PR DESCRIPTION
…py output file after it's no longer necessary so it doesn't inadvertently get added to package with a "*.txt" wildcard Include item.