### PR TITLE
Bugfix/msbuild version multiple installed

### DIFF
--- a/Test/Invoke-WhiskeyNodeNspCheck.Tests.ps1
+++ b/Test/Invoke-WhiskeyNodeNspCheck.Tests.ps1
@@ -48,7 +48,7 @@ function CreatePackageJson
     "devDependencies": {
         $($script:devDependency -join ',')
     }
-} 
+}
 "@ | Set-Content -Path $packageJsonPath -Force
 
     @"
@@ -59,7 +59,7 @@ function CreatePackageJson
     "requires": true,
     "dependencies": {
     }
-} 
+}
 "@ | Set-Content -Path ($packageJsonPath -replace '\bpackage\.json','package-lock.json') -Force
 }
 
@@ -80,20 +80,20 @@ function MockNsp
     }
 }
 
-function GivenDependency 
+function GivenDependency
 {
     param(
         [object[]]
-        $Dependency 
+        $Dependency
     )
     $script:dependency = $Dependency
 }
 
-function GivenDevDependency 
+function GivenDevDependency
 {
     param(
         [object[]]
-        $DevDependency 
+        $DevDependency
     )
     $script:devDependency = $DevDependency
 }
@@ -116,7 +116,7 @@ function WhenRunningTask
     $Global:Error.Clear()
 
     $taskContext = New-WhiskeyTestContext -ForBuildServer -ForBuildRoot $TestDrive.FullName
-    
+
     $taskParameter = @{ }
 
     if ($version)
@@ -151,7 +151,7 @@ function ThenNspInstalled
     if( $WithVersion )
     {
         It ('should install NSP version ''{0}''' -f $WithVersion) {
-            Get-Content -Path (Join-Path -Path $nspRoot -ChildPath 'package.json') -Raw | 
+            Get-Content -Path (Join-Path -Path $nspRoot -ChildPath 'package.json') -Raw |
                 ConvertFrom-Json |
                 Select-Object -ExpandProperty 'Version' |
                 Should -Be $WithVersion
@@ -212,12 +212,17 @@ function ThenTaskSucceeded
 {
     for( $i = $Global:Error.Count - 1; $i -ge 0; $i-- )
     {
-        if( $Global:Error[$i] -match 'npm notice created a lockfile as package-lock.json. You should commit this file.' )
+        $errorMessage = $Global:Error[$i]
+        if( $errorMessage -match 'npm notice created a lockfile as package-lock.json. You should commit this file.' )
+        {
+            $Global:Error.RemoveAt($i)
+        }
+        elseif( $errorMessage -match ([regex]::Escape('The Node Security Platform service is shutting down 9/30')) )
         {
             $Global:Error.RemoveAt($i)
         }
     }
-    
+
     It 'should not write any errors' {
         $Global:Error | Should -BeNullOrEmpty
     }

--- a/Whiskey/Tasks/Invoke-WhiskeyMSBuild.ps1
+++ b/Whiskey/Tasks/Invoke-WhiskeyMSBuild.ps1
@@ -6,39 +6,39 @@ function Invoke-WhiskeyMSBuild
         [Whiskey.Context]
         # The context this task is operating in. Use `New-WhiskeyContext` to create context objects.
         $TaskContext,
-        
+
         [hashtable]
         # The parameters/configuration to use to run the task. Should be a hashtable that contains the following item(s):
-        # 
+        #
         # * `Path` (Mandatory): the relative paths to the files/directories to include in the build. Paths should be relative to the whiskey.yml file they were taken from.
         $TaskParameter
     )
 
-    Set-StrictMode -version 'Latest'  
+    Set-StrictMode -version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
     #setup
     $nuGetPath = Install-WhiskeyNuGet -DownloadRoot $TaskContext.BuildRoot -Version $TaskParameter['NuGetVersion']
-    
+
     # Make sure the Taskpath contains a Path parameter.
     if( -not ($TaskParameter.ContainsKey('Path')) -or -not $TaskParameter['Path'] )
     {
-        Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Element ''Path'' is mandatory. It should be one or more paths, relative to your whiskey.yml file, to build with MSBuild.exe, e.g. 
-        
+        Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Element ''Path'' is mandatory. It should be one or more paths, relative to your whiskey.yml file, to build with MSBuild.exe, e.g.
+
         Build:
         - MSBuild:
             Path:
             - MySolution.sln
             - MyCsproj.csproj')
     }
-    
+
     $path = $TaskParameter['Path'] | Resolve-WhiskeyTaskPath -TaskContext $TaskContext -PropertyName 'Path'
 
     $msbuildInfos = Get-MSBuild | Sort-Object -Descending 'Version'
     $version = $TaskParameter['Version']
     if( $version )
     {
-        $msbuildInfo = $msbuildInfos | Where-Object { $_.Name -eq $version }
+        $msbuildInfo = $msbuildInfos | Where-Object { $_.Name -eq $version } | Select-Object -First 1
     }
     else
     {
@@ -61,7 +61,7 @@ function Invoke-WhiskeyMSBuild
         }
     }
     Write-WhiskeyVerbose -Context $TaskContext -Message ('{0}' -f $msbuildExePath)
-    
+
     $target = @( 'build' )
     if( $TaskContext.ShouldClean )
     {
@@ -99,9 +99,9 @@ function Invoke-WhiskeyMSBuild
 
         if( $TaskContext.ByBuildServer )
         {
-            $projectPath | 
-                Split-Path | 
-                Get-ChildItem -Filter 'AssemblyInfo.cs' -Recurse | 
+            $projectPath |
+                Split-Path |
+                Get-ChildItem -Filter 'AssemblyInfo.cs' -Recurse |
                 ForEach-Object {
                     $assemblyInfo = $_
                     $assemblyInfoPath = $assemblyInfo.FullName
@@ -169,7 +169,7 @@ function Invoke-WhiskeyMSBuild
         Write-WhiskeyVerbose -Context $TaskContext -Message ('  Property    {0}' -f ($property -join $separator))
         Write-WhiskeyVerbose -Context $TaskContext -Message ('  Argument    {0}' -f ($msbuildArgs -join $separator))
 
-        $propertyArgs = $property | ForEach-Object { 
+        $propertyArgs = $property | ForEach-Object {
             $item = $_
             $name,$value = $item -split '=',2
             $value = $value.Trim('"')

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -151,6 +151,7 @@
             ReleaseNotes = @'
 * Created `Get-WhiskeyMSBuildConfiguration` and `Set-WhiskeyMSBuildConfiguration` functions to allow for customizing the configuration to use when running MSBuild tasks/tools.
 * `PublishProGetUniversalPackage` task can now exclude items from being published. Set the `Exclude` property to a list of path wildcards. Any path from the `Path` property that match any wildcards will not be published.
+* Fixed: `MSBuild` task fails when given `Version` property and multiple installs of that version of MSBuild exist on the system.
 '@
         } # End of PSData hashtable
 

--- a/build.ps1
+++ b/build.ps1
@@ -42,7 +42,7 @@ $assemblyVersion = @"
 [assembly: System.Reflection.AssemblyVersion("$version")]
 [assembly: System.Reflection.AssemblyFileVersion("$version")]
 [assembly: System.Reflection.AssemblyInformationalVersion("$version$buildInfo")]
-"@ 
+"@
 
 $assemblyVersionPath = Join-Path -Path $PSScriptRoot -ChildPath 'Assembly\Whiskey\Properties\AssemblyVersion.cs'
 if( -not (Test-Path -Path $assemblyVersionPath -PathType Leaf) )
@@ -61,7 +61,7 @@ Import-Module (Join-Path -Path $PSScriptRoot -ChildPath 'Whiskey\VSSetup')
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Whiskey\Functions\Use-CallerPreference.ps1')
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Whiskey\Functions\Get-MSBuild.ps1')
 
-$msbuild = Get-MSBuild -ErrorAction Ignore | Where-Object { $_.Name -eq '15.0' }
+$msbuild = Get-MSBuild -ErrorAction Ignore | Where-Object { $_.Name -eq '15.0' } | Select-Object -First 1
 if( -not $msbuild )
 {
     Write-Error ('Unable to find MSBuild 15.0.')
@@ -100,10 +100,10 @@ $ErrorActionPreference = 'Continue'
 
 $configPath = Join-Path -Path $PSScriptRoot -ChildPath 'whiskey.yml' -Resolve
 
-Get-ChildItem 'env:' | 
+Get-ChildItem 'env:' |
     Where-Object { $_.Name -notin @( 'POWERSHELL_GALLERY_API_KEY', 'GITHUB_ACCESS_TOKEN' ) } |
     Format-Table |
-    Out-String | 
+    Out-String |
     Write-Verbose
 
 $optionalArgs = @{ }
@@ -130,10 +130,10 @@ $apiKeys = @{
 
 $apiKeys.Keys |
     Where-Object { Test-Path -Path ('env:{0}' -f $apiKeys[$_]) } |
-    ForEach-Object { 
+    ForEach-Object {
         $apiKeyID = $_
         $envVarName = $apiKeys[$apiKeyID]
         Write-Verbose ('Adding API key "{0}" with value from environment variable "{1}".' -f $apiKeyID,$envVarName)
-        Add-WhiskeyApiKey -Context $context -ID $apiKeyID -Value (Get-Item -Path ('env:{0}' -f $envVarName)).Value 
+        Add-WhiskeyApiKey -Context $context -ID $apiKeyID -Value (Get-Item -Path ('env:{0}' -f $envVarName)).Value
     }
 Invoke-WhiskeyBuild -Context $context @optionalArgs


### PR DESCRIPTION
Fixed: `MSBuild` task fails when given `Version` property and multiple installs of that version of MSBuild exist on the system.