### PR TITLE
Bugfix/powershell module download validation

### DIFF
--- a/Test/Install-WhiskeyPowerShellModule.Tests.ps1
+++ b/Test/Install-WhiskeyPowerShellModule.Tests.ps1
@@ -126,4 +126,19 @@ Describe 'Install-WhiskeyPowerShellModule.when PowerShell module is already inst
     }
 }
 
+Describe 'Install-WhiskeyPowerShellModule.when PowerShell module directory exists but is empty' {
+    $moduleRootDir = Join-Path -Path $TestDrive.FullName -ChildPath ('{0}\Pester' -f $powerShellModulesDirectoryName)
+    New-Item -Path $moduleRootDir -ItemType Directory | Write-Debug
+
+    Invoke-PowershellInstall -ForModule 'Pester' -Version '4.4.0'
+}
+
+Describe 'Install-WhiskeyPowerShellModule.when PowerShell module is missing files' {
+    Install-WhiskeyPowerShellModule -Path $TestDrive.FullName -Name 'Pester' -Version '4.4.0'
+    $moduleManifest = Join-Path -Path $TestDrive.FullName -ChildPath ('{0}\Pester\4.4.0\Pester.psd1' -f $powerShellModulesDirectoryName) -Resolve
+    Remove-Item -Path $moduleManifest -Force
+
+    Invoke-PowershellInstall -ForModule 'Pester' -Version '4.4.0'
+}
+
 Remove-Item -Path 'function:Install-WhiskeyPowerShellModule'

--- a/Whiskey/Functions/Install-WhiskeyPowerShellModule.ps1
+++ b/Whiskey/Functions/Install-WhiskeyPowerShellModule.ps1
@@ -55,7 +55,7 @@ function Install-WhiskeyPowerShellModule
 
     $expectedPath = Join-Path -Path $modulesRoot -ChildPath $Name
 
-    if( (Test-Path -Path $expectedPath -PathType Container) )
+    if( (Test-Path -Path $expectedPath -PathType Container) -and (Get-ChildItem -Path $expectedPath -File -Filter ('{0}.psd1' -f $Name) -Recurse))
     {
         Resolve-Path -Path $expectedPath | Select-Object -ExpandProperty 'ProviderPath'
         return

--- a/Whiskey/Functions/Uninstall-WhiskeyPowerShellModule.ps1
+++ b/Whiskey/Functions/Uninstall-WhiskeyPowerShellModule.ps1
@@ -4,7 +4,7 @@ function Uninstall-WhiskeyPowerShellModule
     <#
     .SYNOPSIS
     Removes downloaded PowerShell modules.
-    
+
     .DESCRIPTION
     The `Uninstall-WhiskeyPowerShellModule` function deletes downloaded PowerShell modules from Whiskey's local "PSModules" directory.
 
@@ -12,13 +12,12 @@ function Uninstall-WhiskeyPowerShellModule
     Uninstall-WhiskeyPowerShellModule -Name 'Pester'
 
     This example will uninstall the PowerShell module `Pester` from Whiskey's local `PSModules` directory.
-    
+
     .EXAMPLE
     Uninstall-WhiskeyPowerShellModule -Name 'Pester' -ErrorAction Stop
 
     Demonstrates how to fail a build if uninstalling the module fails by setting the `ErrorAction` parameter to `Stop`.
     #>
-    
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
@@ -47,7 +46,13 @@ function Uninstall-WhiskeyPowerShellModule
         if( Test-Path -Path $removeModule -PathType Container )
         {
             Remove-Item -Path $removeModule -Recurse -Force
-            return
+            break
         }
+    }
+
+    $psmodulesDirEmpty = $null -eq (Get-ChildItem -Path $modulesRoot -File -Recurse)
+    if( $psmodulesDirEmpty )
+    {
+        Remove-Item -Path $modulesRoot -Recurse -Force
     }
 }

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Whiskey.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.38.4'
+    ModuleVersion = '0.38.5'
 
     # ID used to uniquely identify this module
     GUID = '93bd40f1-dee5-45f7-ba98-cb38b7f5b897'

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -145,6 +145,7 @@
             # ReleaseNotes of this module
             ReleaseNotes = @'
 * Fixed: `GetPowerShellModule` task assumes that a module is already installed if an empty directory for that module exists in the `PSModules` directory.
+* Fixed: `PSModules` directory isn't removed removed during `Clean` mode after all contained modules have been deleted.
 '@
         } # End of PSData hashtable
 

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -144,8 +144,7 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-* Updating to YAML.NET 5.2.1 (from 4.2.2) because of security vulnerabilities in the old version.
-* Switched to .NET Core version of YAML.NET. Whiskey now requires .NET Framework 4.6.
+* Fixed: `GetPowerShellModule` task assumes that a module is already installed if an empty directory for that module exists in the `PSModules` directory.
 '@
         } # End of PSData hashtable
 


### PR DESCRIPTION
* Fixed: `GetPowerShellModule` task assumes that a module is already installed if an empty directory for that module exists in the `PSModules` directory.
* Fixed: `PSModules` directory isn't removed removed during `Clean` mode after all contained modules have been deleted.