### PR TITLE
Cleanup wrapper task temp directories

### DIFF
--- a/Test/Invoke-WhiskeyTask.Tests.ps1
+++ b/Test/Invoke-WhiskeyTask.Tests.ps1
@@ -339,13 +339,13 @@ function ThenPluginsRan
         {
             It ('should run {0}' -f $pluginName) {
                 Assert-MockCalled -CommandName $pluginName -ModuleName 'Whiskey' -Times $Times -ParameterFilter { $TaskContext -ne $null }
-                Assert-MockCalled -CommandName $pluginName -ModuleName 'Whiskey' -Times $Times -ParameterFilter { 
+                Assert-MockCalled -CommandName $pluginName -ModuleName 'Whiskey' -Times $Times -ParameterFilter {
                     #$DebugPreference = 'Continue'
                     Write-Debug -Message ('TaskName  expected  {0}' -f $ForTaskNamed)
                     Write-Debug -Message ('          actual    {0}' -f $TaskName)
-                    $TaskName -eq $ForTaskNamed 
+                    $TaskName -eq $ForTaskNamed
                 }
-                Assert-MockCalled -CommandName $pluginName -ModuleName 'Whiskey' -Times $Times -ParameterFilter { 
+                Assert-MockCalled -CommandName $pluginName -ModuleName 'Whiskey' -Times $Times -ParameterFilter {
                     if( $TaskParameter.Count -ne $WithParameter.Count )
                     {
                         return $false
@@ -476,7 +476,7 @@ function ThenTaskRanWithoutParameter
     }
 }
 
-function ThenTempDirectoryCreated 
+function ThenTempDirectoryCreated
 {
     param(
         $TaskName
@@ -485,13 +485,13 @@ function ThenTempDirectoryCreated
     $expectedTempPath = Join-Path -Path $context.OutputDirectory -ChildPath ('Temp.{0}.' -f $TaskName)
     $expectedTempPathRegex = '^{0}[a-z0-9]{{8}}\.[a-z0-9]{{3}}$' -f [regex]::escape($expectedTempPath)
     It ('should create a task-specific temp directory') {
-        Assert-MockCalled -CommandName 'New-Item' -ModuleName 'Whiskey' -ParameterFilter { 
+        Assert-MockCalled -CommandName 'New-Item' -ModuleName 'Whiskey' -ParameterFilter {
             #$DebugPreference = 'Continue'
             Write-Debug ('Path  expected  {0}' -f $expectedTempPathRegex)
             Write-Debug ('      actual    {0}' -f $Path)
             $Path -match $expectedTempPathRegex }
         Assert-MockCalled -CommandName 'New-Item' -ModuleName 'Whiskey' -ParameterFilter { $Force }
-        Assert-MockCalled -CommandName 'New-Item' -ModuleName 'Whiskey' -ParameterFilter { 
+        Assert-MockCalled -CommandName 'New-Item' -ModuleName 'Whiskey' -ParameterFilter {
             #$DebugPreference = 'Continue'
             Write-Debug ('ItemType  expected  {0}' -f 'Directory')
             Write-Debug ('          actual    {0}' -f $ItemType)
@@ -499,12 +499,12 @@ function ThenTempDirectoryCreated
     }
 }
 
-function ThenTempDirectoryRemoved 
+function ThenTempDirectoryRemoved
 {
     param(
         $TaskName
     )
-    
+
     $expectedTempPath = Join-Path -Path $context.OutputDirectory -ChildPath ('Temp.{0}.*' -f $TaskName)
     It ('should delete task-specific temp directory') {
         $expectedTempPath | Should -Not -Exist
@@ -512,12 +512,12 @@ function ThenTempDirectoryRemoved
     }
 }
 
-function ThenTaskRanInWorkingDirectory 
+function ThenTaskRanInWorkingDirectory
 {
     param(
         $Directory
     )
-    
+
     $wd = Join-Path -Path $TestDrive.FullName -ChildPath $Directory
 
     It ('should push the working directory ''{0}'' before executing task' -f $Directory) {
@@ -551,7 +551,7 @@ function ThenToolInstalled
     $taskContext = $context
     It 'should install Node' {
         Assert-MockCalled -CommandName 'Install-WhiskeyTool' -ModuleName 'Whiskey' -ParameterFilter { $Toolinfo.Name -eq $ToolName }
-        Assert-MockCalled -CommandName 'Install-WhiskeyTool' -ModuleName 'Whiskey' -ParameterFilter { 
+        Assert-MockCalled -CommandName 'Install-WhiskeyTool' -ModuleName 'Whiskey' -ParameterFilter {
             #$DebugPreference = 'Continue'
             $expectedInstallRoot = (Resolve-Path -Path 'TestDrive:').ProviderPath.TrimEnd('\')
             Write-Debug -Message ('InstallRoot  expected  {0}' -f $expectedInstallRoot)
@@ -655,7 +655,7 @@ function WhenRunningTask
     {
         $script:threwException = $true
         Write-Error $_
-    }    
+    }
 }
 
 Describe 'Invoke-WhiskeyTask.when running an unknown task' {
@@ -865,7 +865,7 @@ Describe 'Invoke-WhiskeyTask.when WorkingDirectory property is defined and insta
     Init
     GivenRunByDeveloper
     GivenWorkingDirectory '.output' -SkipMock
-    Mock -CommandName 'Install-WhiskeyTool' -ModuleName 'Whiskey' -MockWith { 
+    Mock -CommandName 'Install-WhiskeyTool' -ModuleName 'Whiskey' -MockWith {
             #$DebugPreference = 'Continue'
             $currentPath = (Get-Location).ProviderPath
             $expectedPath = (Resolve-Path -Path 'TestDrive:\.output').ProviderPath
@@ -887,7 +887,7 @@ Describe 'Invoke-WhiskeyTask.when WorkingDirectory property is defined and clean
     GivenRunByDeveloper
     GivenWorkingDirectory '.output' -SkipMock
     Mock -CommandName 'Install-WhiskeyTool' -ModuleName 'Whiskey'
-    Mock -CommandName 'Uninstall-WhiskeyTool' -ModuleName 'Whiskey' -MockWith { 
+    Mock -CommandName 'Uninstall-WhiskeyTool' -ModuleName 'Whiskey' -MockWith {
             #$DebugPreference = 'Continue'
             $currentPath = (Get-Location).ProviderPath
             $expectedPath = (Resolve-Path -Path 'TestDrive:\.output').ProviderPath
@@ -909,7 +909,7 @@ Describe 'Invoke-WhiskeyTask.when WorkingDirectory property is invalid' {
     Mock -CommandName 'Invoke-WhiskeyPowerShell' -ModuleName 'Whiskey'
     WhenRunningTask 'PowerShell' -Parameter @{ 'WorkingDirectory' = 'Invalid/Directory' } -ErrorAction SilentlyContinue
     ThenThrewException 'Build.+WorkingDirectory.+does not exist.'
-    ThenTaskNotRun 'Invoke-WhiskeyPowerShell' 
+    ThenTaskNotRun 'Invoke-WhiskeyPowerShell'
 }
 
 Describe 'Invoke-WhiskeyTask.when run in clean mode' {
@@ -1007,7 +1007,7 @@ Describe 'Invoke-WhiskeyTask.when given OnlyDuring parameter' {
         {
             Context ('OnlyDuring is {0}' -f $runMode) {
                 $TaskParameter = @{ 'OnlyDuring' = $runMode }
-                WhenRunningTask 'MockTask' -Parameter $TaskParameter 
+                WhenRunningTask 'MockTask' -Parameter $TaskParameter
                 WhenRunningTask 'MockTask' -Parameter $TaskParameter -InRunMode 'Clean'
                 WhenRunningTask 'MockTask' -Parameter $TaskParameter -InRunMode 'Initialize'
                 ThenTaskRanWithParameter 'MockTask' @{ } -Times 1
@@ -1031,7 +1031,7 @@ Describe 'Invoke-WhiskeyTask.when given ExceptDuring parameter' {
         {
             Context ('ExceptDuring is {0}' -f $runMode) {
                 $TaskParameter = @{ 'ExceptDuring' = $runMode }
-                WhenRunningTask 'MockTask' -Parameter $TaskParameter 
+                WhenRunningTask 'MockTask' -Parameter $TaskParameter
                 WhenRunningTask 'MockTask' -Parameter $TaskParameter -InRunMode 'Clean'
                 WhenRunningTask 'MockTask' -Parameter $TaskParameter -InRunMode 'Initialize'
                 ThenTaskRanWithParameter 'MockTask' @{ } -Times 2
@@ -1275,7 +1275,7 @@ Describe 'Invoke-WhiskeyTask.when task requires tools and initializing' {
     $parameter = @{ }
     WhenRunningTask 'ToolTask' -Parameter $parameter -InRunMode 'Initialize'
     ThenToolInstalled 'Node'
-    ThenTaskNotRun 
+    ThenTaskNotRun
     ThenToolNotCleaned
     It ('should fail the build if installation fails') {
         Assert-MockCalled -CommandName 'Install-WhiskeyTool' -ModuleName 'Whiskey' -ParameterFilter { $ErrorActionPreference -eq 'Stop' }
@@ -1315,6 +1315,37 @@ Describe 'Invoke-WhiskeyTask.when task needs a required tool in order to clean' 
     finally
     {
         Remove-Node
+    }
+}
+
+Describe 'Invoke-WhiskeyTask.when a task runs another task' {
+    try
+    {
+        function Global::PowerShellWrapperTask
+        {
+            [Whiskey.Task("PowerShellWrapperTask")]
+            [CmdletBinding()]
+            param(
+                $TaskContext,
+                $TaskParameter
+            )
+
+            Invoke-WhiskeyTask -TaskContext $TaskContext -Parameter $TaskParameter -Name 'PowerShell'
+        }
+
+        Init
+        Mock -CommandName 'Invoke-WhiskeyPowerShell' -ModuleName 'Whiskey'
+        WhenRunningTask 'PowerShellWrapperTask' -Parameter @{ 'Path' = 'script.ps1' }
+        ThenTaskRanWithParameter 'Invoke-WhiskeyPowerShell' @{ 'Path' = 'script.ps1' }
+        ThenTempDirectoryCreated 'PowerShellWrapperTask'
+        ThenTempDirectoryCreated 'PowerShell'
+        ThenTempDirectoryRemoved 'PowerShellWrapperTask'
+        ThenTempDirectoryRemoved 'PowerShell'
+        ThenPipelineSucceeded
+    }
+    finally
+    {
+        Remove-Item -Path 'function:PowerShellWrapperTask' -ErrorAction Ignore
     }
 }
 

--- a/Whiskey/Functions/Invoke-WhiskeyTask.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyTask.ps1
@@ -4,7 +4,7 @@ function Invoke-WhiskeyTask
     <#
     .SYNOPSIS
     Runs a Whiskey task.
-    
+
     .DESCRIPTION
     The `Invoke-WhiskeyTask` function runs a Whiskey task.
     #>
@@ -19,10 +19,10 @@ function Invoke-WhiskeyTask
         [string]
         # The name of the task.
         $Name,
-        
+
         [Parameter(Mandatory=$true)]
         [hashtable]
-        # The parameters/configuration to use to run the task. 
+        # The parameters/configuration to use to run the task.
         $Parameter
     )
 
@@ -119,10 +119,10 @@ function Invoke-WhiskeyTask
             return
         }
 
-        $cmd.ScriptBlock.Attributes | 
+        $cmd.ScriptBlock.Attributes |
             Where-Object { $_ -is [Whiskey.RequiresToolAttribute] }
     }
-    
+
     $TaskContext.TaskName = $Name
 
     if( $TaskContext.TaskDefaults.ContainsKey( $Name ) )
@@ -137,13 +137,14 @@ function Invoke-WhiskeyTask
     {
         $taskProperties.Remove($commonPropertyName)
     }
-    
+
     $workingDirectory = $TaskContext.BuildRoot
     if( $Parameter['WorkingDirectory'] )
     {
         $workingDirectory = $Parameter['WorkingDirectory'] | Resolve-WhiskeyTaskPath -TaskContext $TaskContext -PropertyName 'WorkingDirectory'
     }
 
+    $taskTempDirectory = ''
     $requiredTools = Get-RequiredTool -CommandName $task.CommandName
     $startedAt = Get-Date
     $result = 'FAILED'
@@ -165,15 +166,15 @@ function Invoke-WhiskeyTask
                 return
             }
         }
-    
+
         $branch = $TaskContext.BuildMetadata.ScmBranch
         $executeTaskOnBranch = $true
-    
+
         if( $Parameter['OnlyOnBranch'] -and $Parameter['ExceptOnBranch'] )
         {
             Stop-WhiskeyTask -TaskContext $TaskContext -Message ('This task defines both OnlyOnBranch and ExceptOnBranch properties. Only one of these can be used. Please remove one or both of these properties and re-run your build.')
         }
-    
+
         if( $Parameter['OnlyOnBranch'] )
         {
             $runTask = $false
@@ -217,7 +218,7 @@ function Invoke-WhiskeyTask
                 return
             }
         }
-    
+
         $modes = @( 'Clean', 'Initialize', 'Build' )
         $onlyDuring = $Parameter['OnlyDuring']
         $exceptDuring = $Parameter['ExceptDuring']
@@ -259,7 +260,7 @@ function Invoke-WhiskeyTask
             }
             Write-WhiskeyVerbose -Context $TaskContext -Message     ('IfExists  {0}      exists' -f $Parameter['IfExists']) -Verbose
         }
-    
+
         if( $Parameter['UnlessExists'] )
         {
             $exists = Test-Path -Path $Parameter['UnlessExists']
@@ -271,7 +272,7 @@ function Invoke-WhiskeyTask
             }
             Write-WhiskeyVerbose -Context $TaskContext -Message     ('UnlessExists  {0}  not exists' -f $Parameter['UnlessExists']) -Verbose
         }
-    
+
         $inCleanMode = $TaskContext.ShouldClean
         if( $inCleanMode )
         {
@@ -304,7 +305,8 @@ function Invoke-WhiskeyTask
 
         Write-WhiskeyVerbose -Context $TaskContext -Message ''
         $startedAt = Get-Date
-        $TaskContext.Temp = Join-Path -Path $TaskContext.OutputDirectory -ChildPath ('Temp.{0}.{1}' -f $Name,[IO.Path]::GetRandomFileName())
+        $taskTempDirectory = Join-Path -Path $TaskContext.OutputDirectory -ChildPath ('Temp.{0}.{1}' -f $Name,[IO.Path]::GetRandomFileName())
+        $TaskContext.Temp = $taskTempDirectory
         if( -not (Test-Path -Path $TaskContext.Temp -PathType Container) )
         {
             New-Item -Path $TaskContext.Temp -ItemType 'Directory' -Force | Out-Null
@@ -323,9 +325,9 @@ function Invoke-WhiskeyTask
             }
         }
 
-        if( $TaskContext.Temp -and (Test-Path -Path $TaskContext.Temp -PathType Container) )
+        if( $taskTempDirectory -and (Test-Path -Path $taskTempDirectory -PathType Container) )
         {
-            Remove-Item -Path $TaskContext.Temp -Recurse -Force -ErrorAction Ignore
+            Remove-Item -Path $taskTempDirectory -Recurse -Force -ErrorAction Ignore
         }
         $endedAt = Get-Date
         $duration = $endedAt - $startedAt

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -162,7 +162,8 @@
 * All `DotNet` tasks now by default show `minimal` output to the console, instead of `detailed`, when run by a build server.
 * Created `DotNetPublish` task for running `dotnet publish` on .NET Core projects.
 * Fixed: `DotNetBuild` task no longer sets the `OutputDirectory` property relative to the whiskey.yml. The property is passed as-is to the `dotnet build` command and now allows absolute paths.
-* Added about help topics for every Whiskey task. Run `help about_Whiskey_Tasks` to see a list of tasks. Run `help TASK_NAME` to see help for a specific task. 
+* Added about help topics for every Whiskey task. Run `help about_Whiskey_Tasks` to see a list of tasks. Run `help TASK_NAME` to see help for a specific task.
+* Fixed: When a custom written task that wraps a Whiskey task runs, the parent wrapper task's temp diretory does not get cleaned up.
 '@
         } # End of PSData hashtable
 


### PR DESCRIPTION
- Fixed: When a custom written task that wraps a Whiskey task runs, the parent wrapper task's temp diretory does not get cleaned up.