### PR TITLE
Feature/node module publishing dist tags

### DIFF
--- a/Test/PublishNodeModule.Tests.ps1
+++ b/Test/PublishNodeModule.Tests.ps1
@@ -7,6 +7,7 @@ $credential = $null
 $context = $null
 $packageJsonPath = $null
 $prerelease = $null
+$testRoot = $null
 $threwException = $false
 
 function Init
@@ -15,14 +16,15 @@ function Init
     $script:context = $null
     $script:packageJsonPath = $null
     $script:prerelease = $null
+    $script:testRoot = New-WhiskeyTestRoot
     $script:threwException = $false
 
-    Install-Node
+    Install-Node -BuildRoot $testRoot
 }
 
 function Reset
 {
-    Remove-Node
+    Remove-Node -BuildRoot $testRoot
 }
 
 function GivenPackageJson
@@ -31,7 +33,7 @@ function GivenPackageJson
         $Content
     )
 
-    $script:packageJsonPath = Join-Path -Path $TestDrive.Fullname -ChildPath 'package.json'
+    $script:packageJsonPath = Join-Path -Path $testRoot -ChildPath 'package.json'
     New-Item -Path $packageJsonPath -ItemType File -Value $Content -Force | Out-Null
 }
 
@@ -221,7 +223,7 @@ function WhenPublishingNodeModule
         $version = '{0}-{1}' -f $version, $prerelease
     }
 
-    $script:context = New-WhiskeyTestContext -ForBuildServer -ForBuildRoot $TestDrive.FullName -ForVersion $version
+    $script:context = New-WhiskeyTestContext -ForBuildServer -ForBuildRoot $testRoot -ForVersion $version
 
     $parameter = @{ }
     if( $WithCredentialID )

--- a/Test/Resolve-WhiskeyVariable.Tests.ps1
+++ b/Test/Resolve-WhiskeyVariable.Tests.ps1
@@ -381,6 +381,15 @@ Describe 'Resolve-WhiskeyVariable.WHISKEY_SEMVER2_PRERELEASE' {
     }
 }
 
+Describe 'Resolve-WhiskeyVariable.WHISKEY_SEMVER2_PRERELEASE_ID' {
+    It 'should resolve' {
+        Init
+        $context.Version.SemVer2 = [SemVersion.SemanticVersion]'1.2.3-fubar.5+snafu.6'
+        WhenResolving '$(WHISKEY_SEMVER2_PRERELEASE_ID)'
+        ThenValueIs 'fubar'
+    }
+}
+
 Describe 'Resolve-WhiskeyVariable.WHISKEY_SEMVER2_BUILD' {
     It 'should resolve' {
         Init

--- a/Test/Resolve-WhiskeyVariable.Tests.ps1
+++ b/Test/Resolve-WhiskeyVariable.Tests.ps1
@@ -403,6 +403,15 @@ Describe 'Resolve-WhiskeyVariable.WHISKEY_SEMVER2_PRERELEASE_ID' {
     }
 }
 
+Describe 'Resolve-WhiskeyVariable.WHISKEY_SEMVER2_PRERELEASE_ID when version doesn''t contain a prerelease label' {
+    It 'should resolve' {
+        Init
+        $context.Version.SemVer2 = [SemVersion.SemanticVersion]'1.2.3'
+        WhenResolving '$(WHISKEY_SEMVER2_PRERELEASE_ID)'
+        ThenValueIs ''
+    }
+}
+
 Describe 'Resolve-WhiskeyVariable.WHISKEY_SEMVER2_BUILD' {
     It 'should resolve' {
         Init

--- a/Whiskey/Functions/Resolve-WhiskeyVariable.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyVariable.ps1
@@ -10,7 +10,7 @@ function Resolve-WhiskeyVariable
     
     You can add variables to replace via the `Add-WhiskeyVariable` function. If a variable doesn't exist, environment variables are used. If a variable has the same name as an environment variable, the variable value is used instead of the environment variable's value. If no variable or environment variable is found, `Resolve-WhiskeyVariable` will write an error and return the origin string.
 
-    See the `about_Whiskey_Variables` help topic for a list of variables.
+    See the [Variables](https://github.com/webmd-health-services/Whiskey/wiki/Variables) page on the [Whiskey wiki](https://github.com/webmd-health-services/Whiskey/wiki) for a list of variables.
 
     .EXAMPLE
     '$(COMPUTERNAME)' | Resolve-WhiskeyVariable
@@ -70,7 +70,13 @@ function Resolve-WhiskeyVariable
         Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
         $version = $Context.Version
-        $buildInfo = $Context.BuildMetadata;
+        $prereleaseID = ''
+        if( $version.SemVer2.Prerelease -match '^(.*)\..*$' )
+        {
+            $prereleaseID = $Matches[1]
+        }
+        $buildInfo = $Context.BuildMetadata
+
         $sem1Version = ''
         if( $version.SemVer1 )
         {
@@ -84,30 +90,31 @@ function Resolve-WhiskeyVariable
         }
 
         $wellKnownVariables = @{
-                                    'WHISKEY_BUILD_ID' = $buildInfo.BuildID;
-                                    'WHISKEY_BUILD_NUMBER' = $buildInfo.BuildNumber;
-                                    'WHISKEY_BUILD_ROOT' = $Context.BuildRoot;
-                                    'WHISKEY_BUILD_SERVER_NAME' = $buildInfo.BuildServer;
-                                    'WHISKEY_BUILD_STARTED_AT' = $Context.StartedAt;
-                                    'WHISKEY_BUILD_URI' = $buildInfo.BuildUri;
-                                    'WHISKEY_ENVIRONMENT' = $Context.Environment;
-                                    'WHISKEY_JOB_URI' = $buildInfo.JobUri;
-                                    'WHISKEY_MSBUILD_CONFIGURATION' = (Get-WhiskeyMSBuildConfiguration -Context $Context);
-                                    'WHISKEY_OUTPUT_DIRECTORY' = $Context.OutputDirectory;
-                                    'WHISKEY_PIPELINE_NAME' = $Context.PipelineName;
-                                    'WHISKEY_SCM_BRANCH' = $buildInfo.ScmBranch;
-                                    'WHISKEY_SCM_COMMIT_ID' = $buildInfo.ScmCommitID;
-                                    'WHISKEY_SCM_URI' = $buildInfo.ScmUri;
-                                    'WHISKEY_SEMVER1' = $version.SemVer1;
-                                    'WHISKEY_SEMVER1_VERSION' = $sem1Version;
-                                    'WHISKEY_SEMVER2' = $version.SemVer2;
-                                    'WHISKEY_SEMVER2_NO_BUILD_METADATA' = $version.SemVer2NoBuildMetadata;
-                                    'WHISKEY_SEMVER2_VERSION' = $sem2Version;
-                                    'WHISKEY_TASK_NAME' = $Context.TaskName;
-                                    'WHISKEY_TEMP_DIRECTORY' = (Get-Item -Path ([IO.Path]::GetTempPath()));
-                                    'WHISKEY_TASK_TEMP_DIRECTORY' = $Context.Temp;
-                                    'WHISKEY_VERSION' = $version.Version;
-                                }
+            'WHISKEY_BUILD_ID' = $buildInfo.BuildID;
+            'WHISKEY_BUILD_NUMBER' = $buildInfo.BuildNumber;
+            'WHISKEY_BUILD_ROOT' = $Context.BuildRoot;
+            'WHISKEY_BUILD_SERVER_NAME' = $buildInfo.BuildServer;
+            'WHISKEY_BUILD_STARTED_AT' = $Context.StartedAt;
+            'WHISKEY_BUILD_URI' = $buildInfo.BuildUri;
+            'WHISKEY_ENVIRONMENT' = $Context.Environment;
+            'WHISKEY_JOB_URI' = $buildInfo.JobUri;
+            'WHISKEY_MSBUILD_CONFIGURATION' = (Get-WhiskeyMSBuildConfiguration -Context $Context);
+            'WHISKEY_OUTPUT_DIRECTORY' = $Context.OutputDirectory;
+            'WHISKEY_PIPELINE_NAME' = $Context.PipelineName;
+            'WHISKEY_SCM_BRANCH' = $buildInfo.ScmBranch;
+            'WHISKEY_SCM_COMMIT_ID' = $buildInfo.ScmCommitID;
+            'WHISKEY_SCM_URI' = $buildInfo.ScmUri;
+            'WHISKEY_SEMVER1' = $version.SemVer1;
+            'WHISKEY_SEMVER1_VERSION' = $sem1Version;
+            'WHISKEY_SEMVER2' = $version.SemVer2;
+            'WHISKEY_SEMVER2_NO_BUILD_METADATA' = $version.SemVer2NoBuildMetadata;
+            'WHISKEY_SEMVER2_PRERELEASE_ID' = $prereleaseID
+            'WHISKEY_SEMVER2_VERSION' = $sem2Version;
+            'WHISKEY_TASK_NAME' = $Context.TaskName;
+            'WHISKEY_TEMP_DIRECTORY' = (Get-Item -Path ([IO.Path]::GetTempPath()));
+            'WHISKEY_TASK_TEMP_DIRECTORY' = $Context.Temp;
+            'WHISKEY_VERSION' = $version.Version;
+        }
     }
 
     process

--- a/Whiskey/Functions/Resolve-WhiskeyVariable.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyVariable.ps1
@@ -44,11 +44,10 @@ function Resolve-WhiskeyVariable
             'Integer' = 4;
         }
     #>
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='ByPipeline')]
     param(
-        [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
+        [Parameter(Mandatory,ValueFromPipeline,ParameterSetName='ByPipeline')]
         [AllowNull()]
-        [object]
         # The object on which to perform variable replacement/substitution. If the value is a string, all variables in the string are replaced with their values.
         #
         # If the value is an array, variable expansion is done on each item in the array. 
@@ -56,9 +55,13 @@ function Resolve-WhiskeyVariable
         # If the value is a hashtable, variable replcement is done on each value of the hashtable. 
         #
         # Variable expansion is performed on any arrays and hashtables found in other arrays and hashtables, i.e. arrays and hashtables are searched recursively.
-        $InputObject,
+        [object]$InputObject,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(ParameterSetName='ByName')]
+        # The name of a single Whiskey variable to resolve.
+        [string]$Name,
+
+        [Parameter(Mandatory)]
         [Whiskey.Context]
         # The context of the current build. Necessary to lookup any variables.
         $Context
@@ -68,6 +71,11 @@ function Resolve-WhiskeyVariable
     {
         Set-StrictMode -Version 'Latest'
         Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+        if( $Name )
+        {
+            $InputObject = '$({0})' -f $Name
+        }
 
         $version = $Context.Version
         $prereleaseID = ''

--- a/Whiskey/Tasks/PublishNodeModule.ps1
+++ b/Whiskey/Tasks/PublishNodeModule.ps1
@@ -12,7 +12,9 @@ function Publish-WhiskeyNodeModule
 
         [string]$EmailAddress,
 
-        [uri]$NpmRegistryUri
+        [uri]$NpmRegistryUri,
+
+        [string]$Tag
     )
 
     Set-StrictMode -Version 'Latest'
@@ -92,7 +94,21 @@ function Publish-WhiskeyNodeModule
                                 -ErrorAction Stop
 
         Invoke-WhiskeyNpmCommand -Name 'prune' -ArgumentList '--production' -BuildRootPath $TaskContext.BuildRoot -ErrorAction Stop
-        Invoke-WhiskeyNpmCommand -Name 'publish' -BuildRootPath $TaskContext.BuildRoot -ErrorAction Stop
+
+        $publishArgumentList = @(
+            if( $Tag )
+            {
+                '--tag'
+                $Tag
+            }
+            elseif( $TaskContext.Version.SemVer2.Prerelease )
+            {
+                '--tag'
+                Resolve-WhiskeyVariable -Context $TaskContext -Name 'WHISKEY_SEMVER2_PRERELEASE_ID'
+            }
+        )
+
+        Invoke-WhiskeyNpmCommand -Name 'publish' -ArgumentList $publishArgumentList -BuildRootPath $TaskContext.BuildRoot -ErrorAction Stop
     }
     finally
     {

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -159,6 +159,8 @@
             ReleaseNotes = @'
 * Moved Whiskey's documentation to [GitHub](https://github.com/webmd-health-services/Whiskey/wiki).
 * Added a new built-in Whiskey variable `WHISKEY_SEMVER2_PRERELEASE_ID` which contains the prerelease identifier of the prerelease label on a SemVer2 version string. E.g. Given the version `1.2.3-alpha.47+buildmetata`, this variable would be `alpha`.
+* When publishing a prerelease version of a node module, the `PublishNodeModule` task will now automatically publish the module with the prerelease identifier as the distribution tag.
+* Added a `Tag` property to the `PublishNodeModule` task that controls what distribution tag the module is published with. If specified, this property takes precendence over a tag from a prerelease identifier.
 '@
         } # End of PSData hashtable
 

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -158,6 +158,7 @@
             # ReleaseNotes of this module
             ReleaseNotes = @'
 * Moved Whiskey's documentation to [GitHub](https://github.com/webmd-health-services/Whiskey/wiki).
+* Added a new built-in Whiskey variable `WHISKEY_SEMVER2_PRERELEASE_ID` which contains the prerelease identifier of the prerelease label on a SemVer2 version string. E.g. Given the version `1.2.3-alpha.47+buildmetata`, this variable would be `alpha`.
 '@
         } # End of PSData hashtable
 


### PR DESCRIPTION
Resolves #285 

* Added a new built-in Whiskey variable `WHISKEY_SEMVER2_PRERELEASE_ID` which contains the prerelease identifier of the prerelease label on a SemVer2 version string. E.g. Given the version `1.2.3-alpha.47+buildmetata`, this variable would be `alpha`.
* When publishing a prerelease version of a node module, the `PublishNodeModule` task will now automatically publish the module with the prerelease identifier as the distribution tag.
* Added a `Tag` property to the `PublishNodeModule` task that controls what distribution tag the module is published with. If specified, this property takes precendence over a tag from a prerelease identifier.