### PR TITLE
Bugfix/proget package task fail

### DIFF
--- a/Test/ProGetUniversalPackage.Tests.ps1
+++ b/Test/ProGetUniversalPackage.Tests.ps1
@@ -231,7 +231,7 @@ function Assert-NewWhiskeyProGetUniversalPackage
     $byWhoArg = @{ $PSCmdlet.ParameterSetName = $true }
 
     $script:context = $taskContext = New-WhiskeyTestContext -ForBuildRoot 'Repo' -ForBuildServer
-    
+
     Install-ProGetAutomation -BuildRoot $context.BuildRoot
 
     $semVer2 = [SemVersion.SemanticVersion]$Version
@@ -557,35 +557,35 @@ function WhenPackaging
 
         [Parameter(ParameterSetName='WithTaskParameter')]
         $WithDescription = $defaultDescription,
-        
+
         [Parameter(ParameterSetName='WithTaskParameter')]
         [object[]]
         $Paths,
-        
+
         [Parameter(ParameterSetName='WithTaskParameter')]
         [object[]]
         $WithWhitelist,
-        
+
         [Parameter(ParameterSetName='WithTaskParameter')]
         [object[]]
         $ThatExcludes,
-        
+
         [Parameter(ParameterSetName='WithTaskParameter')]
         $FromSourceRoot,
-        
+
         [Parameter(ParameterSetName='WithTaskParameter')]
         [object[]]
         $WithThirdPartyPath,
-        
+
         [Parameter(ParameterSetName='WithTaskParameter')]
         $WithVersion = $defaultVersion,
-        
+
         [Parameter(ParameterSetName='WithTaskParameter')]
         $WithApplicationName,
-        
+
         [Parameter(ParameterSetName='WithTaskParameter')]
         $CompressionLevel,
-        
+
         [Parameter(ParameterSetName='WithTaskParameter')]
         [Switch]
         $SkipExpand,
@@ -1030,7 +1030,7 @@ Describe 'ProGetUniversalPackage.when custom application root doesn''t exist' {
     $fileNames = @( 'html.html', 'thirdparty.txt' )
     $outputFilePath = Initialize-Test -DirectoryName $dirNames -FileName $fileNames
     $context = New-WhiskeyTestContext -ForDeveloper
-    
+
     Install-ProGetAutomation -BuildRoot $context.BuildRoot
     $Global:Error.Clear()
 
@@ -1328,4 +1328,13 @@ Describe 'ProGetUniversalPackage.when missing required properties' {
     }
     WhenPackaging -WithPackageName 'AwesomePackageName' -WithDescription $null -Path 'my.file' -ErrorAction SilentlyContinue
     ThenTaskFails 'Property "Description" is mandatory'
+}
+
+Describe 'ProGetUniversalPackage.when ProGetAutomation function writes an error when packaging a file' {
+    Init
+    Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\PSModules\ProGetAutomation')
+    Mock -CommandName 'Add-ProGetUniversalPackageFile' -ModuleName 'Whiskey' -MockWith { Write-Error -Message 'Failed to add file to package' }
+    GivenARepositoryWithItems 'my.file'
+    WhenPackaging -Paths 'my.file' -ErrorAction SilentlyContinue
+    ThenTaskFails 'Failed\ to\ add\ file\ to\ package'
 }

--- a/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
+++ b/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
@@ -186,14 +186,14 @@ function New-WhiskeyProGetUniversalPackage
                 {
                     Write-WhiskeyInfo -Context $TaskContext -Message ('  packaging unfiltered item    {0}{1}' -f $relativePath,$overrideInfo)
                     Get-Item -Path $sourcePath |
-                        Add-ProGetUniversalPackageFile -PackagePath $outFile @addParams
+                        Add-ProGetUniversalPackageFile -PackagePath $outFile @addParams -ErrorAction Stop
                     continue
                 }
 
                 if( (Test-Path -Path $sourcePath -PathType Leaf) )
                 {
                     Write-WhiskeyInfo -Context $TaskContext -Message ('  packaging file               {0}{1}' -f $relativePath,$overrideInfo)
-                    Add-ProGetUniversalPackageFile -PackagePath $outFile -InputObject $sourcePath @addParams
+                    Add-ProGetUniversalPackageFile -PackagePath $outFile -InputObject $sourcePath @addParams -ErrorAction Stop
                     continue
                 }
 
@@ -243,7 +243,7 @@ function New-WhiskeyProGetUniversalPackage
 
                 Write-WhiskeyInfo -Context $TaskContext -Message ('  packaging filtered directory {0}{1}' -f $relativePath,$overrideInfo)
                 Find-Item -Path $sourcePath |
-                    Add-ProGetUniversalPackageFile -PackagePath $outFile @addParams
+                    Add-ProGetUniversalPackageFile -PackagePath $outFile @addParams -ErrorAction Stop
             }
         }
     }
@@ -273,7 +273,7 @@ function New-WhiskeyProGetUniversalPackage
                                -Description $TaskParameter['Description'] `
                                -AdditionalMetadata $manifestProperties
 
-    Add-ProGetUniversalPackageFile -PackagePath $outFile -InputObject $versionJsonPath
+    Add-ProGetUniversalPackageFile -PackagePath $outFile -InputObject $versionJsonPath -ErrorAction Stop
 
     if( $TaskParameter['Path'] )
     {

--- a/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
+++ b/Whiskey/Tasks/New-WhiskeyProGetUniversalPackage.ps1
@@ -3,7 +3,7 @@ function New-WhiskeyProGetUniversalPackage
 {
     [CmdletBinding()]
     [Whiskey.Task("ProGetUniversalPackage")]
-    [Whiskey.RequiresTool('PowerShellModule::ProGetAutomation','ProGetAutomationPath',Version='0.8.*',VersionParameterName='ProGetAutomationVersion')]
+    [Whiskey.RequiresTool('PowerShellModule::ProGetAutomation','ProGetAutomationPath',Version='0.9.*',VersionParameterName='ProGetAutomationVersion')]
     param(
         [Parameter(Mandatory=$true)]
         [Whiskey.Context]

--- a/Whiskey/Tasks/Publish-WhiskeyProGetAsset.ps1
+++ b/Whiskey/Tasks/Publish-WhiskeyProGetAsset.ps1
@@ -3,7 +3,7 @@
 function Publish-WhiskeyProGetAsset
 {
     [Whiskey.Task("PublishProGetAsset")]
-    [Whiskey.RequiresTool('PowerShellModule::ProGetAutomation','ProGetAutomationPath',Version='0.8.*',VersionParameterName='ProGetAutomationVersion')]
+    [Whiskey.RequiresTool('PowerShellModule::ProGetAutomation','ProGetAutomationPath',Version='0.9.*',VersionParameterName='ProGetAutomationVersion')]
     [CmdletBinding()]
     param(
         [Whiskey.Context]

--- a/Whiskey/Tasks/Publish-WhiskeyProGetUniversalPackage.ps1
+++ b/Whiskey/Tasks/Publish-WhiskeyProGetUniversalPackage.ps1
@@ -3,7 +3,7 @@ function Publish-WhiskeyProGetUniversalPackage
 {
     [CmdletBinding()]
     [Whiskey.Task("PublishProGetUniversalPackage")]
-    [Whiskey.RequiresTool('PowerShellModule::ProGetAutomation','ProGetAutomationPath',Version='0.8.*',VersionParameterName='ProGetAutomationVersion')]
+    [Whiskey.RequiresTool('PowerShellModule::ProGetAutomation','ProGetAutomationPath',Version='0.9.*',VersionParameterName='ProGetAutomationVersion')]
     param(
         [Parameter(Mandatory=$true)]
         [Whiskey.Context]
@@ -29,17 +29,17 @@ function Publish-WhiskeyProGetUniversalPackage
     if( -not $TaskParameter['CredentialID'] )
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message "CredentialID is a mandatory property. It should be the ID of the credential to use when connecting to ProGet:
-        
+
         $exampleTask
-        
+
         Use the `Add-WhiskeyCredential` function to add credentials to the build."
         return
     }
-    
+
     if( -not $TaskParameter['Uri'] )
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message "Uri is a mandatory property. It should be the URI to the ProGet instance where you want to publish your package:
-        
+
         $exampleTask
         "
         return
@@ -48,12 +48,12 @@ function Publish-WhiskeyProGetUniversalPackage
     if( -not $TaskParameter['FeedName'] )
     {
         Stop-WhiskeyTask -TaskContext $TaskContext -Message "FeedName is a mandatory property. It should be the name of the universal feed in ProGet where you want to publish your package:
-        
+
         $exampleTask
         "
         return
     }
-    
+
     $credential = Get-WhiskeyCredential -Context $TaskContext -ID $TaskParameter['CredentialID'] -PropertyName 'CredentialID'
 
     $session = New-ProGetSession -Uri $TaskParameter['Uri'] -Credential $credential
@@ -62,7 +62,7 @@ function Publish-WhiskeyProGetUniversalPackage
     {
         $TaskParameter['Path'] = Join-Path -Path ($TaskContext.OutputDirectory | Split-Path -Leaf) -ChildPath '*.upack'
     }
-    
+
     $errorActionParam = @{ }
     $allowMissingPackages = $false
     if( $TaskParameter.ContainsKey('AllowMissingPackage') )
@@ -74,7 +74,7 @@ function Publish-WhiskeyProGetUniversalPackage
     {
         $errorActionParam['ErrorAction'] = 'Ignore'
     }
-    $packages = $TaskParameter['Path'] | 
+    $packages = $TaskParameter['Path'] |
                     Resolve-WhiskeyTaskPath -TaskContext $TaskContext -PropertyName 'Path' @errorActionParam |
                     Where-Object {
                         if( -not $TaskParameter.ContainsKey('Exclude') )

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -152,6 +152,7 @@
 * Added `WHISKEY_TEMP_DIRECTORY` built-in variable to get the path to the global/system temporary directory. This uses the value returned by the .NET [Path.GetTempPath()] method.
 * Added `WHISKEY_TASK_TEMP_DIRECTORY` built-in variable to get the path to the currently executing task's temporary directory, which Whiskey creates/deletes as each task runs.
 * Fixed: `ProGetUniversalPackage` task doesn''t fail the build if there were errors when adding files to the package.
+* Updated all tasks that use the ProGetAutomation module to default to using version 0.9.* (from 0.8.*).
 '@
         } # End of PSData hashtable
 

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -151,6 +151,7 @@
 * You can now use the [Environment class's static properties](https://docs.microsoft.com/en-us/dotnet/api/system.environment#properties) as Whiskey variables. Using these variables are now recommended over environment variables, since the existence of some environment variables varies between operating systems.
 * Added `WHISKEY_TEMP_DIRECTORY` built-in variable to get the path to the global/system temporary directory. This uses the value returned by the .NET [Path.GetTempPath()] method.
 * Added `WHISKEY_TASK_TEMP_DIRECTORY` built-in variable to get the path to the currently executing task's temporary directory, which Whiskey creates/deletes as each task runs.
+* Fixed: `ProGetUniversalPackage` task doesn''t fail the build if there were errors when adding files to the package.
 '@
         } # End of PSData hashtable
 

--- a/whiskey.yml
+++ b/whiskey.yml
@@ -15,7 +15,7 @@ Build:
 
 - GetPowerShellModule:
     Name: ProGetAutomation
-    Version: 0.8.*
+    Version: 0.9.*
 
 - GetPowerShellModule:
     Name: BitbucketServerAutomation
@@ -105,7 +105,7 @@ Build:
 
 - Zip:
     ArchivePath: .output\Whiskey.zip
-    Path: 
+    Path:
     - Whiskey
     Exclude:
     - "*.pdb"


### PR DESCRIPTION
* Fixed: `ProGetUniversalPackage` task doesn''t fail the build if there were errors when adding files to the package.
* Updated all tasks that use the ProGetAutomation module to default to using version 0.9.* (from 0.8.*).