### PR TITLE
Bugfix/version prerelease branch matching

### DIFF
--- a/Whiskey/Tasks/Set-WhiskeyVersion.ps1
+++ b/Whiskey/Tasks/Set-WhiskeyVersion.ps1
@@ -191,6 +191,16 @@ If you want certain branches to always have certain prerelease versions, set Pre
                         Write-WhiskeyVerbose -Context $TaskContext -Message ('{0}  -notlike  {1}' -f $TaskContext.BuildMetadata.ScmBranch,$wildcardPattern)
                     }
                 }
+
+                if( $foundLabel )
+                {
+                    break
+                }
+            }
+
+            if( $foundLabel )
+            {
+                break
             }
         }
 

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Whiskey.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.41.0'
+    ModuleVersion = '0.41.1'
 
     # ID used to uniquely identify this module
     GUID = '93bd40f1-dee5-45f7-ba98-cb38b7f5b897'
@@ -153,18 +153,7 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-* Adding Linux and MacOS support. Whiskey is now cross-platform!
-* Upgrading to PowerShellGet version 2.0.4.
-* Upgrading to PackageManagement version 1.3.0.
-* Updating BuildMaster tasks to use BuildMasterAutomation PowerShell module version 0.6.0 (from 0.5.0).
-* Updating Bitbucket Server tasks to use BitbucketServerAutomation PowerShell module version 0.9.0 (from 0.8.0).
-* Updating Ziptask to use Zip PowerShell module version 0.3.0 (from 0.2.0).
-* Fixed: PowerShell module import verbose messages appear when running the `Parallel` task.
-* Fixed: `ProGetUniversalPackage` places files in a `.` directory when using the `source_dir: .` syntax to specify the package root as the destination path for items in a package.
-* Fixed: Publishing a PowerShell module fails if old versions of PackageManagement and PowerShellGet are installed in a directory given by `PSModulePath`. See https://github.com/PowerShell/PowerShellGet/issues/446 .
-* The `PublishPowerShellModule` task now adds the current build's prerelease to the module manifest before publishing.
-* The `PublishPowerShellModule` task's `RepositoryUri` property is now only required if the task needs to register a new/custom repository (i.e. the repository given by the task's `RepositoryName` parameter doesn't exist).
-* The `PublishPowerShellModule` task can now register a repository that requires a credential. Use the `CredentialID` property to set the ID of the credential in your whiskey.yml file and `Add-WhiskeyCredential` in your build script to add the credential.
+* Fixed: `Version` task uses the last matching item in the prerelease label branch map instead of the first match.
 '@
         } # End of PSData hashtable
 


### PR DESCRIPTION
Fixes bug where the `Version` task's `Prerelease` branch mapping would use the last matching item in the list instead of the first match for the prerelease label.