### PR TITLE
Code formatting.

### DIFF
--- a/Format-PesterResult.ps1
+++ b/Format-PesterResult.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
-    [string[]]$Path
+    [String[]]$Path
 )
 
 Get-Item -Path $Path |

--- a/Format-PesterResult.ps1
+++ b/Format-PesterResult.ps1
@@ -1,13 +1,12 @@
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$true)]
-    [string[]]
-    $Path
+    [Parameter(Mandatory)]
+    [string[]]$Path
 )
 
 Get-Item -Path $Path |
     Get-Content -Raw |
     ForEach-Object { ([xml]$_).SelectNodes('/test-results/test-suite/results/test-suite') } |
-    ForEach-Object { [pscustomobject]@{ name = ($_.name | Split-Path -Leaf); duration = ([timespan]::FromSeconds( $_.time )) } } |
+    ForEach-Object { [pscustomobject]@{ name = ($_.name | Split-Path -Leaf); duration = ([TimeSpan]::FromSeconds( $_.time )) } } |
     Sort-Object -Descending -Property 'duration'
 

--- a/Test/Add-WhiskeyApiKey.Tests.ps1
+++ b/Test/Add-WhiskeyApiKey.Tests.ps1
@@ -15,16 +15,13 @@ function ThenApiKey
 {
     param(
         [Parameter(Mandatory)]
-        [string]
-        $ID,
+        [string]$ID,
 
         [Parameter(Mandatory)]
-        [string]
-        $WithValue,
+        [string]$WithValue,
 
         [Parameter(Mandatory)]
-        [Switch]
-        $Exists
+        [switch]$Exists
     )
 
     It ('should add API key') {
@@ -37,12 +34,10 @@ function WhenAddingApiKey
 {
     param(
         [Parameter(Mandatory)]
-        [string]
-        $ID,
+        [string]$ID,
 
         [Parameter(Mandatory)]
-        [string]
-        $WithValue
+        [string]$WithValue
     )
 
     $script:context = New-WhiskeyTestContext -ForDeveloper

--- a/Test/Add-WhiskeyApiKey.Tests.ps1
+++ b/Test/Add-WhiskeyApiKey.Tests.ps1
@@ -15,10 +15,10 @@ function ThenApiKey
 {
     param(
         [Parameter(Mandatory)]
-        [string]$ID,
+        [String]$ID,
 
         [Parameter(Mandatory)]
-        [string]$WithValue,
+        [String]$WithValue,
 
         [Parameter(Mandatory)]
         [switch]$Exists
@@ -34,10 +34,10 @@ function WhenAddingApiKey
 {
     param(
         [Parameter(Mandatory)]
-        [string]$ID,
+        [String]$ID,
 
         [Parameter(Mandatory)]
-        [string]$WithValue
+        [String]$WithValue
     )
 
     $script:context = New-WhiskeyTestContext -ForDeveloper

--- a/Test/Add-WhiskeyTaskDefault.Tests.ps1
+++ b/Test/Add-WhiskeyTaskDefault.Tests.ps1
@@ -135,18 +135,6 @@ function ThenTaskDefaultsContains
     $script:context.TaskDefaults[$TaskName][$Property] | Should -Be $Value
 }
 
-Describe 'Add-WhiskeyTaskDefault.when context object is missing TaskDefaults property' {
-    It 'should fail' {
-        Init
-        GivenContext [pscustomobject]@{ RunMode = 'Build' }
-        GiventaskName 'MSBuild'
-        GivenPropertyName 'Version'
-        GivenValue 12.0
-        WhenAddingTaskDefault -ErrorAction SilentlyContinue
-        ThenFailedWithError 'does not contain a ''TaskDefaults'' property'
-    }
-}
-
 Describe 'Add-WhiskeyTaskDefault.when given an invalid task name' {
     It 'should fail' {
         Init

--- a/Test/AppVeyorWaitForBuildJobs.Tests.ps1
+++ b/Test/AppVeyorWaitForBuildJobs.Tests.ps1
@@ -32,7 +32,7 @@ function GivenJob
         [int]$ThatFinishesAtCheck,
 
         [Parameter(Mandatory,ParameterSetName='CurrentJob')]
-        [Switch]$Current,
+        [switch]$Current,
 
         [Parameter(Mandatory,ParameterSetName='ForNotCurrentJob')]
         [string]$WithFinalStatus,
@@ -176,8 +176,8 @@ function WhenRunningTask
 {
     [CmdletBinding()]
     param(
-        [Switch]$AndNothingReturned,
-        [Switch]$AndNoBuildReturned
+        [switch]$AndNothingReturned,
+        [switch]$AndNoBuildReturned
     )
 
     $Global:Error.Clear()
@@ -281,13 +281,13 @@ function WhenRunningTask
 
     $parameter = @{}
     $task = $context.Configuration['Build'][0]
-    $checkInterval = [timespan]'00:00:10'
+    $checkInterval = [TimeSpan]'00:00:10'
     if( $task -isnot [string] )
     {
         $parameter = $task['AppVeyorWaitForBuildJobs']
         if( $parameter.ContainsKey('CheckInterval') )
         {
-            $checkInterval = [timespan]$parameter['CheckInterval']
+            $checkInterval = [TimeSpan]$parameter['CheckInterval']
         }
     }
     

--- a/Test/AppVeyorWaitForBuildJobs.Tests.ps1
+++ b/Test/AppVeyorWaitForBuildJobs.Tests.ps1
@@ -8,7 +8,7 @@ $failed = $false
 $secret = $null
 $secretID = $null
 $whiskeyYml = $null
-[object[]]$jobs = $null
+[Object[]]$jobs = $null
 $nextID = 10000000
 $currentJobID = $null
 $runByAppVeyor = $null
@@ -26,7 +26,7 @@ function GivenJob
         [int]$WithID,
 
         [Parameter(Mandatory,ParameterSetName='ForNotCurrentJob')]
-        [string]$WithStatus,
+        [String]$WithStatus,
 
         [Parameter(Mandatory,ParameterSetName='ForNotCurrentJob')]
         [int]$ThatFinishesAtCheck,
@@ -35,7 +35,7 @@ function GivenJob
         [switch]$Current,
 
         [Parameter(Mandatory,ParameterSetName='ForNotCurrentJob')]
-        [string]$WithFinalStatus,
+        [String]$WithFinalStatus,
 
         [Parameter(ParameterSetName='ForNotCurrentJob')]
         [switch]$ThatHasFinishedProperty
@@ -94,10 +94,10 @@ function GivenSecret
 {
     param(
         [Parameter(Mandatory)]
-        [string]$Secret,
+        [String]$Secret,
 
         [Parameter(Mandatory)]
-        [string]$WithID
+        [String]$WithID
     )
 
     $script:secret = $Secret
@@ -282,7 +282,7 @@ function WhenRunningTask
     $parameter = @{}
     $task = $context.Configuration['Build'][0]
     $checkInterval = [TimeSpan]'00:00:10'
-    if( $task -isnot [string] )
+    if( $task -isnot [String] )
     {
         $parameter = $task['AppVeyorWaitForBuildJobs']
         if( $parameter.ContainsKey('CheckInterval') )

--- a/Test/ConvertFrom-WhiskeyYamlScalar.Tests.ps1
+++ b/Test/ConvertFrom-WhiskeyYamlScalar.Tests.ps1
@@ -59,7 +59,7 @@ $testCases = @(
                 },
                 @{
                     Name = 'datetime';
-                    Result = [datetime]'2001-12-15T02:59:43.1Z';
+                    Result = [DateTime]'2001-12-15T02:59:43.1Z';
                     Values = @(
                         '2001-12-15T02:59:43.1Z'
                         '2001-12-15 02:59:43.1Z'
@@ -67,7 +67,7 @@ $testCases = @(
                 },
                 @{
                     Name = 'datetime';
-                    Result = [datetime]'2001-12-14t21:59:43.10-05:00';
+                    Result = [DateTime]'2001-12-14t21:59:43.10-05:00';
                     Values = @(
                         '2001-12-14t21:59:43.10-05:00',
                         '2001-12-14t21:59:43.10 -5'
@@ -77,7 +77,7 @@ $testCases = @(
                 },
                 @{
                     Name = 'datetime';
-                    Result = [datetime]'2001-12-15 2:59:43.10';
+                    Result = [DateTime]'2001-12-15 2:59:43.10';
                     Values = @(
                         '2001-12-15T2:59:43.10',
                         '2001-12-15 02:59:43.10'
@@ -85,7 +85,7 @@ $testCases = @(
                 },
                 @{
                     Name = 'datetime';
-                    Result = [datetime]'2002-12-14';
+                    Result = [DateTime]'2002-12-14';
                     Values = @(
                         '2002-12-14'
                     )

--- a/Test/ConvertFrom-WhiskeyYamlScalar.Tests.ps1
+++ b/Test/ConvertFrom-WhiskeyYamlScalar.Tests.ps1
@@ -108,14 +108,14 @@ $testCases = @(
                 },
                 @{
                     Name = 'double';
-                    Result = [double]::NegativeInfinity
+                    Result = [Double]::NegativeInfinity
                     Values = @(
                                     '-.Inf'
                                 )
                 },
                 @{
                     Name = 'double';
-                    Result = [double]::PositiveInfinity
+                    Result = [Double]::PositiveInfinity
                     Values = @(
                                     '.Inf'
                                 )
@@ -135,8 +135,8 @@ foreach( $testCase in $testCases )
 }
 
 Describe ('ConvertFrom-WhiskeyYamlScalar.when converting ''NaN''') {
-    It ('should return [double]NaN') {
-        '.NaN' | ConvertFrom-WhiskeyYamlScalar | ForEach-Object { [double]::IsNaN($_) } | Should -Be $true
+    It ('should return [Double]NaN') {
+        '.NaN' | ConvertFrom-WhiskeyYamlScalar | ForEach-Object { [Double]::IsNaN($_) } | Should -Be $true
     }
 }
 

--- a/Test/ConvertTo-WhiskeySemanticVersion.Tests.ps1
+++ b/Test/ConvertTo-WhiskeySemanticVersion.Tests.ps1
@@ -13,12 +13,11 @@ $developerBuildMetadata = '{0}.{1}' -f [Environment]::UserName,[Environment]::Ma
 function Assert-ConvertsTo
 {
     param(
-        [Parameter(ValueFromPipeline=$true)]
+        [Parameter(ValueFromPipeline)]
         $InputObject,
 
-        [Parameter(Mandatory=$true,Position=0)]
-        [SemVersion.SemanticVersion]
-        $ExpectedVersion
+        [Parameter(Mandatory,Position=0)]
+        [SemVersion.SemanticVersion]$ExpectedVersion
     )
 
     process
@@ -36,8 +35,8 @@ function Assert-ConvertsTo
     }
 }
 
-[datetime]'1/2/3'  | Assert-ConvertsTo '1.2.2003'
-[datetime]'1/2/99' | Assert-ConvertsTo '1.2.1999'
+[DateTime]'1/2/3'  | Assert-ConvertsTo '1.2.2003'
+[DateTime]'1/2/99' | Assert-ConvertsTo '1.2.1999'
 '3.2.1+build.info' | Assert-ConvertsTo '3.2.1'
 '3.2.1+build.info' | Assert-ConvertsTo '3.2.1+build.info'
 2.0                | Assert-ConvertsTo '2.0.0'

--- a/Test/ConvertTo-WhiskeySemanticVersion.Tests.ps1
+++ b/Test/ConvertTo-WhiskeySemanticVersion.Tests.ps1
@@ -48,5 +48,5 @@ function Assert-ConvertsTo
 '1.32'             | Assert-ConvertsTo '1.32.0'
 '1.32.4'           | Assert-ConvertsTo '1.32.4'
 '1.0130'           | Assert-ConvertsTo '1.130.0'
-[version]'1.2.3'   | Assert-ConvertsTo '1.2.3'
+[Version]'1.2.3'   | Assert-ConvertsTo '1.2.3'
 [SemVersion.SemanticVersion]'1.2.3-rc.4+build' | Assert-ConvertsTo '1.2.3-rc.4+build'

--- a/Test/CopyFile.Tests.ps1
+++ b/Test/CopyFile.Tests.ps1
@@ -26,7 +26,7 @@ function Get-DestinationRoot
 function GivenFiles
 {
     param(
-        [string[]]$Path
+        [String[]]$Path
     )
 
     $sourceRoot = Get-BuildRoot
@@ -43,7 +43,7 @@ function GivenNoFilesToCopy
 function GivenDirectories
 {
     param(
-        [string[]]$Path
+        [String[]]$Path
     )
 
     foreach( $item in $Path )
@@ -59,7 +59,7 @@ function GivenDirectories
 function GivenUserCannotCreateDestination
 {
     param(
-        [string[]]$To
+        [String[]]$To
     )
 
     $destinationRoot = Get-BuildRoot
@@ -83,9 +83,9 @@ function WhenCopyingFiles
     [CmdletBinding()]
     param(
         [Parameter(Position=0)]
-        [string[]]$Path,
+        [String[]]$Path,
 
-        [string[]]$To
+        [String[]]$To
     )
 
     $taskContext = New-WhiskeyTestContext -ForBuildServer
@@ -118,7 +118,7 @@ function WhenCopyingFiles
 function ThenNothingCopied
 {
     param(
-        [string[]]$To
+        [String[]]$To
     )
 
     $destinationRoot = Get-DestinationRoot
@@ -135,9 +135,9 @@ function ThenNothingCopied
 function ThenFilesCopied
 {
     param(
-        [string[]]$Path,
+        [String[]]$Path,
 
-        [string[]]$To
+        [String[]]$To
     )
 
     if( -not $To )

--- a/Test/CopyFile.Tests.ps1
+++ b/Test/CopyFile.Tests.ps1
@@ -26,8 +26,7 @@ function Get-DestinationRoot
 function GivenFiles
 {
     param(
-        [string[]]
-        $Path
+        [string[]]$Path
     )
 
     $sourceRoot = Get-BuildRoot
@@ -44,8 +43,7 @@ function GivenNoFilesToCopy
 function GivenDirectories
 {
     param(
-        [string[]]
-        $Path
+        [string[]]$Path
     )
 
     foreach( $item in $Path )
@@ -61,8 +59,7 @@ function GivenDirectories
 function GivenUserCannotCreateDestination
 {
     param(
-        [string[]]
-        $To
+        [string[]]$To
     )
 
     $destinationRoot = Get-BuildRoot
@@ -86,11 +83,9 @@ function WhenCopyingFiles
     [CmdletBinding()]
     param(
         [Parameter(Position=0)]
-        [string[]]
-        $Path,
+        [string[]]$Path,
 
-        [string[]]
-        $To
+        [string[]]$To
     )
 
     $taskContext = New-WhiskeyTestContext -ForBuildServer
@@ -123,8 +118,7 @@ function WhenCopyingFiles
 function ThenNothingCopied
 {
     param(
-        [string[]]
-        $To
+        [string[]]$To
     )
 
     $destinationRoot = Get-DestinationRoot
@@ -141,11 +135,9 @@ function ThenNothingCopied
 function ThenFilesCopied
 {
     param(
-        [string[]]
-        $Path,
+        [string[]]$Path,
 
-        [string[]]
-        $To
+        [string[]]$To
     )
 
     if( -not $To )

--- a/Test/Delete.Tests.ps1
+++ b/Test/Delete.Tests.ps1
@@ -15,14 +15,12 @@ function GivenClean
 function GivenItem
 {
     param(
-        [string[]]
-        $Path,
+        [string[]]$Path,
         
         [ValidateSet('File','Directory')]
         $ItemType,
 
-        [Switch]
-        $ReadOnly
+        [switch]$ReadOnly
     )
 
     foreach( $item in $Path )
@@ -39,8 +37,7 @@ function GivenItem
 function GivenPath
 {
     param(
-        [string[]]
-        $Path
+        [string[]]$Path
     )
 
     $script:path = $Path
@@ -55,8 +52,7 @@ function Init
 function ThenItemDoesNotExist
 {
     param(
-        [string[]]
-        $Path
+        [string[]]$Path
     )
     
     foreach( $item in $Path )
@@ -70,8 +66,7 @@ function ThenItemDoesNotExist
 function ThenItemExists
 {
     param(
-        [string[]]
-        $Path
+        [string[]]$Path
     )
 
     foreach( $item in $Path )

--- a/Test/Delete.Tests.ps1
+++ b/Test/Delete.Tests.ps1
@@ -15,7 +15,7 @@ function GivenClean
 function GivenItem
 {
     param(
-        [string[]]$Path,
+        [String[]]$Path,
         
         [ValidateSet('File','Directory')]
         $ItemType,
@@ -37,7 +37,7 @@ function GivenItem
 function GivenPath
 {
     param(
-        [string[]]$Path
+        [String[]]$Path
     )
 
     $script:path = $Path
@@ -52,7 +52,7 @@ function Init
 function ThenItemDoesNotExist
 {
     param(
-        [string[]]$Path
+        [String[]]$Path
     )
     
     foreach( $item in $Path )
@@ -66,7 +66,7 @@ function ThenItemDoesNotExist
 function ThenItemExists
 {
     param(
-        [string[]]$Path
+        [String[]]$Path
     )
 
     foreach( $item in $Path )

--- a/Test/DotNet.Tests.ps1
+++ b/Test/DotNet.Tests.ps1
@@ -18,8 +18,7 @@ $verbosity = $null
 function GivenDotNetCoreProject
 {
     param(
-        [string[]]
-        $Path,
+        [string[]]$Path,
 
         $Targeting
     )
@@ -63,10 +62,8 @@ function ThenLogFile
 {
     param(
         $Name,
-        [Switch]
-        $Not,
-        [Switch]
-        $Exists
+        [switch]$Not,
+        [switch]$Exists
     )
 
     $fullPath = Join-Path -Path $testRoot -ChildPath '.output'
@@ -90,8 +87,7 @@ function ThenLogFile
 function ThenProjectBuilt
 {
     param(
-        [string]
-        $AssemblyPath
+        [string]$AssemblyPath
     )
 
     $AssemblyPath = Join-Path -Path $testRoot -ChildPath $AssemblyPath

--- a/Test/DotNet.Tests.ps1
+++ b/Test/DotNet.Tests.ps1
@@ -18,7 +18,7 @@ $verbosity = $null
 function GivenDotNetCoreProject
 {
     param(
-        [string[]]$Path,
+        [String[]]$Path,
 
         $Targeting
     )
@@ -87,7 +87,7 @@ function ThenLogFile
 function ThenProjectBuilt
 {
     param(
-        [string]$AssemblyPath
+        [String]$AssemblyPath
     )
 
     $AssemblyPath = Join-Path -Path $testRoot -ChildPath $AssemblyPath

--- a/Test/Exec.Tests.ps1
+++ b/Test/Exec.Tests.ps1
@@ -181,10 +181,10 @@ function ThenExecutableRan
 function ThenSpecifiedArgumentsWerePassed
 {
     param(
-        [string[]]$Arguments = @()
+        [String[]]$Arguments = @()
     )
 
-    [string[]]$argumentsResult = Get-ChildItem -Path (Get-BuildRoot) -Filter 'Arguments.txt' -Recurse | Get-Content
+    [String[]]$argumentsResult = Get-ChildItem -Path (Get-BuildRoot) -Filter 'Arguments.txt' -Recurse | Get-Content
     if( -not $argumentsResult )
     {
         $argumentsResult = @()

--- a/Test/Exec.Tests.ps1
+++ b/Test/Exec.Tests.ps1
@@ -117,11 +117,9 @@ function WhenRunningExecutable
 {
     [CmdletBinding()]
     param(
-        [Switch]
-        $InCleanMode,
+        [switch]$InCleanMode,
 
-        [Switch]
-        $InInitializeMode
+        [switch]$InInitializeMode
     )
 
     $TaskParameter = @{}
@@ -183,8 +181,7 @@ function ThenExecutableRan
 function ThenSpecifiedArgumentsWerePassed
 {
     param(
-        [string[]]
-        $Arguments = @()
+        [string[]]$Arguments = @()
     )
 
     [string[]]$argumentsResult = Get-ChildItem -Path (Get-BuildRoot) -Filter 'Arguments.txt' -Recurse | Get-Content

--- a/Test/Get-TaskParameter.Tests.ps1
+++ b/Test/Get-TaskParameter.Tests.ps1
@@ -233,11 +233,11 @@ Describe ('Get-TaskParameter.when passing typed parameters') {
         {
             [Whiskey.Task('Task')]
             param(
-                [Switch]$SwitchOne,
+                [switch]$SwitchOne,
 
-                [Switch]$SwitchTwo,
+                [switch]$SwitchTwo,
 
-                [Switch]$SwitchThree,
+                [switch]$SwitchThree,
 
                 [bool]$Bool,
 

--- a/Test/Get-TaskParameter.Tests.ps1
+++ b/Test/Get-TaskParameter.Tests.ps1
@@ -100,11 +100,11 @@ function WhenRunningTask
 {
     [CmdletBinding(SupportsShouldProcess)]
     param(
-        [string]$Name,
+        [String]$Name,
 
         [hashtable]$Parameter,
 
-        [string]$BuildRoot
+        [String]$BuildRoot
     )
 
     $optionalParams = @{}
@@ -196,7 +196,7 @@ Describe ('Get-TaskParameter.when task parameter should come from a Whiskey vari
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ParameterValueFromVariable('WHISKEY_ENVIRONMENT')]
-                [string]$Environment
+                [String]$Environment
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -215,7 +215,7 @@ Describe ('Get-TaskParameter.when task parameter value uses a Whiskey variable m
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ParameterValueFromVariable('WHISKEY_ENVIRONMENT.Length')]
-                [string]$Environment
+                [String]$Environment
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters

--- a/Test/Get-WhiskeyApiKey.Tests.ps1
+++ b/Test/Get-WhiskeyApiKey.Tests.ps1
@@ -11,7 +11,7 @@ function WhenGettingApiKey
 {
     [CmdletBinding()]
     param(
-        [parameter(Mandatory=$true)]
+        [parameter(Mandatory)]
         $PropertyName
     )
 

--- a/Test/Get-WhiskeyBuildMetadata.Tests.ps1
+++ b/Test/Get-WhiskeyBuildMetadata.Tests.ps1
@@ -34,26 +34,25 @@ InModuleScope 'Whiskey' {
     {
         [CmdletBinding()]
         param(
-            [Parameter(Mandatory=$true)]
-            [int]
-            $BuildNumber,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
+            [int]$BuildNumber,
+            [Parameter(Mandatory)]
             $BuildID,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $ProjectName,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $ProjectSlug,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $ScmProvider,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $ScmRepoName,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $ScmBranch,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $ScmCommit,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $AccountName,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $BuildVersion
         )
 
@@ -74,22 +73,21 @@ InModuleScope 'Whiskey' {
     {
         [CmdletBinding()]
         param(
-            [Parameter(Mandatory=$true)]
-            [int]
-            $BuildNumber,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
+            [int]$BuildNumber,
+            [Parameter(Mandatory)]
             $BuildID,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $JobName,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $JobUri,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $BuildUri,
-            [Parameter(Mandatory=$true,ParameterSetName='WithGitScm')]
+            [Parameter(Mandatory,ParameterSetName='WithGitScm')]
             $GitUri,
-            [Parameter(Mandatory=$true,ParameterSetName='WithGitScm')]
+            [Parameter(Mandatory,ParameterSetName='WithGitScm')]
             $GitCommit,
-            [Parameter(Mandatory=$true,ParameterSetName='WithGitScm')]
+            [Parameter(Mandatory,ParameterSetName='WithGitScm')]
             $GitBranch
         )
 
@@ -116,22 +114,21 @@ InModuleScope 'Whiskey' {
     function GivenTeamCityEnvironment
     {
         param(
-            [Parameter(Mandatory=$true)]
-            [int]
-            $BuildNumber,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
+            [int]$BuildNumber,
+            [Parameter(Mandatory)]
             $VcsNumber,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $ProjectName,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $VcsBranch,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $VcsUri,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $ServerUri,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $BuildTypeID,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $BuildID
         )
 
@@ -175,28 +172,24 @@ InModuleScope 'Whiskey' {
     {
         [CmdletBinding()]
         param(
-            [Parameter(Mandatory=$true)]
-            [int]
-            $BuildNumber,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
+            [int]$BuildNumber,
+            [Parameter(Mandatory)]
             $BuildID,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             $JobName,
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory)]
             [AllowNull()]
-            [uri]
-            $JobUri,
-            [Parameter(Mandatory=$true)]
+            [uri]$JobUri,
+            [Parameter(Mandatory)]
             [AllowNull()]
-            [uri]
-            $BuildUri,
-            [Parameter(Mandatory=$true,ParameterSetName='WithGitScm')]
+            [uri]$BuildUri,
+            [Parameter(Mandatory,ParameterSetName='WithGitScm')]
             [AllowNull()]
-            [uri]
-            $ScmUri,
-            [Parameter(Mandatory=$true,ParameterSetName='WithGitScm')]
+            [uri]$ScmUri,
+            [Parameter(Mandatory,ParameterSetName='WithGitScm')]
             $ScmCommit,
-            [Parameter(Mandatory=$true,ParameterSetName='WithGitScm')]
+            [Parameter(Mandatory,ParameterSetName='WithGitScm')]
             $ScmBranch
         )
 

--- a/Test/Get-WhiskeyBuildMetadata.Tests.ps1
+++ b/Test/Get-WhiskeyBuildMetadata.Tests.ps1
@@ -180,13 +180,13 @@ InModuleScope 'Whiskey' {
             $JobName,
             [Parameter(Mandatory)]
             [AllowNull()]
-            [uri]$JobUri,
+            [Uri]$JobUri,
             [Parameter(Mandatory)]
             [AllowNull()]
-            [uri]$BuildUri,
+            [Uri]$BuildUri,
             [Parameter(Mandatory,ParameterSetName='WithGitScm')]
             [AllowNull()]
-            [uri]$ScmUri,
+            [Uri]$ScmUri,
             [Parameter(Mandatory,ParameterSetName='WithGitScm')]
             $ScmCommit,
             [Parameter(Mandatory,ParameterSetName='WithGitScm')]

--- a/Test/GetPowerShellModule.Tests.ps1
+++ b/Test/GetPowerShellModule.Tests.ps1
@@ -23,8 +23,7 @@ function Init
 function GivenModule
 {
     Param(
-        [string]
-        $Module
+        [string]$Module
     )
     $script:taskParameter['Name'] = $Module
 
@@ -35,8 +34,7 @@ function GivenModule
 function GivenVersion
 {
     param(
-        [string]
-        $Version
+        [string]$Version
     )
     $script:taskParameter['Version'] = $Version
 }
@@ -95,8 +93,7 @@ function ThenModuleShouldNotExist
 function ThenErrorShouldBeThrown
 {
     param(
-        [string]
-        $Message
+        [string]$Message
     )
 
     $Global:Error | Should -Match $Message

--- a/Test/GetPowerShellModule.Tests.ps1
+++ b/Test/GetPowerShellModule.Tests.ps1
@@ -23,7 +23,7 @@ function Init
 function GivenModule
 {
     Param(
-        [string]$Module
+        [String]$Module
     )
     $script:taskParameter['Name'] = $Module
 
@@ -34,7 +34,7 @@ function GivenModule
 function GivenVersion
 {
     param(
-        [string]$Version
+        [String]$Version
     )
     $script:taskParameter['Version'] = $Version
 }
@@ -93,7 +93,7 @@ function ThenModuleShouldNotExist
 function ThenErrorShouldBeThrown
 {
     param(
-        [string]$Message
+        [String]$Message
     )
 
     $Global:Error | Should -Match $Message

--- a/Test/GitHubRelease.Tests.ps1
+++ b/Test/GitHubRelease.Tests.ps1
@@ -40,7 +40,7 @@ function GivenAssets
 function GivenAssetUpdated
 {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         $To
     )
 
@@ -52,7 +52,7 @@ function GivenAssetUpdated
 function GivenAssetUploaded
 {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         $To
     )
 
@@ -163,14 +163,13 @@ function ThenNoApiCalled
 function ThenRequest
 {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         $Should,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         $ToUri,
 
-        [Microsoft.PowerShell.Commands.WebRequestMethod]
-        $UsedMethod,
+        [Microsoft.PowerShell.Commands.WebRequestMethod]$UsedMethod,
 
         $WithBody,
 

--- a/Test/GitHubRelease.Tests.ps1
+++ b/Test/GitHubRelease.Tests.ps1
@@ -137,7 +137,7 @@ function ThenAssetNotUploadedTo
             #$DebugPreference = 'Continue'
             Write-Debug ('Uri   expected  {0}' -f $toUri)
             Write-Debug ('      actual    {0}' -f $Uri)
-            $Uri -eq [uri]$toUri
+            $Uri -eq [Uri]$toUri
         }
     }
 }
@@ -186,7 +186,7 @@ function ThenRequest
                 Write-Debug ('')
                 Write-Debug ('Uri   expected  {0}' -f $ToUri)
                 Write-Debug ('      actual    {0}' -f $Uri)
-                $uriEqual = $Uri -eq [uri]$ToUri
+                $uriEqual = $Uri -eq [Uri]$ToUri
                 Write-Debug ('                {0}' -f $uriEqual)
                 Write-Debug ('Body  expected  {0}' -f $WithBody)
                 Write-Debug ('      actual    {0}' -f $Body)
@@ -219,7 +219,7 @@ function ThenRequest
                 Write-Debug ('        actual    {0}' -f $Uri)
                 Write-Debug ('Method  expected  {0}' -f $UsedMethod)
                 Write-Debug ('        actual    {0}' -f $Method)
-                $Uri -eq [uri]$ToUri -and $Method -eq $UsedMethod 
+                $Uri -eq [Uri]$ToUri -and $Method -eq $UsedMethod 
             }
         }
 
@@ -231,7 +231,7 @@ function ThenRequest
                 Write-Debug ('             actual    {0}' -f $Uri)
                 Write-Debug ('ContentType  expected  {0}' -f $AsContentType)
                 Write-Debug ('             actual    {0}' -f $ContentType)
-                $Uri -eq [uri]$ToUri -and $ContentType -eq $AsContentType 
+                $Uri -eq [Uri]$ToUri -and $ContentType -eq $AsContentType 
             }
         }
 
@@ -244,7 +244,7 @@ function ThenRequest
                 $WithFile = Join-Path -Path $TestDrive.FullName -ChildPath $WithFile
                 Write-Debug ('InFile  expected  {0}' -f $WithFile)
                 Write-Debug ('        actual    {0}' -f $InFile)
-                $Uri -eq [uri]$ToUri -and $InFile -eq $WithFile 
+                $Uri -eq [Uri]$ToUri -and $InFile -eq $WithFile 
             }
         }
     }

--- a/Test/Install-WhiskeyDotNetSdk.Tests.ps1
+++ b/Test/Install-WhiskeyDotNetSdk.Tests.ps1
@@ -138,8 +138,7 @@ function ThenNotInstalledDotNet
 function ThenReturnedPathToDotNet
 {
     param(
-        [switch]
-        $Global
+        [switch]$Global
     )
 
     If ($Global)
@@ -167,8 +166,7 @@ function WhenInstallingDotNet
     param(
         $Version,
 
-        [switch]
-        $Global
+        [switch]$Global
     )
 
     $parameter = $PSBoundParameters

--- a/Test/Install-WhiskeyDotNetTool.Tests.ps1
+++ b/Test/Install-WhiskeyDotNetTool.Tests.ps1
@@ -133,8 +133,7 @@ function ThenDotNetNotLocallyInstalled
 function ThenDotNetSdkVersion
 {
     param(
-        [string]
-        $Version
+        [string]$Version
     )
 
     Push-Location -Path $workingDirectory

--- a/Test/Install-WhiskeyDotNetTool.Tests.ps1
+++ b/Test/Install-WhiskeyDotNetTool.Tests.ps1
@@ -133,7 +133,7 @@ function ThenDotNetNotLocallyInstalled
 function ThenDotNetSdkVersion
 {
     param(
-        [string]$Version
+        [String]$Version
     )
 
     Push-Location -Path $workingDirectory

--- a/Test/Install-WhiskeyNode.Tests.ps1
+++ b/Test/Install-WhiskeyNode.Tests.ps1
@@ -38,9 +38,9 @@ function Init
 function ThenNodeInstalled
 {
     param(
-        [string]$NodeVersion,
+        [String]$NodeVersion,
 
-        [string]$NpmVersion,
+        [String]$NpmVersion,
 
         [switch]$AtLatestVersion
     )

--- a/Test/Install-WhiskeyNode.Tests.ps1
+++ b/Test/Install-WhiskeyNode.Tests.ps1
@@ -38,14 +38,11 @@ function Init
 function ThenNodeInstalled
 {
     param(
-        [string]
-        $NodeVersion,
+        [string]$NodeVersion,
 
-        [string]
-        $NpmVersion,
+        [string]$NpmVersion,
 
-        [Switch]
-        $AtLatestVersion
+        [switch]$AtLatestVersion
     )
 
     $nodePath = Resolve-WhiskeyNodePath -BuildRootPath $TestDrive.FullName
@@ -126,7 +123,7 @@ function WhenInstallingTool
     param(
         $Version,
 
-        [Switch]$InCleanMode
+        [switch]$InCleanMode
     )
 
     $Global:Error.Clear()

--- a/Test/Install-WhiskeyNodeModule.Tests.ps1
+++ b/Test/Install-WhiskeyNodeModule.Tests.ps1
@@ -97,20 +97,16 @@ function ThenModule
 {
     param(
         [Parameter(Position=0)]
-        [string]
-        $Name,
+        [string]$Name,
 
-        [Parameter(Mandatory=$false,ParameterSetName='Exists')]
-        [string]
-        $Version,
+        [Parameter(ParameterSetName='Exists')]
+        [string]$Version,
         
-        [Parameter(Mandatory=$true,ParameterSetName='Exists')]
-        [switch]
-        $Exists,
+        [Parameter(Mandatory,ParameterSetName='Exists')]
+        [switch]$Exists,
 
-        [Parameter(Mandatory=$true,ParameterSetName='DoesNotExist')]
-        [switch]
-        $DoesNotExist
+        [Parameter(Mandatory,ParameterSetName='DoesNotExist')]
+        [switch]$DoesNotExist
     )
 
     $modulePath = Resolve-WhiskeyNodeModulePath -Name $Name -BuildRootPath $TestDrive.FullName

--- a/Test/Install-WhiskeyNodeModule.Tests.ps1
+++ b/Test/Install-WhiskeyNodeModule.Tests.ps1
@@ -97,10 +97,10 @@ function ThenModule
 {
     param(
         [Parameter(Position=0)]
-        [string]$Name,
+        [String]$Name,
 
         [Parameter(ParameterSetName='Exists')]
-        [string]$Version,
+        [String]$Version,
         
         [Parameter(Mandatory,ParameterSetName='Exists')]
         [switch]$Exists,

--- a/Test/Install-WhiskeyPowerShellModule.Tests.ps1
+++ b/Test/Install-WhiskeyPowerShellModule.Tests.ps1
@@ -27,7 +27,7 @@ function Install-WhiskeyPowerShellModule
     param(
         $Name,
         $Version,
-        [Switch]$SkipImport
+        [switch]$SkipImport
     )
 
     $parameter = $PSBoundParameters
@@ -42,7 +42,7 @@ function Invoke-PowershellInstall
         $ForModule,
         $Version,
         $ActualVersion,
-        [Switch]$SkipImport
+        [switch]$SkipImport
     )
 
     if( -not $ActualVersion )

--- a/Test/Install-WhiskeyPowerShellModule.Tests.ps1
+++ b/Test/Install-WhiskeyPowerShellModule.Tests.ps1
@@ -147,7 +147,7 @@ Describe 'Install-WhiskeyPowerShellModule.when installing a PowerShell module us
     AfterEach { Reset }
     It 'should resolve to the latest version that matches the wildcard' {
         Init
-        $version = [version]($latestZip.Version)
+        $version = [Version]($latestZip.Version)
         Invoke-PowershellInstall -ForModule 'Zip' -Version ('{0}.*' -f $version.Major) -ActualVersion $latestZip.Version
         ThenModuleImported 'Zip' -AtVersion $latestZip.Version
     }

--- a/Test/Install-WhiskeyTool.Tests.ps1
+++ b/Test/Install-WhiskeyTool.Tests.ps1
@@ -24,11 +24,9 @@ function Invoke-NuGetInstall
         $Package,
         $Version,
 
-        [Switch]
-        $InvalidPackage,
+        [switch]$InvalidPackage,
 
-        [string]
-        $ExpectedError
+        [string]$ExpectedError
     )
 
     $Global:Error.Clear()
@@ -172,7 +170,7 @@ function ThenNodeInstalled
 
         [string]$NpmVersion,
 
-        [Switch]$AtLatestVersion,
+        [switch]$AtLatestVersion,
 
         [string]$AndPathParameterIs
     )
@@ -413,10 +411,8 @@ function ThenDirectory
 {
     param(
         $Path,
-        [Switch]
-        $Not,
-        [Switch]
-        $Exists
+        [switch]$Not,
+        [switch]$Exists
     )
 
     if( $Not )

--- a/Test/Install-WhiskeyTool.Tests.ps1
+++ b/Test/Install-WhiskeyTool.Tests.ps1
@@ -26,7 +26,7 @@ function Invoke-NuGetInstall
 
         [switch]$InvalidPackage,
 
-        [string]$ExpectedError
+        [String]$ExpectedError
     )
 
     $Global:Error.Clear()
@@ -157,7 +157,7 @@ function ThenDotNetPathAddedToTaskParameter
 {
     param(
         [Parameter(Mandatory)]
-        [string]$Named
+        [String]$Named
     )
 
     $taskParameter[$Named] | Should -Match '[\\/]dotnet(\.exe)$'
@@ -166,13 +166,13 @@ function ThenDotNetPathAddedToTaskParameter
 function ThenNodeInstalled
 {
     param(
-        [string]$NodeVersion,
+        [String]$NodeVersion,
 
-        [string]$NpmVersion,
+        [String]$NpmVersion,
 
         [switch]$AtLatestVersion,
 
-        [string]$AndPathParameterIs
+        [String]$AndPathParameterIs
     )
 
     $nodePath = Resolve-WhiskeyNodePath -BuildRootPath $testRoot
@@ -277,7 +277,7 @@ function WhenInstallingTool
         $Version,
 
         [Parameter(ParameterSetName='HandleAttributeForMe')]
-        [string]$PathParameterName
+        [String]$PathParameterName
     )
 
     $Global:Error.Clear()

--- a/Test/Invoke-WhiskeyBuild.Tests.ps1
+++ b/Test/Invoke-WhiskeyBuild.Tests.ps1
@@ -195,7 +195,7 @@ function ThenBuildRunInMode
 function ThenBuildStatusSetTo
 {
     param(
-        [string]$ExpectedStatus
+        [String]$ExpectedStatus
     )
 
     It ('should set commmit build status to ''{0}''' -f $ExpectedStatus) {
@@ -235,7 +235,7 @@ function WhenRunningBuild
 {
     [CmdletBinding()]
     param(
-        [string[]]$PipelineName,
+        [String[]]$PipelineName,
 
         [switch]$WithCleanSwitch,
 

--- a/Test/Invoke-WhiskeyBuild.Tests.ps1
+++ b/Test/Invoke-WhiskeyBuild.Tests.ps1
@@ -195,8 +195,7 @@ function ThenBuildRunInMode
 function ThenBuildStatusSetTo
 {
     param(
-        [string]
-        $ExpectedStatus
+        [string]$ExpectedStatus
     )
 
     It ('should set commmit build status to ''{0}''' -f $ExpectedStatus) {
@@ -236,14 +235,11 @@ function WhenRunningBuild
 {
     [CmdletBinding()]
     param(
-        [string[]]
-        $PipelineName,
+        [string[]]$PipelineName,
 
-        [Switch]
-        $WithCleanSwitch,
+        [switch]$WithCleanSwitch,
 
-        [Switch]
-        $WithInitializeSwitch
+        [switch]$WithInitializeSwitch
     )
 
     Mock -CommandName 'Set-WhiskeyBuildStatus' -ModuleName 'Whiskey'

--- a/Test/Invoke-WhiskeyDotNetCommand.Tests.ps1
+++ b/Test/Invoke-WhiskeyDotNetCommand.Tests.ps1
@@ -18,8 +18,7 @@ function Write-WhiskeyCommand
 function Init
 {
     param(
-        [Switch]
-        $SkipDotNetMock
+        [switch]$SkipDotNetMock
     )
     $script:argumentList = $null
     $script:commandName = $null
@@ -130,8 +129,7 @@ function ThenRanCommand
 function ThenRanWithArguments
 {
     param(
-        [string[]]
-        $ExpectedArguments
+        [string[]]$ExpectedArguments
     )
 
     Assert-MockCalled -CommandName 'Invoke-Command' -ModuleName 'Whiskey' -ParameterFilter {

--- a/Test/Invoke-WhiskeyDotNetCommand.Tests.ps1
+++ b/Test/Invoke-WhiskeyDotNetCommand.Tests.ps1
@@ -129,7 +129,7 @@ function ThenRanCommand
 function ThenRanWithArguments
 {
     param(
-        [string[]]$ExpectedArguments
+        [String[]]$ExpectedArguments
     )
 
     Assert-MockCalled -CommandName 'Invoke-Command' -ModuleName 'Whiskey' -ParameterFilter {

--- a/Test/Invoke-WhiskeyNpmCommand.Tests.ps1
+++ b/Test/Invoke-WhiskeyNpmCommand.Tests.ps1
@@ -52,7 +52,7 @@ function GivenArgument
 function GivenDependency 
 {
     param(
-        [object[]]$Dependency 
+        [Object[]]$Dependency 
     )
     $script:dependency = $Dependency
 }
@@ -60,7 +60,7 @@ function GivenDependency
 function GivenDevDependency 
 {
     param(
-        [object[]]$DevDependency 
+        [Object[]]$DevDependency 
     )
     $script:devDependency = $DevDependency
 }
@@ -103,7 +103,7 @@ function ThenPackage
 {
     param(
         [Parameter(Position=0)]
-        [string]$PackageName,
+        [String]$PackageName,
         
         [Parameter(Mandatory,ParameterSetName='Exists')]
         [switch]$Exists,

--- a/Test/Invoke-WhiskeyNpmCommand.Tests.ps1
+++ b/Test/Invoke-WhiskeyNpmCommand.Tests.ps1
@@ -52,8 +52,7 @@ function GivenArgument
 function GivenDependency 
 {
     param(
-        [object[]]
-        $Dependency 
+        [object[]]$Dependency 
     )
     $script:dependency = $Dependency
 }
@@ -61,8 +60,7 @@ function GivenDependency
 function GivenDevDependency 
 {
     param(
-        [object[]]
-        $DevDependency 
+        [object[]]$DevDependency 
     )
     $script:devDependency = $DevDependency
 }
@@ -105,16 +103,13 @@ function ThenPackage
 {
     param(
         [Parameter(Position=0)]
-        [string]
-        $PackageName,
+        [string]$PackageName,
         
-        [Parameter(Mandatory=$true,ParameterSetName='Exists')]
-        [switch]
-        $Exists,
+        [Parameter(Mandatory,ParameterSetName='Exists')]
+        [switch]$Exists,
 
-        [Parameter(Mandatory=$true,ParameterSetName='DoesNotExist')]
-        [switch]
-        $DoesNotExist
+        [Parameter(Mandatory,ParameterSetName='DoesNotExist')]
+        [switch]$DoesNotExist
     )
 
     $packagePath = Resolve-WhiskeyNodeModulePath -Name $PackageName -BuildRootPath $testRoot -ErrorAction Ignore

--- a/Test/Invoke-WhiskeyPipelineTask.Tests.ps1
+++ b/Test/Invoke-WhiskeyPipelineTask.Tests.ps1
@@ -48,16 +48,13 @@ function ThenPowershellModule
 {
     param(
         [Parameter(Position=0)]
-        [string]
-        $Name,
+        [string]$Name,
 
         [Parameter(ParameterSetName='Cleaned')]
-        [switch]
-        $Cleaned,
+        [switch]$Cleaned,
 
         [Parameter(ParameterSetName='Installed')]
-        [switch]
-        $Installed
+        [switch]$Installed
     )
 
     $expectedName = $Name
@@ -92,8 +89,7 @@ function ThenPipelineRun
 {
     param(
         $Name,
-        [string]
-        $BecauseFileExists
+        [string]$BecauseFileExists
     )
 
     Join-Path -Path $testRoot -ChildPath $BecauseFileExists | Should -Exist

--- a/Test/Invoke-WhiskeyPipelineTask.Tests.ps1
+++ b/Test/Invoke-WhiskeyPipelineTask.Tests.ps1
@@ -38,7 +38,7 @@ function Init
 {
     $script:clean = $false
     $script:initialize = $false
-    $script:pipelines = New-Object 'Collections.Generic.List[string]'
+    $script:pipelines = New-Object 'Collections.Generic.List[String]'
     $script:threwException = $false
 
     $script:testRoot = New-WhiskeyTestRoot
@@ -48,7 +48,7 @@ function ThenPowershellModule
 {
     param(
         [Parameter(Position=0)]
-        [string]$Name,
+        [String]$Name,
 
         [Parameter(ParameterSetName='Cleaned')]
         [switch]$Cleaned,
@@ -89,7 +89,7 @@ function ThenPipelineRun
 {
     param(
         $Name,
-        [string]$BecauseFileExists
+        [String]$BecauseFileExists
     )
 
     Join-Path -Path $testRoot -ChildPath $BecauseFileExists | Should -Exist

--- a/Test/Invoke-WhiskeyTask.Tests.ps1
+++ b/Test/Invoke-WhiskeyTask.Tests.ps1
@@ -37,10 +37,10 @@ function Invoke-PreTaskPlugin
 {
     param(
         [Parameter(Mandatory)]
-        [object]$TaskContext,
+        [Object]$TaskContext,
 
         [Parameter(Mandatory)]
-        [string]$TaskName,
+        [String]$TaskName,
 
         [Parameter(Mandatory)]
         [hashtable]$TaskParameter
@@ -52,10 +52,10 @@ function Invoke-PostTaskPlugin
 {
     param(
         [Parameter(Mandatory)]
-        [object]$TaskContext,
+        [Object]$TaskContext,
 
         [Parameter(Mandatory)]
-        [string]$TaskName,
+        [String]$TaskName,
 
         [Parameter(Mandatory)]
         [hashtable]$TaskParameter
@@ -157,7 +157,7 @@ function GivenRunByDeveloper
 function GivenPlugins
 {
     param(
-        [string]$ForSpecificTask
+        [String]$ForSpecificTask
     )
 
     $taskNameParam = @{ }
@@ -177,7 +177,7 @@ function GivenDefaults
     param(
         [hashtable]$Default,
 
-        [string]$ForTask
+        [String]$ForTask
     )
 
     $script:taskDefaults[$ForTask] = $Default
@@ -186,7 +186,7 @@ function GivenDefaults
 function GivenScmBranch
 {
     param(
-        [string]$Branch
+        [String]$Branch
     )
     $script:scmBranch = $Branch
 }
@@ -205,7 +205,7 @@ function GivenWhiskeyYmlBuildFile
 {
     param(
         [Parameter(Position=0)]
-        [string]$Yaml
+        [String]$Yaml
     )
 
     $config = $null
@@ -217,7 +217,7 @@ function GivenWhiskeyYmlBuildFile
 function GivenWorkingDirectory
 {
     param(
-        [string]$Directory,
+        [String]$Directory,
 
         [switch]$SkipMock
     )
@@ -265,9 +265,9 @@ function ThenPipelineSucceeded
 function ThenDotNetProjectsCompilationFailed
 {
     param(
-        [string]$ConfigurationPath,
+        [String]$ConfigurationPath,
 
-        [string[]]$ProjectName
+        [String[]]$ProjectName
     )
 
     $root = Split-Path -Path $ConfigurationPath -Parent
@@ -422,7 +422,7 @@ function ThenTaskRanWithoutParameter
 {
     param(
         $CommandName,
-        [string[]]$ParameterName
+        [String[]]$ParameterName
     )
 
     foreach( $name in $ParameterName )
@@ -534,11 +534,11 @@ function WhenRunningTask
 {
     [CmdletBinding()]
     param(
-        [string]$Name,
+        [String]$Name,
 
         [hashtable]$Parameter,
 
-        [string]$InRunMode
+        [String]$InRunMode
     )
 
     Mock -CommandName 'Invoke-PreTaskPlugin' -ModuleName 'Whiskey'

--- a/Test/Invoke-WhiskeyTask.Tests.ps1
+++ b/Test/Invoke-WhiskeyTask.Tests.ps1
@@ -36,17 +36,14 @@ function Global::ToolTask
 function Invoke-PreTaskPlugin
 {
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [object]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $TaskName,
+        [Parameter(Mandatory)]
+        [string]$TaskName,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
 }
@@ -54,17 +51,14 @@ function Invoke-PreTaskPlugin
 function Invoke-PostTaskPlugin
 {
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [object]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $TaskName,
+        [Parameter(Mandatory)]
+        [string]$TaskName,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 }
 
@@ -98,10 +92,8 @@ function GivenFile
 function GivenMockTask
 {
     param(
-        [switch]
-        $SupportsClean,
-        [switch]
-        $SupportsInitialize
+        [switch]$SupportsClean,
+        [switch]$SupportsInitialize
     )
 
     if ($SupportsClean -and $SupportsInitialize)
@@ -165,8 +157,7 @@ function GivenRunByDeveloper
 function GivenPlugins
 {
     param(
-        [string]
-        $ForSpecificTask
+        [string]$ForSpecificTask
     )
 
     $taskNameParam = @{ }
@@ -184,11 +175,9 @@ function GivenPlugins
 function GivenDefaults
 {
     param(
-        [hashtable]
-        $Default,
+        [hashtable]$Default,
 
-        [string]
-        $ForTask
+        [string]$ForTask
     )
 
     $script:taskDefaults[$ForTask] = $Default
@@ -197,8 +186,7 @@ function GivenDefaults
 function GivenScmBranch
 {
     param(
-        [string]
-        $Branch
+        [string]$Branch
     )
     $script:scmBranch = $Branch
 }
@@ -217,8 +205,7 @@ function GivenWhiskeyYmlBuildFile
 {
     param(
         [Parameter(Position=0)]
-        [string]
-        $Yaml
+        [string]$Yaml
     )
 
     $config = $null
@@ -230,11 +217,9 @@ function GivenWhiskeyYmlBuildFile
 function GivenWorkingDirectory
 {
     param(
-        [string]
-        $Directory,
+        [string]$Directory,
 
-        [Switch]
-        $SkipMock
+        [switch]$SkipMock
     )
 
     $wd = Join-Path -Path $testRoot -ChildPath $Directory
@@ -280,11 +265,9 @@ function ThenPipelineSucceeded
 function ThenDotNetProjectsCompilationFailed
 {
     param(
-        [string]
-        $ConfigurationPath,
+        [string]$ConfigurationPath,
 
-        [string[]]
-        $ProjectName
+        [string[]]$ProjectName
     )
 
     $root = Split-Path -Path $ConfigurationPath -Parent
@@ -314,8 +297,7 @@ function ThenPluginsRan
 
         $WithParameter,
 
-        [int]
-        $Times = 1
+        [int]$Times = 1
     )
 
     foreach( $pluginName in @( 'Invoke-PreTaskPlugin', 'Invoke-PostTaskPlugin' ) )
@@ -387,10 +369,8 @@ function ThenTaskRanWithParameter
 {
     param(
         $CommandName,
-        [hashtable]
-        $ExpectedParameter,
-        [int]
-        $Times
+        [hashtable]$ExpectedParameter,
+        [int]$Times
     )
 
     $TimesParam = @{}
@@ -442,8 +422,7 @@ function ThenTaskRanWithoutParameter
 {
     param(
         $CommandName,
-        [string[]]
-        $ParameterName
+        [string[]]$ParameterName
     )
 
     foreach( $name in $ParameterName )
@@ -555,14 +534,11 @@ function WhenRunningTask
 {
     [CmdletBinding()]
     param(
-        [string]
-        $Name,
+        [string]$Name,
 
-        [hashtable]
-        $Parameter,
+        [hashtable]$Parameter,
 
-        [string]
-        $InRunMode
+        [string]$InRunMode
     )
 
     Mock -CommandName 'Invoke-PreTaskPlugin' -ModuleName 'Whiskey'

--- a/Test/LoadTask.Tests.ps1
+++ b/Test/LoadTask.Tests.ps1
@@ -44,8 +44,7 @@ function ThenFile
 {
     param(
         $Name,
-        [Switch]
-        $Exists
+        [switch]$Exists
     )
 
     It ('should create file') {
@@ -57,8 +56,7 @@ function ThenTask
 {
     param(
         $Name,
-        [Switch]
-        $Exists
+        [switch]$Exists
     )
 
     It ('should load task') {
@@ -93,13 +91,11 @@ function script:MyTask
 {
     [Whiskey.Task('Fubar')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter        
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter        
     )
 }
 '@
@@ -119,13 +115,11 @@ function MyTask
 {
     [Whiskey.Task('Fubar')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter        
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter        
     )
 }
 '@
@@ -146,13 +140,11 @@ function script:MyTask
 {
     [Whiskey.Task('Fubar')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter        
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter        
     )
 
     New-Item -Path 'fubar' -ItemType 'File'
@@ -179,13 +171,11 @@ function script:MyTask
 {
     [Whiskey.Task('Fubar')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter        
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter        
     )
 }
 '@

--- a/Test/MSBuild.Tests.ps1
+++ b/Test/MSBuild.Tests.ps1
@@ -38,8 +38,7 @@ function GivenCustomMSBuildScriptWithMultipleTargets
 function GivenAProjectThatCompiles
 {
     param(
-        [string]
-        $ProjectName = 'NUnit2PassingTest'
+        [string]$ProjectName = 'NUnit2PassingTest'
     )
 
     $source = Join-Path -Path $PSScriptRoot -ChildPath ('Assemblies\{0}' -f $ProjectName)
@@ -136,25 +135,19 @@ function WhenRunningTask
 {
     [CmdletBinding()]
     param(
-        [hashtable]
-        $WithParameter = @{},
+        [hashtable]$WithParameter = @{},
 
-        [Parameter(Mandatory=$true,ParameterSetName='AsDeveloper')]
-        [Switch]
-        $AsDeveloper,
+        [Parameter(Mandatory,ParameterSetName='AsDeveloper')]
+        [switch]$AsDeveloper,
 
-        [Parameter(Mandatory=$true,ParameterSetName='AsBuildServer')]
-        [Switch]
-        $AsBuildServer,
+        [Parameter(Mandatory,ParameterSetName='AsBuildServer')]
+        [switch]$AsBuildServer,
 
-        [Switch]
-        $InCleanMode,
+        [switch]$InCleanMode,
 
-        [SemVersion.SemanticVersion]
-        $AtVersion,
+        [SemVersion.SemanticVersion]$AtVersion,
 
-        [Switch]
-        $WithNoPath
+        [switch]$WithNoPath
     )
 
     $optionalParams = @{ }
@@ -218,11 +211,9 @@ function WhenRunningTask
 function ThenAssembliesAreVersioned
 {
     param(
-        [string]
-        $ProductVersion,
+        [string]$ProductVersion,
 
-        [string]
-        $FileVersion
+        [string]$FileVersion
     )
 
     Get-ChildItem -Path (Get-BuildRoot) -Filter $assembly -File -Recurse |
@@ -290,8 +281,7 @@ function ThenOutputNotLogged
 function ThenProjectsCompiled
 {
     param(
-        [string]
-        $To
+        [string]$To
     )
 
     if( $To )
@@ -325,14 +315,11 @@ function ThenProjectsNotCompiled
 function ThenOutput
 {
     param(
-        [string[]]
-        $Contains,
+        [string[]]$Contains,
 
-        [string[]]
-        $DoesNotContain,
+        [string[]]$DoesNotContain,
 
-        [string]
-        $Is
+        [string]$Is
     )
 
     # remove the NuGet output

--- a/Test/MSBuild.Tests.ps1
+++ b/Test/MSBuild.Tests.ps1
@@ -38,7 +38,7 @@ function GivenCustomMSBuildScriptWithMultipleTargets
 function GivenAProjectThatCompiles
 {
     param(
-        [string]$ProjectName = 'NUnit2PassingTest'
+        [String]$ProjectName = 'NUnit2PassingTest'
     )
 
     $source = Join-Path -Path $PSScriptRoot -ChildPath ('Assemblies\{0}' -f $ProjectName)
@@ -211,9 +211,9 @@ function WhenRunningTask
 function ThenAssembliesAreVersioned
 {
     param(
-        [string]$ProductVersion,
+        [String]$ProductVersion,
 
-        [string]$FileVersion
+        [String]$FileVersion
     )
 
     Get-ChildItem -Path (Get-BuildRoot) -Filter $assembly -File -Recurse |
@@ -281,7 +281,7 @@ function ThenOutputNotLogged
 function ThenProjectsCompiled
 {
     param(
-        [string]$To
+        [String]$To
     )
 
     if( $To )
@@ -315,11 +315,11 @@ function ThenProjectsNotCompiled
 function ThenOutput
 {
     param(
-        [string[]]$Contains,
+        [String[]]$Contains,
 
-        [string[]]$DoesNotContain,
+        [String[]]$DoesNotContain,
 
-        [string]$Is
+        [String]$Is
     )
 
     # remove the NuGet output
@@ -647,7 +647,7 @@ Describe 'MSBuild.when customizing version of MSBuild' {
 </Project>
 "@
         $toolsVersionsRegPath = 'hklm:\software\Microsoft\MSBuild\ToolsVersions'
-        $version = Get-ChildItem -Path $toolsVersionsRegPath | Select-Object -ExpandProperty 'Name' | Split-Path -Leaf | Sort-Object -Property { [version]$_ } -Descending | Select -Last 1
+        $version = Get-ChildItem -Path $toolsVersionsRegPath | Select-Object -ExpandProperty 'Name' | Split-Path -Leaf | Sort-Object -Property { [Version]$_ } -Descending | Select -Last 1
         $expectedPath = Get-ItemProperty -Path (Join-Path -Path $toolsVersionsRegPath -ChildPath $version) -Name 'MSBuildToolsPath' | Select-Object -ExpandProperty 'MSBuildToolsPath'
         GivenVersion $version
         WhenRunningTask -AsDeveloper -WithParameter @{ 'NoMaxCpuCountArgument' = $true ; 'NoFileLogger' = $true; }
@@ -668,14 +668,14 @@ Describe 'MSBuild.when customizing version of MSBuild and multiple installs for 
 </Project>
 "@
         $toolsVersionsRegPath = 'hklm:\software\Microsoft\MSBuild\ToolsVersions'
-        $version = Get-ChildItem -Path $toolsVersionsRegPath | Select-Object -ExpandProperty 'Name' | Split-Path -Leaf | Sort-Object -Property { [version]$_ } -Descending | Select -Last 1
+        $version = Get-ChildItem -Path $toolsVersionsRegPath | Select-Object -ExpandProperty 'Name' | Split-Path -Leaf | Sort-Object -Property { [Version]$_ } -Descending | Select -Last 1
         $msbuildRoot = Get-ItemProperty -Path (Join-Path -Path $toolsVersionsRegPath -ChildPath $version) -Name 'MSBuildToolsPath' | Select-Object -ExpandProperty 'MSBuildToolsPath'
         $msbuildPath = Join-Path -Path $msbuildRoot -ChildPath 'MSBuild.exe' -Resolve
         Mock -CommandName 'Get-MSBuild' -ModuleName 'Whiskey' -MockWith {
             1..2 | ForEach-Object {
                 [pscustomobject]@{
                                     Name =  $version;
-                                    Version = [version]$version;
+                                    Version = [Version]$version;
                                     Path = $msbuildPath;
                                     Path32 = $msbuildPath;
                                 }

--- a/Test/MergeFile.Tests.ps1
+++ b/Test/MergeFile.Tests.ps1
@@ -71,7 +71,7 @@ function ThenFile
         [string]$Path,
 
         [Parameter(Mandatory,ParameterSetName='DoesNotExist')]
-        [Switch]$DoesNotExist,
+        [switch]$DoesNotExist,
 
         [Parameter(ParameterSetName='Exists')]
         [switch]$Exists,

--- a/Test/MergeFile.Tests.ps1
+++ b/Test/MergeFile.Tests.ps1
@@ -10,19 +10,19 @@ function GivenFile
 {
     param(
         [Parameter(Mandatory)]
-        [string]$Path,
+        [String]$Path,
 
-        [object]$WithContent
+        [Object]$WithContent
     )
 
     $fullPath = Join-Path -Path $TestDrive.FullName -ChildPath $Path
     if( $WithContent )
     {
-        if( $WithContent -is [string] )
+        if( $WithContent -is [String] )
         {
             [IO.File]::WriteAllText($fullPath,$WithContent)
         }
-        elseif( $WithContent -is [byte[]] )
+        elseif( $WithContent -is [Byte[]] )
         {
             [IO.File]::WriteAllBytes($fullPath,$WithContent)
         }
@@ -40,7 +40,7 @@ function GivenFile
 function Get-RandomByte
 {
     [CmdletBinding()]
-    [OutputType([byte[]])]
+    [OutputType([Byte[]])]
     param(
     )
 
@@ -56,7 +56,7 @@ function ThenFailed
 {
     param(
         [Parameter(Mandatory)]
-        [string]$WithError
+        [String]$WithError
     )
 
     $Global:Error | Should -Not -BeNullOrEmpty
@@ -68,7 +68,7 @@ function ThenFile
     [CmdletBinding(DefaultParameterSetName='Exists')]
     param(
         [Parameter(Mandatory,Position=0)]
-        [string]$Path,
+        [String]$Path,
 
         [Parameter(Mandatory,ParameterSetName='DoesNotExist')]
         [switch]$DoesNotExist,
@@ -77,7 +77,7 @@ function ThenFile
         [switch]$Exists,
 
         [Parameter(ParameterSetName='Exists')]
-        [object]$HasContent
+        [Object]$HasContent
     )
 
     $fullPath = Join-Path -Path $TestDrive.FullName -ChildPath $Path
@@ -86,18 +86,18 @@ function ThenFile
         $fullPath | Should -Exist
         if( $PSBoundParameters.ContainsKey('HasContent') )
         {
-            if( $HasContent -is [string] )
+            if( $HasContent -is [String] )
             {
                 [IO.File]::ReadAllText($fullPath) | Should -Be $HasContent
             }
-            elseif( $HasContent -is [byte[]] )
+            elseif( $HasContent -is [Byte[]] )
             {
-                [byte[]]$content = [IO.File]::ReadAllBytes($fullPath)
+                [Byte[]]$content = [IO.File]::ReadAllBytes($fullPath)
                 $content | Should -Be $HasContent
             }
             else
             {
-                throw ('ThenFile: parameter "HasContent" must be a [string] or [byte[]] but got a [{0}]' -f $HasContent.GetType().FullName)
+                throw ('ThenFile: parameter "HasContent" must be a [String] or [Byte[]] but got a [{0}]' -f $HasContent.GetType().FullName)
             }
         }
     }
@@ -112,20 +112,20 @@ function WhenMerging
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string[]]$Path,
+        [String[]]$Path,
 
         [Parameter(Mandatory)]
-        [string]$Into,
+        [String]$Into,
 
         [switch]$AndDeletingSourceFiles,
 
-        [string]$WithTextSeparator,
+        [String]$WithTextSeparator,
 
-        [byte[]]$WithBinarySeparator,
+        [Byte[]]$WithBinarySeparator,
 
         [switch]$Clear,
 
-        [string[]]$Excluding
+        [String[]]$Excluding
     )
 
     $context = New-WhiskeyTestContext -ForBuildServer
@@ -288,24 +288,24 @@ Describe 'MergeFile.when files are empty' {
 Describe 'MergeFile.when files are binary' {
     It 'should concatenate files' {
         Init
-        [byte[]]$content = Get-RandomByte
+        [Byte[]]$content = Get-RandomByte
         GivenFile 'one.txt' -WithContent $content 
-        [byte[]]$content2 = Get-RandomByte
+        [Byte[]]$content2 = Get-RandomByte
         GivenFile 'two.txt' -WithContent ($content2)
         WhenMerging 'one.txt','two.txt' -Into 'merged.txt'
-        ThenFile 'merged.txt' -HasContent ([byte[]]($content + $content2))
+        ThenFile 'merged.txt' -HasContent ([Byte[]]($content + $content2))
     }
 }
 
 Describe 'MergeFile.when separator and files are binary' {
     It 'should concatenate files with separator' {
         Init
-        [byte[]]$content = Get-RandomByte
+        [Byte[]]$content = Get-RandomByte
         GivenFile 'one.txt' -WithContent $content 
-        [byte[]]$content2 = Get-RandomByte
+        [Byte[]]$content2 = Get-RandomByte
         GivenFile 'two.txt' -WithContent ($content2)
-        WhenMerging 'one.txt','two.txt' -Into 'merged.txt' -WithBinarySeparator ([byte[]]@( 28 ))
-        ThenFile 'merged.txt' -HasContent ([byte[]]($content + 28 + $content2))
+        WhenMerging 'one.txt','two.txt' -Into 'merged.txt' -WithBinarySeparator ([Byte[]]@( 28 ))
+        ThenFile 'merged.txt' -HasContent ([Byte[]]($content + 28 + $content2))
     }
 }
 

--- a/Test/NUnit2.Tests.ps1
+++ b/Test/NUnit2.Tests.ps1
@@ -12,8 +12,7 @@ $latestNUnit2Version = '2.6.4'
 function Assert-NUnitTestsRun
 {
     param(
-        [string]
-        $ReportPath
+        [string]$ReportPath
     )
     $reports = $ReportPath | Split-Path | Get-ChildItem -Filter 'nunit2*.xml'
     $reports | Should -Not -BeNullOrEmpty
@@ -24,8 +23,7 @@ function Assert-NUnitTestsRun
 function Assert-NUnitTestsNotRun
 {
     param(
-        [string]
-        $ReportPath
+        [string]$ReportPath
     )
     $ReportPath | Split-Path | Get-ChildItem -Filter 'nunit2*.xml' | Should -BeNullOrEmpty
 }
@@ -33,8 +31,7 @@ function Assert-NUnitTestsNotRun
 function Assert-OpenCoverRuns
 {
     param(
-        [String]
-        $OpenCoverDirectoryPath
+        [string]$OpenCoverDirectoryPath
     )
     $openCoverFilePath = Join-Path -Path $OpenCoverDirectoryPath -ChildPath 'openCover.xml'
     $reportGeneratorFilePath = Join-Path -Path $OpenCoverDirectoryPath -ChildPath 'index.htm'
@@ -45,8 +42,7 @@ function Assert-OpenCoverRuns
 function Assert-OpenCoverNotRun
 {
     param(
-        [String]
-        $OpenCoverDirectoryPath
+        [string]$OpenCoverDirectoryPath
     )
     $openCoverFilePath = Join-Path -Path $OpenCoverDirectoryPath -ChildPath 'openCover.xml'
     $reportGeneratorFilePath = Join-Path -Path $OpenCoverDirectoryPath -ChildPath 'index.htm'
@@ -59,41 +55,29 @@ function Invoke-NUnitTask
 
     [CmdletBinding()]
     param(
-        [Switch]
-        $ThatFails,
+        [switch]$ThatFails,
 
-        [Switch]
-        $WithNoPath,
+        [switch]$WithNoPath,
 
-        [Switch]
-        $WithInvalidPath,
+        [switch]$WithInvalidPath,
 
-        [Switch]
-        $WhenJoinPathResolveFails,
+        [switch]$WhenJoinPathResolveFails,
 
-        [switch]
-        $WithFailingTests,
+        [switch]$WithFailingTests,
 
-        [switch]
-        $WithRunningTests,
+        [switch]$WithRunningTests,
 
-        [String]
-        $WithError,
+        [string]$WithError,
 
-        [Switch]
-        $WhenRunningClean,
+        [switch]$WhenRunningClean,
 
-        [Switch]
-        $WhenRunningInitialize,
+        [switch]$WhenRunningInitialize,
 
-        [Switch]
-        $WithDisabledCodeCoverage,
+        [switch]$WithDisabledCodeCoverage,
 
-        [String[]]
-        $CoverageFilter,
+        [String[]]$CoverageFilter,
 
-        [ScriptBlock]
-        $MockInstallWhiskeyToolWith
+        [scriptblock]$MockInstallWhiskeyToolWith
     )
 
     process
@@ -285,8 +269,7 @@ function GivenCodeCoverageIsDisabled
 function GivenExclude
 {
     param(
-        [String[]]
-        $Value
+        [String[]]$Value
     )
     $script:exclude = $value
 }
@@ -294,8 +277,7 @@ function GivenExclude
 function GivenInclude
 {
     param(
-        [String[]]
-        $Value
+        [String[]]$Value
     )
     $script:include = $value
 }
@@ -330,8 +312,7 @@ function GivenVersion
 function GivenCoverageFilter
 {
     Param(
-        [String]
-        $Filter
+        [string]$Filter
     )
     $script:CoverageFilter = $Filter
 }
@@ -358,11 +339,9 @@ function Init
 function WhenRunningTask
 {
     param(
-        [hashtable]
-        $WithParameters = @{ },
+        [hashtable]$WithParameters = @{ },
 
-        [Switch]
-        $WhenRunningInitialize
+        [switch]$WhenRunningInitialize
     )
 
     $Global:Error.Clear()
@@ -427,8 +406,7 @@ function Get-TestCaseResult
 {
     [OutputType([System.Xml.XmlElement])]
     param(
-        [string]
-        $TestName
+        [string]$TestName
     )
 
     Get-ChildItem -Path $context.OutputDirectory -Filter 'nunit2*.xml' |
@@ -442,11 +420,9 @@ function Get-TestCaseResult
 function ThenOutput
 {
     param(
-        [string[]]
-        $Contains,
+        [string[]]$Contains,
 
-        [string[]]
-        $DoesNotContain
+        [string[]]$DoesNotContain
     )
 
     foreach( $regex in $Contains )
@@ -463,8 +439,7 @@ function ThenOutput
 function ThenTestsNotRun
 {
     param(
-        [string[]]
-        $TestName
+        [string[]]$TestName
     )
 
     foreach( $name in $TestName )
@@ -476,8 +451,7 @@ function ThenTestsNotRun
 function ThenTestsPassed
 {
     param(
-        [string[]]
-        $TestName
+        [string[]]$TestName
     )
 
     foreach( $name in $TestName )
@@ -496,11 +470,9 @@ function ThenItShouldNotRunTests {
 
 function ThenItInstalled {
     param (
-        [string]
-        $Name,
+        [string]$Name,
 
-        [Version]
-        $Version
+        [Version]$Version
     )
 
     $expectedVersion = $Version

--- a/Test/NUnit2.Tests.ps1
+++ b/Test/NUnit2.Tests.ps1
@@ -12,7 +12,7 @@ $latestNUnit2Version = '2.6.4'
 function Assert-NUnitTestsRun
 {
     param(
-        [string]$ReportPath
+        [String]$ReportPath
     )
     $reports = $ReportPath | Split-Path | Get-ChildItem -Filter 'nunit2*.xml'
     $reports | Should -Not -BeNullOrEmpty
@@ -23,7 +23,7 @@ function Assert-NUnitTestsRun
 function Assert-NUnitTestsNotRun
 {
     param(
-        [string]$ReportPath
+        [String]$ReportPath
     )
     $ReportPath | Split-Path | Get-ChildItem -Filter 'nunit2*.xml' | Should -BeNullOrEmpty
 }
@@ -31,7 +31,7 @@ function Assert-NUnitTestsNotRun
 function Assert-OpenCoverRuns
 {
     param(
-        [string]$OpenCoverDirectoryPath
+        [String]$OpenCoverDirectoryPath
     )
     $openCoverFilePath = Join-Path -Path $OpenCoverDirectoryPath -ChildPath 'openCover.xml'
     $reportGeneratorFilePath = Join-Path -Path $OpenCoverDirectoryPath -ChildPath 'index.htm'
@@ -42,7 +42,7 @@ function Assert-OpenCoverRuns
 function Assert-OpenCoverNotRun
 {
     param(
-        [string]$OpenCoverDirectoryPath
+        [String]$OpenCoverDirectoryPath
     )
     $openCoverFilePath = Join-Path -Path $OpenCoverDirectoryPath -ChildPath 'openCover.xml'
     $reportGeneratorFilePath = Join-Path -Path $OpenCoverDirectoryPath -ChildPath 'index.htm'
@@ -67,7 +67,7 @@ function Invoke-NUnitTask
 
         [switch]$WithRunningTests,
 
-        [string]$WithError,
+        [String]$WithError,
 
         [switch]$WhenRunningClean,
 
@@ -312,7 +312,7 @@ function GivenVersion
 function GivenCoverageFilter
 {
     Param(
-        [string]$Filter
+        [String]$Filter
     )
     $script:CoverageFilter = $Filter
 }
@@ -406,7 +406,7 @@ function Get-TestCaseResult
 {
     [OutputType([System.Xml.XmlElement])]
     param(
-        [string]$TestName
+        [String]$TestName
     )
 
     Get-ChildItem -Path $context.OutputDirectory -Filter 'nunit2*.xml' |
@@ -420,9 +420,9 @@ function Get-TestCaseResult
 function ThenOutput
 {
     param(
-        [string[]]$Contains,
+        [String[]]$Contains,
 
-        [string[]]$DoesNotContain
+        [String[]]$DoesNotContain
     )
 
     foreach( $regex in $Contains )
@@ -439,7 +439,7 @@ function ThenOutput
 function ThenTestsNotRun
 {
     param(
-        [string[]]$TestName
+        [String[]]$TestName
     )
 
     foreach( $name in $TestName )
@@ -451,7 +451,7 @@ function ThenTestsNotRun
 function ThenTestsPassed
 {
     param(
-        [string[]]$TestName
+        [String[]]$TestName
     )
 
     foreach( $name in $TestName )
@@ -470,7 +470,7 @@ function ThenItShouldNotRunTests {
 
 function ThenItInstalled {
     param (
-        [string]$Name,
+        [String]$Name,
 
         [Version]$Version
     )

--- a/Test/NUnit3.Tests.ps1
+++ b/Test/NUnit3.Tests.ps1
@@ -219,8 +219,7 @@ function WhenRunningTask
 {
     [CmdletBinding()]
     param(
-        [Switch]
-        $InCleanMode
+        [switch]$InCleanMode
     )
 
     $taskContext = New-WhiskeyTestContext -ForDeveloper -ForBuildRoot $buildRoot -ForOutputDirectory $outputDirectory

--- a/Test/New-WhiskeyContext.Tests.ps1
+++ b/Test/New-WhiskeyContext.Tests.ps1
@@ -22,7 +22,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
 
             $Environment,
 
-            [Switch] $ByBuildServer,
+            [switch] $ByBuildServer,
 
             [string]$DownloadRoot
         )
@@ -73,18 +73,14 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     function GivenConfiguration
     {
         param(
-            [Switch]
-            $ForBuildServer,
+            [switch]$ForBuildServer,
 
-            [String]
-            $OnBranch = 'develop',
+            [string]$OnBranch = 'develop',
 
-            [string[]]
-            $PublishingOn,
+            [string[]]$PublishingOn,
 
             [Parameter(Position=0)]
-            [Collections.IDictionary]
-            $Configuration,
+            [Collections.IDictionary]$Configuration,
 
             $BuildNumber = '1'
         )
@@ -154,8 +150,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     function ThenSemVer1Is
     {
         param(
-            [SemVersion.SemanticVersion]
-            $SemanticVersion
+            [SemVersion.SemanticVersion]$SemanticVersion
         )
 
         $script:context.Version.SemVer1.ToString() | Should -Be $SemanticVersion.ToString()
@@ -165,8 +160,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     function ThenSemVer2Is
     {
         param(
-            [SemVersion.SemanticVersion]
-            $SemanticVersion
+            [SemVersion.SemanticVersion]$SemanticVersion
         )
         $script:context.Version.SemVer2.ToString() | Should -Be $SemanticVersion.ToString()
         $script:context.Version.SemVer2 | Should -BeOfType ([SemVersion.SemanticVersion])
@@ -175,8 +169,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     function ThenSemVer2NoBuildMetadataIs
     {
         param(
-            [SemVersion.SemanticVersion]
-            $SemanticVersion
+            [SemVersion.SemanticVersion]$SemanticVersion
         )
 
         $script:Context.Version.SemVer2NoBuildMetadata.ToString() | Should -Be $SemanticVersion.ToString()
@@ -186,8 +179,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     function ThenVersionIs
     {
         param(
-            [Version]
-            $ExpectedVersion
+            [Version]$ExpectedVersion
         )
 
         $script:Context.Version.Version.ToString() | Should -Be $expectedVersion.ToString()
@@ -261,8 +253,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     {
         [CmdletBinding()]
         param(
-            [string]
-            $Environment = 'developer',
+            [string]$Environment = 'developer',
 
             $WithDownloadRoot
         )
@@ -291,8 +282,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     {
         [CmdletBinding()]
         param(
-            [string]
-            $Environment = 'developer'
+            [string]$Environment = 'developer'
         )
 
         begin
@@ -344,8 +334,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     function ThenVersionMatches
     {
         param(
-            [string]
-            $Version
+            [string]$Version
         )
 
         $script:context.Version.SemVer2 | Should -Match $Version

--- a/Test/New-WhiskeyContext.Tests.ps1
+++ b/Test/New-WhiskeyContext.Tests.ps1
@@ -8,7 +8,7 @@ $testRoot = $null
 
 InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
 
-    $progetUri = [uri]'https://proget.example.com/'
+    $progetUri = [Uri]'https://proget.example.com/'
     $configurationPath = $null
     $context = $null
     $path = "bad"
@@ -24,7 +24,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
 
             [switch] $ByBuildServer,
 
-            [string]$DownloadRoot
+            [String]$DownloadRoot
         )
 
         $Context.Environment | Should -Be $Environment
@@ -75,9 +75,9 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
         param(
             [switch]$ForBuildServer,
 
-            [string]$OnBranch = 'develop',
+            [String]$OnBranch = 'develop',
 
-            [string[]]$PublishingOn,
+            [String[]]$PublishingOn,
 
             [Parameter(Position=0)]
             [Collections.IDictionary]$Configuration,
@@ -183,18 +183,18 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
         )
 
         $script:Context.Version.Version.ToString() | Should -Be $expectedVersion.ToString()
-        $script:Context.Version.Version | Should -BeOfType ([version])
+        $script:Context.Version.Version | Should -BeOfType ([Version])
     }
 
     function WhenCreatingContext
     {
         [CmdletBinding()]
         param(
-            [string] $Environment = 'developer',
+            [String] $Environment = 'developer',
 
-            [string] $ThenCreationFailsWithErrorMessage,
+            [String] $ThenCreationFailsWithErrorMessage,
 
-            [string]$WithDownloadRoot,
+            [String]$WithDownloadRoot,
 
             [Whiskey.RunBy] $RunBy
         )
@@ -253,7 +253,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     {
         [CmdletBinding()]
         param(
-            [string]$Environment = 'developer',
+            [String]$Environment = 'developer',
 
             $WithDownloadRoot
         )
@@ -282,7 +282,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     {
         [CmdletBinding()]
         param(
-            [string]$Environment = 'developer'
+            [String]$Environment = 'developer'
         )
 
         begin
@@ -334,7 +334,7 @@ InModuleScope -ModuleName 'Whiskey' -ScriptBlock {
     function ThenVersionMatches
     {
         param(
-            [string]$Version
+            [String]$Version
         )
 
         $script:context.Version.SemVer2 | Should -Match $Version

--- a/Test/NodeLicenseChecker.Tests.ps1
+++ b/Test/NodeLicenseChecker.Tests.ps1
@@ -55,7 +55,7 @@ function GivenBadJson
 function GivenDependency 
 {
     param(
-        [object[]]$Dependency 
+        [Object[]]$Dependency 
     )
     $script:dependency = $Dependency
 }
@@ -63,7 +63,7 @@ function GivenDependency
 function GivenDevDependency 
 {
     param(
-        [object[]]$DevDependency 
+        [Object[]]$DevDependency 
     )
     $script:devDependency = $DevDependency
 }

--- a/Test/NodeLicenseChecker.Tests.ps1
+++ b/Test/NodeLicenseChecker.Tests.ps1
@@ -55,8 +55,7 @@ function GivenBadJson
 function GivenDependency 
 {
     param(
-        [object[]]
-        $Dependency 
+        [object[]]$Dependency 
     )
     $script:dependency = $Dependency
 }
@@ -64,8 +63,7 @@ function GivenDependency
 function GivenDevDependency 
 {
     param(
-        [object[]]
-        $DevDependency 
+        [object[]]$DevDependency 
     )
     $script:devDependency = $DevDependency
 }

--- a/Test/Npm.Tests.ps1
+++ b/Test/Npm.Tests.ps1
@@ -9,8 +9,7 @@ $failed = $false
 function Init
 {
     param(
-        [Switch]
-        $SkipInstall
+        [switch]$SkipInstall
     )
 
     $script:failed = $false

--- a/Test/NuGetPack.Tests.ps1
+++ b/Test/NuGetPack.Tests.ps1
@@ -35,11 +35,9 @@ function InitTest
 function GivenABuiltLibrary
 {
     param(
-        [Switch]
-        $ThatDoesNotExist,
+        [switch]$ThatDoesNotExist,
 
-        [Switch]
-        $InReleaseMode
+        [switch]$InReleaseMode
     )
 
     @'
@@ -146,8 +144,7 @@ function GivenRunByBuildServer
 function GivenPath
 {
     param(
-        [string[]]
-        $Path
+        [string[]]$Path
     )
 
     $script:path = $Path
@@ -171,8 +168,7 @@ function WhenRunningNuGetPackTask
 {
     [CmdletBinding()]
     param(
-        [Switch]
-        $Symbols,
+        [switch]$Symbols,
 
         $Property,
 
@@ -291,8 +287,7 @@ function ThenPackageCreated
 
         $Version = $context.Version.SemVer1,
 
-        [Switch]
-        $Symbols
+        [switch]$Symbols
     )
 
     $symbolsPath = Join-Path -Path $Context.OutputDirectory -ChildPath ('{0}.{1}.symbols.nupkg' -f $Name,$Version)

--- a/Test/NuGetPack.Tests.ps1
+++ b/Test/NuGetPack.Tests.ps1
@@ -144,7 +144,7 @@ function GivenRunByBuildServer
 function GivenPath
 {
     param(
-        [string[]]$Path
+        [String[]]$Path
     )
 
     $script:path = $Path

--- a/Test/NuGetPush.Tests.ps1
+++ b/Test/NuGetPush.Tests.ps1
@@ -37,7 +37,7 @@ function Init
 function GivenANuGetPackage
 {
     param(
-        [string[]]
+        [String[]]
         [ValidatePattern('\.\d+\.\d+\.\d+(-.*)?(\.symbols)?\.nupkg')]
         $Path
     )

--- a/Test/NuGetPush.Tests.ps1
+++ b/Test/NuGetPush.Tests.ps1
@@ -107,17 +107,13 @@ function WhenRunningNuGetPackTask
 {
     [CmdletBinding()]
     param(
-        [Switch]
-        $ForProjectThatDoesNotExist,
+        [switch]$ForProjectThatDoesNotExist,
 
-        [Switch]
-        $ForMultiplePackages,
+        [switch]$ForMultiplePackages,
 
-        [Switch]
-        $Symbols,
+        [switch]$Symbols,
 
-        [Switch]
-        $SkipUploadedCheck
+        [switch]$SkipUploadedCheck
     )
 
     $script:context = New-WhiskeyTestContext -ForVersion $packageVersion `

--- a/Test/Parallel.Tests.ps1
+++ b/Test/Parallel.Tests.ps1
@@ -35,7 +35,7 @@ function Init
 function Invoke-ImportWhiskeyYaml
 {
     param(
-        [string]$Yaml
+        [String]$Yaml
     )
 
     Invoke-WhiskeyPrivateCommand -Name 'Import-WhiskeyYaml' -Parameter @{ 'Yaml' = $Yaml }
@@ -136,7 +136,7 @@ Queues:
     - PowerShell:
         Path: two.ps1
 '@
-        [object[]]$result = WhenRunningTask $task -ErrorAction SilentlyContinue
+        [Object[]]$result = WhenRunningTask $task -ErrorAction SilentlyContinue
         ThenFailed
         ThenErrorIs 'Queue\[1\]:\ Property\ "Tasks"\ is\ mandatory'
         $result | Should -BeNullOrEmpty
@@ -199,7 +199,7 @@ Queues:
     - PowerShell:
         Path: two.ps1
 '@
-        [object[]]$output = WhenRunningTask $task #-ErrorAction SilentlyContinue
+        [Object[]]$output = WhenRunningTask $task #-ErrorAction SilentlyContinue
         ThenCompleted
         $output.Count | Should -Be 2
         $output[0] | Should -Be 2
@@ -225,7 +225,7 @@ Queues:
     - PowerShell:
         Path: three.ps1
 '@
-        [object[]]$output = WhenRunningTask $task
+        [Object[]]$output = WhenRunningTask $task
         ThenCompleted
         $output.Count | Should -Be 3
         $output -contains 1 | Should -Be $true
@@ -254,7 +254,7 @@ Describe 'Parallel.when API keys, variables, credentials, and task defaults are 
         Init
         GivenFile 'one.ps1' -Content @'
 param(
-    [object]$TaskContext
+    [Object]$TaskContext
 )
 
 if( $TaskContext.Variables['Fubar'] -ne 'Snafu' )

--- a/Test/Parallel.Tests.ps1
+++ b/Test/Parallel.Tests.ps1
@@ -254,8 +254,7 @@ Describe 'Parallel.when API keys, variables, credentials, and task defaults are 
         Init
         GivenFile 'one.ps1' -Content @'
 param(
-    [object]
-    $TaskContext
+    [object]$TaskContext
 )
 
 if( $TaskContext.Variables['Fubar'] -ne 'Snafu' )

--- a/Test/Pester3.Tests.ps1
+++ b/Test/Pester3.Tests.ps1
@@ -42,7 +42,7 @@ function GivenTestContext
 function GivenVersion
 {
     param(
-        [string]$Version
+        [String]$Version
     )
 
     $taskParameter['Version'] = $Version
@@ -51,8 +51,8 @@ function GivenVersion
 function GivenTestFile
 {
     param(
-        [string]$Path,
-        [string]$Content
+        [String]$Path,
+        [String]$Content
     )
 
     $taskParameter['Path'] = & {
@@ -111,7 +111,7 @@ function WhenPesterTaskIsInvoked
 function ThenPesterShouldBeInstalled
 {
     param(
-        [string]$ExpectedVersion
+        [String]$ExpectedVersion
     )
 
     $pesterDirectoryName = '{0}\Pester\{1}' -f $PSModulesDirectoryName,$ExpectedVersion
@@ -177,7 +177,7 @@ function ThenPesterShouldHaveRun
 function ThenTestShouldFail
 {
     param(
-        [string]$failureMessage
+        [String]$failureMessage
     )
     $Script:failed | Should -BeTrue
     $Global:Error | Where-Object { $_ -match $failureMessage} | Should -Not -BeNullOrEmpty

--- a/Test/Pester3.Tests.ps1
+++ b/Test/Pester3.Tests.ps1
@@ -88,8 +88,7 @@ function WhenPesterTaskIsInvoked
 {
     [CmdletBinding()]
     param(
-        [Switch]
-        $WithClean
+        [switch]$WithClean
     )
 
     $failed = $false
@@ -112,8 +111,7 @@ function WhenPesterTaskIsInvoked
 function ThenPesterShouldBeInstalled
 {
     param(
-        [string]
-        $ExpectedVersion
+        [string]$ExpectedVersion
     )
 
     $pesterDirectoryName = '{0}\Pester\{1}' -f $PSModulesDirectoryName,$ExpectedVersion
@@ -130,13 +128,11 @@ function ThenPesterShouldBeInstalled
 function ThenPesterShouldHaveRun
 {
     param(
-        [Parameter(Mandatory=$true)]
-        [int]
-        $FailureCount,
+        [Parameter(Mandatory)]
+        [int]$FailureCount,
             
-        [Parameter(Mandatory=$true)]
-        [int]
-        $PassingCount
+        [Parameter(Mandatory)]
+        [int]$PassingCount
     )
     $reportsIn =  $script:context.outputDirectory
     $testReports = Get-ChildItem -Path $reportsIn -Filter 'pester+*.xml' |
@@ -181,8 +177,7 @@ function ThenPesterShouldHaveRun
 function ThenTestShouldFail
 {
     param(
-        [string]
-        $failureMessage
+        [string]$failureMessage
     )
     $Script:failed | Should -BeTrue
     $Global:Error | Where-Object { $_ -match $failureMessage} | Should -Not -BeNullOrEmpty

--- a/Test/Pester4.Tests.ps1
+++ b/Test/Pester4.Tests.ps1
@@ -67,8 +67,7 @@ function GivenExclude
 function GivenVersion
 {
     param(
-        [string]
-        $Version
+        [string]$Version
     )
     $Script:taskParameter['Version'] = $Version
 }
@@ -107,7 +106,7 @@ function WhenPesterTaskIsInvoked
 {
     [CmdletBinding()]
     param(
-        [Switch]$WithClean,
+        [switch]$WithClean,
 
         [switch]$CaptureOutput
     )
@@ -184,13 +183,11 @@ function ThenItDurationReportHasRows
 function ThenPesterShouldHaveRun
 {
     param(
-        [Parameter(Mandatory=$true)]
-        [int]
-        $FailureCount,
+        [Parameter(Mandatory)]
+        [int]$FailureCount,
             
-        [Parameter(Mandatory=$true)]
-        [int]
-        $PassingCount
+        [Parameter(Mandatory)]
+        [int]$PassingCount
     )
     $reportsIn =  $script:context.outputDirectory
     $testReports = Get-ChildItem -Path $reportsIn -Filter 'pester+*.xml' |
@@ -240,8 +237,7 @@ function ThenPesterShouldHaveRun
 function ThenTestShouldFail
 {
     param(
-        [string]
-        $failureMessage
+        [string]$failureMessage
     )
     $Script:failed | Should -BeTrue
     $Global:Error | Where-Object { $_ -match $failureMessage} | Should -Not -BeNullOrEmpty

--- a/Test/Pester4.Tests.ps1
+++ b/Test/Pester4.Tests.ps1
@@ -67,7 +67,7 @@ function GivenExclude
 function GivenVersion
 {
     param(
-        [string]$Version
+        [String]$Version
     )
     $Script:taskParameter['Version'] = $Version
 }
@@ -84,8 +84,8 @@ function GivenInvalidVersion
 function GivenTestFile
 {
     param(
-        [string]$Path,
-        [string]$Content
+        [String]$Path,
+        [String]$Content
     )
 
     $taskParameter['Path'] = & {
@@ -237,7 +237,7 @@ function ThenPesterShouldHaveRun
 function ThenTestShouldFail
 {
     param(
-        [string]$failureMessage
+        [String]$failureMessage
     )
     $Script:failed | Should -BeTrue
     $Global:Error | Where-Object { $_ -match $failureMessage} | Should -Not -BeNullOrEmpty

--- a/Test/Pipeline.Tests.ps1
+++ b/Test/Pipeline.Tests.ps1
@@ -16,12 +16,10 @@ function GivenFile
 {
     param(
         [Parameter(Mandatory)]
-        [string]
-        $Name,
+        [string]$Name,
 
         [Parameter(Mandatory)]
-        [string]
-        $Content
+        [string]$Content
     )
 
     $path = Join-Path -Path $TestDrive.FullName -ChildPath $Name
@@ -31,42 +29,35 @@ function GivenFile
 function Invoke-PreTaskPlugin
 {
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [object]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $TaskName,
+        [Parameter(Mandatory)]
+        [string]$TaskName,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 }
 
 function Invoke-PostTaskPlugin
 {
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [object]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $TaskName,
+        [Parameter(Mandatory)]
+        [string]$TaskName,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 }
 
 function GivenPlugins
 {
     param(
-        [string]
-        $ForSpecificTask
+        [string]$ForSpecificTask
     )
 
     $taskNameParam = @{ }
@@ -85,8 +76,7 @@ function GivenWhiskeyYmlBuildFile
 {
     param(
         [Parameter(Position=0)]
-        [string]
-        $Yaml
+        [string]$Yaml
     )
 
     $config = $null
@@ -100,19 +90,15 @@ function ThenFile
 {
     param(
         [Parameter(Mandatory)]
-        [string]
-        $Named,
+        [string]$Named,
 
-        [Switch]
-        $Not,
+        [switch]$Not,
 
         [Parameter(Mandatory)]
-        [Switch]
-        $Exists,
+        [switch]$Exists,
 
         [Parameter(Mandatory)]
-        [string]
-        $Because
+        [string]$Because
     )
 
     Join-Path -Path $TestDrive.FullName -ChildPath $Named | Should -Not:$Not -Exist
@@ -136,11 +122,9 @@ function ThenPipelineSucceeded
 function ThenDotNetProjectsCompilationFailed
 {
     param(
-        [string]
-        $ConfigurationPath,
+        [string]$ConfigurationPath,
 
-        [string[]]
-        $ProjectName
+        [string[]]$ProjectName
     )
 
     $root = Split-Path -Path $ConfigurationPath -Parent
@@ -166,8 +150,7 @@ function ThenPluginsRan
 
         $WithParameter,
 
-        [int]
-        $Times = 1
+        [int]$Times = 1
     )
 
     foreach( $pluginName in @( 'Invoke-PreTaskPlugin', 'Invoke-PostTaskPlugin' ) )
@@ -228,8 +211,7 @@ function WhenRunningPipeline
 {
     [CmdletBinding()]
     param(
-        [string]
-        $Name
+        [string]$Name
     )
 
     $environment = $PSCmdlet.ParameterSetName

--- a/Test/Pipeline.Tests.ps1
+++ b/Test/Pipeline.Tests.ps1
@@ -16,10 +16,10 @@ function GivenFile
 {
     param(
         [Parameter(Mandatory)]
-        [string]$Name,
+        [String]$Name,
 
         [Parameter(Mandatory)]
-        [string]$Content
+        [String]$Content
     )
 
     $path = Join-Path -Path $TestDrive.FullName -ChildPath $Name
@@ -30,10 +30,10 @@ function Invoke-PreTaskPlugin
 {
     param(
         [Parameter(Mandatory)]
-        [object]$TaskContext,
+        [Object]$TaskContext,
 
         [Parameter(Mandatory)]
-        [string]$TaskName,
+        [String]$TaskName,
 
         [Parameter(Mandatory)]
         [hashtable]$TaskParameter
@@ -44,10 +44,10 @@ function Invoke-PostTaskPlugin
 {
     param(
         [Parameter(Mandatory)]
-        [object]$TaskContext,
+        [Object]$TaskContext,
 
         [Parameter(Mandatory)]
-        [string]$TaskName,
+        [String]$TaskName,
 
         [Parameter(Mandatory)]
         [hashtable]$TaskParameter
@@ -57,7 +57,7 @@ function Invoke-PostTaskPlugin
 function GivenPlugins
 {
     param(
-        [string]$ForSpecificTask
+        [String]$ForSpecificTask
     )
 
     $taskNameParam = @{ }
@@ -76,7 +76,7 @@ function GivenWhiskeyYmlBuildFile
 {
     param(
         [Parameter(Position=0)]
-        [string]$Yaml
+        [String]$Yaml
     )
 
     $config = $null
@@ -90,7 +90,7 @@ function ThenFile
 {
     param(
         [Parameter(Mandatory)]
-        [string]$Named,
+        [String]$Named,
 
         [switch]$Not,
 
@@ -98,7 +98,7 @@ function ThenFile
         [switch]$Exists,
 
         [Parameter(Mandatory)]
-        [string]$Because
+        [String]$Because
     )
 
     Join-Path -Path $TestDrive.FullName -ChildPath $Named | Should -Not:$Not -Exist
@@ -122,9 +122,9 @@ function ThenPipelineSucceeded
 function ThenDotNetProjectsCompilationFailed
 {
     param(
-        [string]$ConfigurationPath,
+        [String]$ConfigurationPath,
 
-        [string[]]$ProjectName
+        [String[]]$ProjectName
     )
 
     $root = Split-Path -Path $ConfigurationPath -Parent
@@ -211,7 +211,7 @@ function WhenRunningPipeline
 {
     [CmdletBinding()]
     param(
-        [string]$Name
+        [String]$Name
     )
 
     $environment = $PSCmdlet.ParameterSetName

--- a/Test/PowerShell.Tests.ps1
+++ b/Test/PowerShell.Tests.ps1
@@ -33,9 +33,9 @@ function GivenAScript
 {
     param(
         [Parameter(Position=0)]
-        [string]$Script,
+        [String]$Script,
 
-        [string]$WithParam = 'param([Parameter(Mandatory)][object]$TaskContext)'
+        [String]$WithParam = 'param([Parameter(Mandatory)][Object]$TaskContext)'
     )
 
     $script:scriptName = 'myscript.ps1'
@@ -67,7 +67,7 @@ function GivenNoWorkingDirectory
 function GivenWorkingDirectory
 {
     param(
-        [string]$Path,
+        [String]$Path,
 
         [switch]$ThatDoesNotExist
     )
@@ -147,7 +147,7 @@ function WhenTheTaskRuns
 {
     [CmdletBinding()]
     param(
-        [object]$WithArgument,
+        [Object]$WithArgument,
 
         [switch]$InCleanMode,
 
@@ -358,12 +358,12 @@ $(
         }
     }
 
-    if( `$TaskContext.Version -is [string] )
+    if( `$TaskContext.Version -is [String] )
     {
         throw ('TaskContext.Version is a string instead of a [Whiskey.BuildVersion].')
     }
 
-    if( `$TaskContext.BuildMetadata -is [string] )
+    if( `$TaskContext.BuildMetadata -is [String] )
     {
         throw ('TaskContext.BuildMetadata is a string instead of a [Whiskey.BuildInfo].')
     }

--- a/Test/PowerShell.Tests.ps1
+++ b/Test/PowerShell.Tests.ps1
@@ -33,11 +33,9 @@ function GivenAScript
 {
     param(
         [Parameter(Position=0)]
-        [string]
-        $Script,
+        [string]$Script,
 
-        [string]
-        $WithParam = 'param([Parameter(Mandatory=$true)][object]$TaskContext)'
+        [string]$WithParam = 'param([Parameter(Mandatory)][object]$TaskContext)'
     )
 
     $script:scriptName = 'myscript.ps1'
@@ -69,11 +67,9 @@ function GivenNoWorkingDirectory
 function GivenWorkingDirectory
 {
     param(
-        [string]
-        $Path,
+        [string]$Path,
 
-        [Switch]
-        $ThatDoesNotExist
+        [switch]$ThatDoesNotExist
     )
 
     $script:workingDirectory = $Path
@@ -151,14 +147,11 @@ function WhenTheTaskRuns
 {
     [CmdletBinding()]
     param(
-        [object]
-        $WithArgument,
+        [object]$WithArgument,
 
-        [Switch]
-        $InCleanMode,
+        [switch]$InCleanMode,
 
-        [Switch]
-        $InInitMode
+        [switch]$InInitMode
     )
 
     $taskParameter = @{
@@ -390,11 +383,9 @@ if( -not `$SomeBool -or `$SomeOtherBool )
 }
 "@ -WithParam @"
 param(
-    [Switch]
-    `$SomeBool,
+    [switch]`$SomeBool,
 
-    [Switch]
-    `$SomeOtherBool
+    [switch]`$SomeOtherBool
 )
 "@
         WhenTheTaskRuns -WithArgument @{ 'SomeBool' = 'true' ; 'SomeOtherBool' = 'false' }

--- a/Test/ProGetUniversalPackage.Tests.ps1
+++ b/Test/ProGetUniversalPackage.Tests.ps1
@@ -83,7 +83,7 @@ function Reset
 function ThenTaskFails
 {
     Param(
-        [string]$error
+        [String]$error
     )
 
     $Global:Error | Should -Match $error
@@ -108,17 +108,17 @@ function ThenVersionIs
     $versionJsonPath = Join-Path -Path $expandPath -ChildPath 'package\version.json'
 
     $versionJson = Get-Content -Path $versionJsonPath -Raw | ConvertFrom-Json
-    $versionJson.Version | Should -BeOfType ([string])
+    $versionJson.Version | Should -BeOfType ([String])
     $versionJson.Version | Should -Be $Version
-    $versionJson.PrereleaseMetadata | Should -BeOfType ([string])
+    $versionJson.PrereleaseMetadata | Should -BeOfType ([String])
     $versionJson.PrereleaseMetadata | Should -Be $PrereleaseMetadata
-    $versionJson.BuildMetadata | Should -BeOfType ([string])
+    $versionJson.BuildMetadata | Should -BeOfType ([String])
     $versionJson.BuildMetadata | Should -Be $BuildMetadata
-    $versionJson.SemVer2 | Should -BeOfType ([string])
+    $versionJson.SemVer2 | Should -BeOfType ([String])
     $versionJson.SemVer2 | Should -Be $SemVer2
-    $versionJson.SemVer1 | Should -BeOfType ([string])
+    $versionJson.SemVer1 | Should -BeOfType ([String])
     $versionJson.SemVer1 | Should -Be $SemVer1
-    $versionJson.SemVer2NoBuildMetadata | Should -BeOfType ([string])
+    $versionJson.SemVer2NoBuildMetadata | Should -BeOfType ([String])
     $versionJson.SemVer2NoBuildMetadata | Should -Be $SemVer2NoBuildMetadata
 }
 
@@ -126,39 +126,39 @@ function Assert-NewWhiskeyProGetUniversalPackage
 {
     [CmdletBinding()]
     param(
-        [object[]]$ForPath,
+        [Object[]]$ForPath,
 
-        [string[]]$ThatIncludes,
+        [String[]]$ThatIncludes,
 
-        [string[]]$ThatExcludes,
+        [String[]]$ThatExcludes,
 
-        [string]$Name = $defaultPackageName,
+        [String]$Name = $defaultPackageName,
 
-        [string]$Description = $defaultDescription,
+        [String]$Description = $defaultDescription,
 
-        [string]$Version,
+        [String]$Version,
 
-        [string[]]$HasRootItems,
+        [String[]]$HasRootItems,
 
-        [string[]]$HasFiles,
+        [String[]]$HasFiles,
 
-        [string[]]$NotHasFiles,
+        [String[]]$NotHasFiles,
 
-        [string]$ShouldFailWithErrorMessage,
+        [String]$ShouldFailWithErrorMessage,
 
         [switch]$ShouldWriteNoErrors,
 
         [switch]$ShouldReturnNothing,
 
-        [string[]]$HasThirdPartyRootItem,
+        [String[]]$HasThirdPartyRootItem,
 
-        [object[]]$WithThirdPartyRootItem,
+        [Object[]]$WithThirdPartyRootItem,
 
-        [string[]]$HasThirdPartyFile,
+        [String[]]$HasThirdPartyFile,
 
-        [string]$FromSourceRoot,
+        [String]$FromSourceRoot,
 
-        [string[]]$MissingRootItems,
+        [String[]]$MissingRootItems,
 
         [switch]$WhenCleaning,
 
@@ -199,7 +199,7 @@ function Assert-NewWhiskeyProGetUniversalPackage
 
     $semVer2 = [SemVersion.SemanticVersion]$Version
     $taskContext.Version.SemVer2 = $semVer2
-    $taskContext.Version.Version = [version]('{0}.{1}.{2}' -f $taskContext.Version.SemVer2.Major,$taskContext.Version.SemVer2.Minor,$taskContext.Version.SemVer2.Patch)
+    $taskContext.Version.Version = [Version]('{0}.{1}.{2}' -f $taskContext.Version.SemVer2.Major,$taskContext.Version.SemVer2.Minor,$taskContext.Version.SemVer2.Patch)
     $taskContext.Version.SemVer2NoBuildMetadata = [SemVersion.SemanticVersion]('{0}.{1}.{2}' -f $semVer2.Major,$semVer2.Minor,$semVer2.Patch)
     if( $taskContext.Version.SemVer2.Prerelease )
     {
@@ -297,17 +297,17 @@ function Assert-NewWhiskeyProGetUniversalPackage
     $versionJsonPath | Should -Exist
 
     $versionJson = Get-Content -Path $versionJsonPath -Raw | ConvertFrom-Json
-    $versionJson.Version | Should -BeOfType ([string])
+    $versionJson.Version | Should -BeOfType ([String])
     $versionJson.Version | Should -Be $taskContext.Version.Version.ToString()
-    $versionJson.PrereleaseMetadata | Should -BeOfType ([string])
+    $versionJson.PrereleaseMetadata | Should -BeOfType ([String])
     $versionJson.PrereleaseMetadata | Should -Be $taskContext.Version.SemVer2.Prerelease.ToString()
-    $versionJson.BuildMetadata | Should -BeOfType ([string])
+    $versionJson.BuildMetadata | Should -BeOfType ([String])
     $versionJson.BuildMetadata | Should -Be $taskContext.Version.SemVer2.Build.ToString()
-    $versionJson.SemVer2 | Should -BeOfType ([string])
+    $versionJson.SemVer2 | Should -BeOfType ([String])
     $versionJson.SemVer2 | Should -Be $taskContext.Version.SemVer2.ToString()
-    $versionJson.SemVer1 | Should -BeOfType ([string])
+    $versionJson.SemVer1 | Should -BeOfType ([String])
     $versionJson.SemVer1 | Should -Be $taskContext.Version.SemVer1.ToString()
-    $versionJson.SemVer2NoBuildMetadata | Should -BeOfType ([string])
+    $versionJson.SemVer2NoBuildMetadata | Should -BeOfType ([String])
     $versionJson.SemVer2NoBuildMetadata | Should -Be $taskContext.Version.SemVer2NoBuildMetadata.ToString()
 
     if( $NotHasFiles )
@@ -342,11 +342,11 @@ function Assert-NewWhiskeyProGetUniversalPackage
 function Initialize-Test
 {
     param(
-        [string[]]$DirectoryName,
+        [String[]]$DirectoryName,
 
-        [string[]]$FileName,
+        [String[]]$FileName,
 
-        [string[]]$RootFileName,
+        [String[]]$RootFileName,
 
         [switch]$WhenUploadFails,
 
@@ -364,7 +364,7 @@ function Initialize-Test
 
         [switch]$OnBugFixBranch,
 
-        [string]$SourceRoot
+        [String]$SourceRoot
     )
 
     $repoRoot = Get-BuildRoot
@@ -416,7 +416,7 @@ function Get-BuildRoot
 function GivenARepositoryWithItems
 {
     param(
-        [string[]]$Path,
+        [String[]]$Path,
 
         $ItemType = 'File'
     )
@@ -439,9 +439,9 @@ function GivenARepositoryWithItems
 function ThenPackageArchive
 {
     param(
-        [string]$PackageName,
+        [String]$PackageName,
 
-        [string[]]$ContainsPath
+        [String[]]$ContainsPath
     )
 
     $outputRoot = Join-Path -Path (Get-BuildRoot) -ChildPath '.output'
@@ -468,7 +468,7 @@ function ThenPackageShouldInclude
         $PackageName = $defaultPackageName,
         $PackageVersion = $defaultVersion,
         [Parameter(Position=0)]
-        [string[]]$Path
+        [String[]]$Path
     )
 
     $Path += @( 'version.json' )
@@ -483,7 +483,7 @@ function ThenPackageShouldInclude
 function ThenPackageShouldNotInclude
 {
     param(
-        [string[]]$Path
+        [String[]]$Path
     )
 
     $packageRoot = Join-Path -Path $expandPath -ChildPath 'package'
@@ -575,7 +575,7 @@ function ThenPackageShouldBeCompressed
         $PackageName = $defaultPackageName,
         $PackageVersion = $defaultVersion,
         [Parameter(Position=0)]
-        [string[]]$Path,
+        [String[]]$Path,
 
         [int]$GreaterThan,
 
@@ -608,19 +608,19 @@ function WhenPackaging
         $WithDescription = $defaultDescription,
 
         [Parameter(ParameterSetName='WithTaskParameter')]
-        [object[]]$Paths,
+        [Object[]]$Paths,
 
         [Parameter(ParameterSetName='WithTaskParameter')]
-        [object[]]$WithWhitelist,
+        [Object[]]$WithWhitelist,
 
         [Parameter(ParameterSetName='WithTaskParameter')]
-        [object[]]$ThatExcludes,
+        [Object[]]$ThatExcludes,
 
         [Parameter(ParameterSetName='WithTaskParameter')]
         $FromSourceRoot,
 
         [Parameter(ParameterSetName='WithTaskParameter')]
-        [object[]]$WithThirdPartyPath,
+        [Object[]]$WithThirdPartyPath,
 
         [Parameter(ParameterSetName='WithTaskParameter')]
         $WithVersion = $defaultVersion,

--- a/Test/ProGetUniversalPackage.Tests.ps1
+++ b/Test/ProGetUniversalPackage.Tests.ps1
@@ -34,8 +34,7 @@ function Get-PackageSize
 function GivenBuildVersion
 {
     param(
-        [SemVersion.SemanticVersion]
-        $Version
+        [SemVersion.SemanticVersion]$Version
     )
 
     $script:buildVersion = Invoke-WhiskeyPrivateCommand -Name 'New-WhiskeyVersionObject'
@@ -57,8 +56,7 @@ function GivenPackageVersion
 function GivenManifestProperties
 {
     param(
-        [hashtable]
-        $Content
+        [hashtable]$Content
     )
     $script:manifestProperties = $Content
 }
@@ -85,8 +83,7 @@ function Reset
 function ThenTaskFails
 {
     Param(
-        [String]
-        $error
+        [string]$error
     )
 
     $Global:Error | Should -Match $error
@@ -149,9 +146,9 @@ function Assert-NewWhiskeyProGetUniversalPackage
 
         [string]$ShouldFailWithErrorMessage,
 
-        [Switch]$ShouldWriteNoErrors,
+        [switch]$ShouldWriteNoErrors,
 
-        [Switch]$ShouldReturnNothing,
+        [switch]$ShouldReturnNothing,
 
         [string[]]$HasThirdPartyRootItem,
 
@@ -163,9 +160,9 @@ function Assert-NewWhiskeyProGetUniversalPackage
 
         [string[]]$MissingRootItems,
 
-        [Switch]$WhenCleaning,
+        [switch]$WhenCleaning,
 
-        [Switch]$withInitialize
+        [switch]$withInitialize
     )
 
     if( -not $Version )
@@ -351,21 +348,21 @@ function Initialize-Test
 
         [string[]]$RootFileName,
 
-        [Switch]$WhenUploadFails,
+        [switch]$WhenUploadFails,
 
-        [Switch]$OnFeatureBranch,
+        [switch]$OnFeatureBranch,
 
-        [Switch]$OnMasterBranch,
+        [switch]$OnMasterBranch,
 
-        [Switch]$OnReleaseBranch,
+        [switch]$OnReleaseBranch,
 
-        [Switch]$OnPermanentReleaseBranch,
+        [switch]$OnPermanentReleaseBranch,
 
-        [Switch]$OnDevelopBranch,
+        [switch]$OnDevelopBranch,
 
-        [Switch]$OnHotFixBranch,
+        [switch]$OnHotFixBranch,
 
-        [Switch]$OnBugFixBranch,
+        [switch]$OnBugFixBranch,
 
         [string]$SourceRoot
     )
@@ -419,8 +416,7 @@ function Get-BuildRoot
 function GivenARepositoryWithItems
 {
     param(
-        [string[]]
-        $Path,
+        [string[]]$Path,
 
         $ItemType = 'File'
     )
@@ -443,11 +439,9 @@ function GivenARepositoryWithItems
 function ThenPackageArchive
 {
     param(
-        [string]
-        $PackageName,
+        [string]$PackageName,
 
-        [string[]]
-        $ContainsPath
+        [string[]]$ContainsPath
     )
 
     $outputRoot = Join-Path -Path (Get-BuildRoot) -ChildPath '.output'
@@ -474,8 +468,7 @@ function ThenPackageShouldInclude
         $PackageName = $defaultPackageName,
         $PackageVersion = $defaultVersion,
         [Parameter(Position=0)]
-        [string[]]
-        $Path
+        [string[]]$Path
     )
 
     $Path += @( 'version.json' )
@@ -490,8 +483,7 @@ function ThenPackageShouldInclude
 function ThenPackageShouldNotInclude
 {
     param(
-        [string[]]
-        $Path
+        [string[]]$Path
     )
 
     $packageRoot = Join-Path -Path $expandPath -ChildPath 'package'
@@ -505,18 +497,15 @@ function ThenPackageShouldNotInclude
 function ThenUpackMetadataIs
 {
     param(
-        [hashtable]
-        $ExpectedContent
+        [hashtable]$ExpectedContent
     )
 
     function Assert-HashTableEqual
     {
         param(
-            [hashtable]
-            $Reference,
+            [hashtable]$Reference,
 
-            [hashtable]
-            $Difference
+            [hashtable]$Difference
         )
 
         # $DebugPreference = 'Continue'
@@ -586,14 +575,11 @@ function ThenPackageShouldBeCompressed
         $PackageName = $defaultPackageName,
         $PackageVersion = $defaultVersion,
         [Parameter(Position=0)]
-        [string[]]
-        $Path,
+        [string[]]$Path,
 
-        [Int]
-        $GreaterThan,
+        [int]$GreaterThan,
 
-        [int]
-        $LessThanOrEqualTo
+        [int]$LessThanOrEqualTo
     )
 
     $packageSize = Get-PackageSize -PackageName $PackageName -PackageVersion $PackageVersion
@@ -622,23 +608,19 @@ function WhenPackaging
         $WithDescription = $defaultDescription,
 
         [Parameter(ParameterSetName='WithTaskParameter')]
-        [object[]]
-        $Paths,
+        [object[]]$Paths,
 
         [Parameter(ParameterSetName='WithTaskParameter')]
-        [object[]]
-        $WithWhitelist,
+        [object[]]$WithWhitelist,
 
         [Parameter(ParameterSetName='WithTaskParameter')]
-        [object[]]
-        $ThatExcludes,
+        [object[]]$ThatExcludes,
 
         [Parameter(ParameterSetName='WithTaskParameter')]
         $FromSourceRoot,
 
         [Parameter(ParameterSetName='WithTaskParameter')]
-        [object[]]
-        $WithThirdPartyPath,
+        [object[]]$WithThirdPartyPath,
 
         [Parameter(ParameterSetName='WithTaskParameter')]
         $WithVersion = $defaultVersion,
@@ -650,8 +632,7 @@ function WhenPackaging
         $CompressionLevel,
 
         [Parameter(ParameterSetName='WithTaskParameter')]
-        [Switch]
-        $SkipExpand,
+        [switch]$SkipExpand,
 
         [Parameter(Mandatory,ParameterSetName='WithYaml')]
         $WithYaml

--- a/Test/PublishBitbucketServerTag.Tests.ps1
+++ b/Test/PublishBitbucketServerTag.Tests.ps1
@@ -225,7 +225,7 @@ function ThenTheCommitShouldBeTagged
 function ThenTheCommitShouldNotBeTagged
 {
     param(
-        [string]$WithError
+        [String]$WithError
     )
 
     Assert-MockCalled -CommandName 'New-BBServerTag' -ModuleName 'Whiskey' -Times 0

--- a/Test/PublishBitbucketServerTag.Tests.ps1
+++ b/Test/PublishBitbucketServerTag.Tests.ps1
@@ -18,8 +18,7 @@ $gitUri = $null
 function GivenACommit
 {
     param(
-        [Switch]
-        $ThatIsInvalid
+        [switch]$ThatIsInvalid
     )
 
     if( -not $ThatIsInvalid )
@@ -116,8 +115,7 @@ function WhenTaggingACommit
 {
     [CmdletBinding()]
     param(
-        [Switch]
-        $ThatWillFail
+        [switch]$ThatWillFail
     )
 
     $script:context = New-WhiskeyTestContext -ForTaskName 'PublishBitbucketServerTag' `
@@ -190,22 +188,22 @@ function ThenTaskSucceeds
 function ThenTheCommitShouldBeTagged
 {
     param(
-        [Parameter(Mandatory=$true,Position=0)]
+        [Parameter(Mandatory,Position=0)]
         $Tag,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         $InProject,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         $InRepository,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         $AtUri,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         $AsUser,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         $WithPassword
     )
 
@@ -227,8 +225,7 @@ function ThenTheCommitShouldBeTagged
 function ThenTheCommitShouldNotBeTagged
 {
     param(
-        [String]
-        $WithError
+        [string]$WithError
     )
 
     Assert-MockCalled -CommandName 'New-BBServerTag' -ModuleName 'Whiskey' -Times 0

--- a/Test/PublishBuildMasterPackage.Tests.ps1
+++ b/Test/PublishBuildMasterPackage.Tests.ps1
@@ -52,9 +52,9 @@ function GivenNoRelease
 {
     param(
         [Parameter(Mandatory,Position=0)]
-        [string]$Name,
+        [String]$Name,
         [Parameter(Mandatory)]
-        [string]$ForApplication
+        [String]$ForApplication
     )
 
     $script:appName = $ForApplication
@@ -217,19 +217,19 @@ function ThenCreatedPackage
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,Position=0)]
-        [string]$Name,
+        [String]$Name,
 
         [Parameter(Mandatory)]
-        [string]$InRelease,
+        [String]$InRelease,
 
         [Parameter(Mandatory)]
-        [string]$ForApplication,
+        [String]$ForApplication,
 
         [Parameter(Mandatory)]
-        [string]$AtUri,
+        [String]$AtUri,
 
         [Parameter(Mandatory)]
-        [string]$UsingApiKey,
+        [String]$UsingApiKey,
 
         [Parameter(Mandatory)]
         [hashtable]$WithVariables
@@ -263,12 +263,12 @@ function ThenPackageDeployed
 {
     param(
         [Parameter(Mandatory)]
-        [string]$AtUri,
+        [String]$AtUri,
 
         [Parameter(Mandatory)]
-        [string]$UsingApiKey,
+        [String]$UsingApiKey,
         
-        [string]$AtStage
+        [String]$AtStage
     )
     
     if( $AtStage )

--- a/Test/PublishBuildMasterPackage.Tests.ps1
+++ b/Test/PublishBuildMasterPackage.Tests.ps1
@@ -51,12 +51,10 @@ function GivenNoReleaseName
 function GivenNoRelease
 {
     param(
-        [Parameter(Mandatory=$true,Position=0)]
-        [string]
-        $Name,
-        [Parameter(Mandatory=$true)]
-        [string]
-        $ForApplication
+        [Parameter(Mandatory,Position=0)]
+        [string]$Name,
+        [Parameter(Mandatory)]
+        [string]$ForApplication
     )
 
     $script:appName = $ForApplication
@@ -71,7 +69,7 @@ function GivenNoUri
 function GivenProperty
 {
     param(
-        [Parameter(Mandatory=$true,Position=0)]
+        [Parameter(Mandatory,Position=0)]
         $Property
     )
 
@@ -81,7 +79,7 @@ function GivenProperty
 function GivenPackageName
 {
     param(
-        [Parameter(Mandatory=$true,Position=0)]
+        [Parameter(Mandatory,Position=0)]
         $Name
     )
     
@@ -91,7 +89,7 @@ function GivenPackageName
 function GivenStartAtStage
 {
     param(
-        [Parameter(Mandatory=$true,Position=0)]
+        [Parameter(Mandatory,Position=0)]
         $Stage
     )
     
@@ -218,29 +216,23 @@ function ThenCreatedPackage
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true,Position=0)]
-        [string]
-        $Name,
+        [Parameter(Mandatory,Position=0)]
+        [string]$Name,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $InRelease,
+        [Parameter(Mandatory)]
+        [string]$InRelease,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $ForApplication,
+        [Parameter(Mandatory)]
+        [string]$ForApplication,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $AtUri,
+        [Parameter(Mandatory)]
+        [string]$AtUri,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $UsingApiKey,
+        [Parameter(Mandatory)]
+        [string]$UsingApiKey,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $WithVariables
+        [Parameter(Mandatory)]
+        [hashtable]$WithVariables
     )
 
     Assert-MockCalled -CommandName 'New-BMPackage' -ModuleName 'Whiskey' -ParameterFilter { $PackageNumber -eq $Name }
@@ -270,16 +262,13 @@ function ThenCreatedPackage
 function ThenPackageDeployed
 {
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
-        $AtUri,
+        [Parameter(Mandatory)]
+        [string]$AtUri,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $UsingApiKey,
+        [Parameter(Mandatory)]
+        [string]$UsingApiKey,
         
-        [string]
-        $AtStage
+        [string]$AtStage
     )
     
     if( $AtStage )

--- a/Test/PublishNodeModule.Tests.ps1
+++ b/Test/PublishNodeModule.Tests.ps1
@@ -121,8 +121,8 @@ function ThenNpmPackagesPruned
 function ThenNpmrcCreated
 {
     param(
-        [string]$WithEmail,
-        [uri]$WithRegistry
+        [String]$WithEmail,
+        [Uri]$WithRegistry
     )
 
     $buildRoot = $context.BuildRoot
@@ -171,7 +171,7 @@ function ThenPublishedWithTag
     [CmdletBinding(DefaultParameterSetName='ExpectedTag')]
     param(
         [Parameter(Mandatory,Position=0,ParameterSetName='ExpectedTag')]
-        [string]$ExpectedTag,
+        [String]$ExpectedTag,
 
         [Parameter(ParameterSetName='None')]
         [switch]$None
@@ -221,10 +221,10 @@ function WhenPublishingNodeModule
 {
     [CmdletBinding()]
     param(
-        [string]$WithCredentialID,
-        [string]$WithEmailAddress,
-        [string]$WithNpmRegistryUri,
-        [string]$WithTag
+        [String]$WithCredentialID,
+        [String]$WithEmailAddress,
+        [String]$WithNpmRegistryUri,
+        [String]$WithTag
     )
 
     Mock -CommandName 'Invoke-WhiskeyNpmCommand' -ModuleName 'Whiskey' -ParameterFilter { $Name -ne 'version' }

--- a/Test/PublishPowerShellModule.Tests.ps1
+++ b/Test/PublishPowerShellModule.Tests.ps1
@@ -96,23 +96,23 @@ function Invoke-Publish
 {
     [CmdletBinding()]
     param(
-        [Switch]$withoutRegisteredRepo,
+        [switch]$withoutRegisteredRepo,
 
-        [String]$ForRepositoryNamed,
+        [string]$ForRepositoryNamed,
 
         [string]$RepoAtUri,
 
-        [String]$ForManifestPath,
+        [string]$ForManifestPath,
 
-        [Switch]$WithNoRepositoryName,
+        [switch]$WithNoRepositoryName,
 
-        [Switch]$withNoProgetURI,
+        [switch]$withNoProgetURI,
 
-        [Switch]$WithInvalidPath,
+        [switch]$WithInvalidPath,
 
-        [Switch]$WithNonExistentPath,
+        [switch]$WithNonExistentPath,
 
-        [Switch]$WithoutPathParameter,
+        [switch]$WithoutPathParameter,
 
         [string]$WithCredentialID
     )
@@ -196,7 +196,7 @@ function Invoke-Publish
                         $NuGetApiKey,
                         $Repository,
                         $Path,
-                        [Switch]$Force
+                        [switch]$Force
                     ) 
                     Write-Error -Message $message
                 }.GetNewClosure()

--- a/Test/PublishPowerShellModule.Tests.ps1
+++ b/Test/PublishPowerShellModule.Tests.ps1
@@ -21,7 +21,7 @@ function GivenCredential
         [pscredential]$Credential,
 
         [Parameter(Mandatory)]
-        [string]$WithID
+        [String]$WithID
     )
 
     $credentials[$WithID] = $Credential
@@ -46,7 +46,7 @@ function GivenPublishingFails
 {
     param(
         [Parameter(Mandatory)]
-        [string]$WithError
+        [String]$WithError
     )
 
     $script:publishError = $WithError
@@ -56,7 +56,7 @@ function GivenRegisteringFails
 {
     param(
         [Parameter(Mandatory)]
-        [string]$WithError
+        [String]$WithError
     )
 
     $script:registerError = $WithError
@@ -98,11 +98,11 @@ function Invoke-Publish
     param(
         [switch]$withoutRegisteredRepo,
 
-        [string]$ForRepositoryNamed,
+        [String]$ForRepositoryNamed,
 
-        [string]$RepoAtUri,
+        [String]$RepoAtUri,
 
-        [string]$ForManifestPath,
+        [String]$ForManifestPath,
 
         [switch]$WithNoRepositoryName,
 
@@ -114,7 +114,7 @@ function Invoke-Publish
 
         [switch]$WithoutPathParameter,
 
-        [string]$WithCredentialID
+        [String]$WithCredentialID
     )
     
     $version = '1.2.3'
@@ -296,10 +296,10 @@ function ThenRepositoryRegistered
 {
     param(
         [Parameter(Mandatory)]
-        [string]$Named,
+        [String]$Named,
 
         [Parameter(Mandatory)]
-        [string]$AtUri,
+        [String]$AtUri,
 
         [pscredential]$WithCredential
     )
@@ -336,9 +336,9 @@ function ThenModulePublished
 {
     param(
         [Parameter(Mandatory)]
-        [string]$ToRepositoryNamed,
+        [String]$ToRepositoryNamed,
 
-        [string]$ExpectedPathName = (Join-Path -Path $testRoot -ChildPath 'MyModule'),
+        [String]$ExpectedPathName = (Join-Path -Path $testRoot -ChildPath 'MyModule'),
 
         [switch]$WithNoRepositoryName
     )
@@ -371,11 +371,11 @@ function ThenModulePublished
 function ThenManifest
 {
     param(
-        [string]$ManifestPath = (Join-Path -Path $testRoot -ChildPath 'MyModule\MyModule.psd1'),
+        [String]$ManifestPath = (Join-Path -Path $testRoot -ChildPath 'MyModule\MyModule.psd1'),
 
-        [string]$AtVersion,
+        [String]$AtVersion,
 
-        [string]$HasPrerelease
+        [String]$HasPrerelease
     )
 
     if( -not $AtVersion )

--- a/Test/PublishProGetAsset.Tests.ps1
+++ b/Test/PublishProGetAsset.Tests.ps1
@@ -35,9 +35,9 @@ function GivenCredentials
 function GivenAsset
 {
     param(
-        [string[]]$Name,
-        [string]$directory,
-        [string[]]$FilePath
+        [String[]]$Name,
+        [String]$directory,
+        [String[]]$FilePath
     )
     $script:taskParameter['AssetPath'] = $name
     $script:taskParameter['AssetDirectory'] = $directory
@@ -51,9 +51,9 @@ function GivenAsset
 function GivenAssetWithInvalidDirectory
 {
     param(
-        [string]$Name,
-        [string]$directory,
-        [string]$FilePath
+        [String]$Name,
+        [String]$directory,
+        [String]$FilePath
     )
     # $script:taskParameter['Name'] = $name
     $script:taskParameter['AssetDirectory'] = $directory
@@ -65,9 +65,9 @@ function GivenAssetWithInvalidDirectory
 function GivenAssetThatDoesntExist
 {
     param(
-        [string]$Name,
-        [string]$directory,
-        [string]$FilePath
+        [String]$Name,
+        [String]$directory,
+        [String]$FilePath
 
     )
     $script:taskParameter['AssetPath'] = $name
@@ -104,7 +104,7 @@ function WhenAssetIsUploaded
 function ThenTaskFails 
 {
     Param(
-        [string]$ExpectedError
+        [String]$ExpectedError
     )
     $Global:Error | Where-Object {$_ -match $ExpectedError } |  Should -Not -BeNullOrEmpty
 }
@@ -112,7 +112,7 @@ function ThenTaskFails
 function ThenAssetShouldExist
 {
     param(
-        [string[]]$AssetName
+        [String[]]$AssetName
     )
     foreach( $file in $AssetName ){
         Assert-mockCalled -CommandName 'Set-ProGetAsset' -ModuleName 'Whiskey' -ParameterFilter { $Path -eq $file }.getNewClosure()
@@ -122,7 +122,7 @@ function ThenAssetShouldExist
 function ThenAssetShouldNotExist
 {
     param(
-        [string[]]$AssetName
+        [String[]]$AssetName
     )
     foreach( $file in $AssetName ){
         Assert-mockCalled -CommandName 'Set-ProGetAsset' -ModuleName 'Whiskey' -ParameterFilter { $Name -eq $file } -Times 0

--- a/Test/PublishProGetAsset.Tests.ps1
+++ b/Test/PublishProGetAsset.Tests.ps1
@@ -35,12 +35,9 @@ function GivenCredentials
 function GivenAsset
 {
     param(
-        [string[]]
-        $Name,
-        [string]
-        $directory,
-        [string[]]
-        $FilePath
+        [string[]]$Name,
+        [string]$directory,
+        [string[]]$FilePath
     )
     $script:taskParameter['AssetPath'] = $name
     $script:taskParameter['AssetDirectory'] = $directory
@@ -54,12 +51,9 @@ function GivenAsset
 function GivenAssetWithInvalidDirectory
 {
     param(
-        [string]
-        $Name,
-        [string]
-        $directory,
-        [string]
-        $FilePath
+        [string]$Name,
+        [string]$directory,
+        [string]$FilePath
     )
     # $script:taskParameter['Name'] = $name
     $script:taskParameter['AssetDirectory'] = $directory
@@ -71,12 +65,9 @@ function GivenAssetWithInvalidDirectory
 function GivenAssetThatDoesntExist
 {
     param(
-        [string]
-        $Name,
-        [string]
-        $directory,
-        [string]
-        $FilePath
+        [string]$Name,
+        [string]$directory,
+        [string]$FilePath
 
     )
     $script:taskParameter['AssetPath'] = $name
@@ -113,8 +104,7 @@ function WhenAssetIsUploaded
 function ThenTaskFails 
 {
     Param(
-        [String]
-        $ExpectedError
+        [string]$ExpectedError
     )
     $Global:Error | Where-Object {$_ -match $ExpectedError } |  Should -Not -BeNullOrEmpty
 }
@@ -122,8 +112,7 @@ function ThenTaskFails
 function ThenAssetShouldExist
 {
     param(
-        [string[]]
-        $AssetName
+        [string[]]$AssetName
     )
     foreach( $file in $AssetName ){
         Assert-mockCalled -CommandName 'Set-ProGetAsset' -ModuleName 'Whiskey' -ParameterFilter { $Path -eq $file }.getNewClosure()
@@ -133,8 +122,7 @@ function ThenAssetShouldExist
 function ThenAssetShouldNotExist
 {
     param(
-        [string[]]
-        $AssetName
+        [string[]]$AssetName
     )
     foreach( $file in $AssetName ){
         Assert-mockCalled -CommandName 'Set-ProGetAsset' -ModuleName 'Whiskey' -ParameterFilter { $Name -eq $file } -Times 0

--- a/Test/PublishProGetUniversalPackage.Tests.ps1
+++ b/Test/PublishProGetUniversalPackage.Tests.ps1
@@ -63,10 +63,10 @@ function GivenProGetIsAt
 function GivenCredential
 {
     param(
-        [Parameter(Mandatory=$true,Position=0)]
+        [Parameter(Mandatory,Position=0)]
         $Credential,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         $WithID
     )
 

--- a/Test/Resolve-WhiskeyDotnetSdkVersion.Tests.ps1
+++ b/Test/Resolve-WhiskeyDotnetSdkVersion.Tests.ps1
@@ -74,7 +74,7 @@ function ThenResolvedLatestLTSVersion
 function ThenResolvedVersion
 {
     param(
-        [version]$Version
+        [Version]$Version
     )
 
     $resolvedVersion | Should -HaveCount 1 -Because 'it should only return one version'
@@ -91,7 +91,7 @@ function WhenResolvingSdkVersion
     [CmdletBinding()]
     param(
         [switch]$LatestLTS,
-        [string]$Version
+        [String]$Version
     )
 
     $script:resolvedVersion = Invoke-WhiskeyPrivateCommand -Name 'Resolve-WhiskeyDotNetSdkVersion' `

--- a/Test/Resolve-WhiskeyNodeModulePath.Tests.ps1
+++ b/Test/Resolve-WhiskeyNodeModulePath.Tests.ps1
@@ -39,7 +39,7 @@ function GivenNodeModuleInstalled
 function ThenError
 {
     param(
-        [string]$Matches
+        [String]$Matches
     )
 
     It ('should write an error') {
@@ -61,7 +61,7 @@ function ThenPathIsGlobal
 {
     param(
         [Parameter(Mandatory)]
-        [string]$Name
+        [String]$Name
     )
 
     $nodeRoot = Join-Path -Path $TestDrive.FullName -ChildPath '.node'
@@ -86,7 +86,7 @@ function ThenPathIsLocal
 {
     param(
         [Parameter(Mandatory)]
-        [string]$Name
+        [String]$Name
     )
 
     It ('should resolve path') {
@@ -99,16 +99,16 @@ function WhenResolving
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,Position=0)]
-        [string]$Name,
+        [String]$Name,
 
         [Parameter(Mandatory,ParameterSetName='WithBuildRoot')]
-        [string]$BuildRootPath,
+        [String]$BuildRootPath,
 
         [Parameter(ParameterSetName='WithBuildRoot')]
         [switch]$Global,
 
         [Parameter(Mandatory,ParameterSetName='WithNodeRoot')]
-        [string]$NodeRootPath
+        [String]$NodeRootPath
     )
 
     if( $BuildRootPath )

--- a/Test/Resolve-WhiskeyNodeModulePath.Tests.ps1
+++ b/Test/Resolve-WhiskeyNodeModulePath.Tests.ps1
@@ -17,8 +17,7 @@ function GivenNodeModuleInstalled
     param(
         $Name,
 
-        [Switch]
-        $Global
+        [switch]$Global
     )
 
     $nodeModulesPath = $TestDrive.FullName
@@ -40,8 +39,7 @@ function GivenNodeModuleInstalled
 function ThenError
 {
     param(
-        [string]
-        $Matches
+        [string]$Matches
     )
 
     It ('should write an error') {
@@ -63,8 +61,7 @@ function ThenPathIsGlobal
 {
     param(
         [Parameter(Mandatory)]
-        [string]
-        $Name
+        [string]$Name
     )
 
     $nodeRoot = Join-Path -Path $TestDrive.FullName -ChildPath '.node'
@@ -89,8 +86,7 @@ function ThenPathIsLocal
 {
     param(
         [Parameter(Mandatory)]
-        [string]
-        $Name
+        [string]$Name
     )
 
     It ('should resolve path') {
@@ -103,20 +99,16 @@ function WhenResolving
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,Position=0)]
-        [string]
-        $Name,
+        [string]$Name,
 
         [Parameter(Mandatory,ParameterSetName='WithBuildRoot')]
-        [string]
-        $BuildRootPath,
+        [string]$BuildRootPath,
 
         [Parameter(ParameterSetName='WithBuildRoot')]
-        [Switch]
-        $Global,
+        [switch]$Global,
 
         [Parameter(Mandatory,ParameterSetName='WithNodeRoot')]
-        [string]
-        $NodeRootPath
+        [string]$NodeRootPath
     )
 
     if( $BuildRootPath )

--- a/Test/Resolve-WhiskeyNodePath.Tests.ps1
+++ b/Test/Resolve-WhiskeyNodePath.Tests.ps1
@@ -20,8 +20,7 @@ function GivenNodeInstalled
 function ThenError
 {
     param(
-        [string]
-        $Matches
+        [string]$Matches
     )
 
     It ('should write an error') {
@@ -64,12 +63,10 @@ function WhenResolving
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,ParameterSetName='WithBuildRoot')]
-        [string]
-        $BuildRootPath,
+        [string]$BuildRootPath,
 
         [Parameter(Mandatory,ParameterSetName='WithNodeRoot')]
-        [string]
-        $NodeRootPath
+        [string]$NodeRootPath
     )
 
     if( $BuildRootPath )

--- a/Test/Resolve-WhiskeyNodePath.Tests.ps1
+++ b/Test/Resolve-WhiskeyNodePath.Tests.ps1
@@ -20,7 +20,7 @@ function GivenNodeInstalled
 function ThenError
 {
     param(
-        [string]$Matches
+        [String]$Matches
     )
 
     It ('should write an error') {
@@ -63,10 +63,10 @@ function WhenResolving
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,ParameterSetName='WithBuildRoot')]
-        [string]$BuildRootPath,
+        [String]$BuildRootPath,
 
         [Parameter(Mandatory,ParameterSetName='WithNodeRoot')]
-        [string]$NodeRootPath
+        [String]$NodeRootPath
     )
 
     if( $BuildRootPath )

--- a/Test/Resolve-WhiskeyNuGetPackageVersion.Tests.ps1
+++ b/Test/Resolve-WhiskeyNuGetPackageVersion.Tests.ps1
@@ -34,7 +34,7 @@ function GivenNuGetPackageName
 function GivenNugetReturnsMultipleVersions
 {
     param(
-        [string[]]$PackageVersions
+        [String[]]$PackageVersions
     )
 
     Mock -CommandName 'Invoke-Command' -ModuleName 'Whiskey' -ParameterFilter { $ScriptBlock.ToString() -match 'list' } -MockWith { $PackageVersions }.GetNewClosure()

--- a/Test/Resolve-WhiskeyNuGetPackageVersion.Tests.ps1
+++ b/Test/Resolve-WhiskeyNuGetPackageVersion.Tests.ps1
@@ -34,8 +34,7 @@ function GivenNuGetPackageName
 function GivenNugetReturnsMultipleVersions
 {
     param(
-        [string[]]
-        $PackageVersions
+        [string[]]$PackageVersions
     )
 
     Mock -CommandName 'Invoke-Command' -ModuleName 'Whiskey' -ParameterFilter { $ScriptBlock.ToString() -match 'list' } -MockWith { $PackageVersions }.GetNewClosure()

--- a/Test/Resolve-WhiskeyPowerShellModule.Tests.ps1
+++ b/Test/Resolve-WhiskeyPowerShellModule.Tests.ps1
@@ -65,7 +65,7 @@ function WhenResolvingPowerShellModule
 {
     [CmdletBinding()]
     param(
-        [Switch]$SkipCaching
+        [switch]$SkipCaching
     )
 
     $parameter = @{

--- a/Test/Resolve-WhiskeyTaskPathParameter.Tests.ps1
+++ b/Test/Resolve-WhiskeyTaskPathParameter.Tests.ps1
@@ -93,11 +93,11 @@ function WhenRunningTask
 {
     [CmdletBinding(SupportsShouldProcess)]
     param(
-        [string]$Name,
+        [String]$Name,
 
         [hashtable]$Parameter,
 
-        [string]$BuildRoot
+        [String]$BuildRoot
     )
 
     $optionalParams = @{}
@@ -130,7 +130,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when parameter is an optional path')
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath()]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -149,7 +149,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when parameter is an optional path b
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath()]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -168,7 +168,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when parameter is a path with wildca
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath()]
-                [string[]]$Path
+                [String[]]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -191,7 +191,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when parameter is a path that the us
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath()]
-                [string[]]$Path
+                [String[]]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -211,7 +211,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when path parameter wants to be reso
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath()]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -232,7 +232,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when path should be a file') {
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath(Mandatory,PathType='File')]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -251,7 +251,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when path should be a file but it''s
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath(Mandatory,PathType='File')]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -271,7 +271,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when path should be a directory but 
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath(Mandatory,PathType='Directory')]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -291,7 +291,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when all paths should be files but o
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath(Mandatory,PathType='File')]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -312,7 +312,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when an optional path that doesn''t 
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath(PathType='File')]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -330,7 +330,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when path is mandatory and missing')
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath(Mandatory)]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -350,7 +350,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when path is outside of build root a
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath(Mandatory,PathType='File',AllowNonexistent,AllowOutsideBuildRoot)]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -369,7 +369,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when path is outside of build root a
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath(Mandatory,PathType='File',AllowNonexistent)]
-                [string]$Path
+                [String]$Path
                 
             )
             $global:taskCalled = $true
@@ -389,7 +389,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when path must exist and does') {
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath(Mandatory,PathType='File')]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -409,7 +409,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when path must exist and does not') 
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath(Mandatory,PathType='File')]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -428,7 +428,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when path is absolute') {
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath(Mandatory,AllowNonexistent,PathType='File')]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -447,7 +447,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when path doesn''t exist but has a w
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath(Mandatory,AllowNonexistent,PathType='File')]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -474,7 +474,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when path is outside build root') {
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath(Mandatory,AllowNonexistent,PathType='File')]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -496,7 +496,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when multiple paths contain wildcard
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath()]
-                [string[]]$Path
+                [String[]]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -526,7 +526,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when given multipe paths') {
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath(Mandatory,PathType='File')]
-                [string[]]$Path
+                [String[]]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters
@@ -552,7 +552,7 @@ Describe ('Resolve-WhiskeyTaskPathParameter.when a path uses different case to t
             [Whiskey.Task('Task')]
             param(
                 [Whiskey.Tasks.ValidatePath(AllowNonexistent)]
-                [string]$Path
+                [String]$Path
             )
             $global:taskCalled = $true
             $global:taskParameters = $PSBoundParameters

--- a/Test/Resolve-WhiskeyTaskPathParameter.Tests.ps1
+++ b/Test/Resolve-WhiskeyTaskPathParameter.Tests.ps1
@@ -58,8 +58,7 @@ function ThenPipelineSucceeded
 function ThenTaskCalled
 {
     param(
-        [hashtable]
-        $WithParameter
+        [hashtable]$WithParameter
     )
     $taskCalled | should -BeTrue
     $taskParameters | Should -Not -BeNullOrEmpty
@@ -94,14 +93,11 @@ function WhenRunningTask
 {
     [CmdletBinding(SupportsShouldProcess)]
     param(
-        [string]
-        $Name,
+        [string]$Name,
 
-        [hashtable]
-        $Parameter,
+        [hashtable]$Parameter,
 
-        [string]
-        $BuildRoot
+        [string]$BuildRoot
     )
 
     $optionalParams = @{}

--- a/Test/Resolve-WhiskeyVariable.Tests.ps1
+++ b/Test/Resolve-WhiskeyVariable.Tests.ps1
@@ -12,7 +12,7 @@ function GivenEnvironmentVariable
 {
     param(
         [ValidatePattern('^ResolveWhiskey')]
-        [string]$Named,
+        [String]$Named,
         $WithValue
     )
 
@@ -228,7 +228,7 @@ Describe 'Resolve-WhiskeyVariable.when passed a List object' {
     It 'should resolve variables in each item' {
         Init
         GivenEnvironmentVariable 'ResolveWhiskeyVariable' -WithValue '010'
-        $list = New-Object 'Collections.Generic.List[string]'
+        $list = New-Object 'Collections.Generic.List[String]'
         $list.Add( '$(ResolveWhiskeyVariable)' )
         $list.Add( 'fubar' )
         $list.Add( 'snafu' )

--- a/Test/Resolve-WhiskeyVariable.Tests.ps1
+++ b/Test/Resolve-WhiskeyVariable.Tests.ps1
@@ -11,9 +11,8 @@ $result = $null
 function GivenEnvironmentVariable
 {
     param(
-        [string]
         [ValidatePattern('^ResolveWhiskey')]
-        $Named,
+        [string]$Named,
         $WithValue
     )
 

--- a/Test/Set-WhiskeyBuildStatus.Tests.ps1
+++ b/Test/Set-WhiskeyBuildStatus.Tests.ps1
@@ -10,11 +10,9 @@ $failed = $false
 function GivenCredential
 {
     param(
-        [string]
-        $ID,
+        [string]$ID,
 
-        [pscredential]
-        $Credential
+        [pscredential]$Credential
     )
 
     Add-WhiskeyCredential -Context $context -ID $ID -Credential $Credential
@@ -46,8 +44,7 @@ function GivenReporter
 {
     param(
         [Parameter(Position=0)]
-        [object]
-        $Reporter
+        [object]$Reporter
     )
 
     $context.Configuration['PublishBuildStatusTo'] = @( $Reporter )

--- a/Test/Set-WhiskeyBuildStatus.Tests.ps1
+++ b/Test/Set-WhiskeyBuildStatus.Tests.ps1
@@ -10,7 +10,7 @@ $failed = $false
 function GivenCredential
 {
     param(
-        [string]$ID,
+        [String]$ID,
 
         [pscredential]$Credential
     )
@@ -44,7 +44,7 @@ function GivenReporter
 {
     param(
         [Parameter(Position=0)]
-        [object]$Reporter
+        [Object]$Reporter
     )
 
     $context.Configuration['PublishBuildStatusTo'] = @( $Reporter )

--- a/Test/TaskDefaults.Tests.ps1
+++ b/Test/TaskDefaults.Tests.ps1
@@ -29,8 +29,7 @@ function GivenRunMode
 function GivenTaskDefaults
 {
     param(
-        [hashtable]
-        $Defaults,
+        [hashtable]$Defaults,
         $ForTask
     )
 

--- a/Test/Uninstall-WhiskeyNodeModule.Tests.ps1
+++ b/Test/Uninstall-WhiskeyNodeModule.Tests.ps1
@@ -118,7 +118,7 @@ function ThenModule
 {
     param(
         [Parameter(Position=0)]
-        [string]$Name,
+        [String]$Name,
 
         [Parameter(Mandatory,ParameterSetName='Exists')]
         [switch]$Exists,

--- a/Test/Uninstall-WhiskeyNodeModule.Tests.ps1
+++ b/Test/Uninstall-WhiskeyNodeModule.Tests.ps1
@@ -118,16 +118,13 @@ function ThenModule
 {
     param(
         [Parameter(Position=0)]
-        [string]
-        $Name,
+        [string]$Name,
 
-        [Parameter(Mandatory=$true,ParameterSetName='Exists')]
-        [switch]
-        $Exists,
+        [Parameter(Mandatory,ParameterSetName='Exists')]
+        [switch]$Exists,
 
-        [Parameter(Mandatory=$true,ParameterSetName='DoesNotExist')]
-        [switch]
-        $DoesNotExist
+        [Parameter(Mandatory,ParameterSetName='DoesNotExist')]
+        [switch]$DoesNotExist
     )
 
     $modulePath = Resolve-WhiskeyNodeModulePath -Name $Name -BuildRootPath $script:applicationRoot -ErrorAction Ignore

--- a/Test/Uninstall-WhiskeyPowerShellModule.Tests.ps1
+++ b/Test/Uninstall-WhiskeyPowerShellModule.Tests.ps1
@@ -9,9 +9,9 @@ function GivenAnInstalledPowerShellModule
 {
     [CmdLetBinding()]
     param(
-        [string]$WithVersion = '0.37.1',
+        [String]$WithVersion = '0.37.1',
 
-        [string]$WithName = 'SomeModule'
+        [String]$WithName = 'SomeModule'
     )
 
     $moduleRoot = Join-Path -Path $testRoot -ChildPath $PSModulesDirectoryName
@@ -40,9 +40,9 @@ function WhenUninstallingPowerShellModule
 {
     [CmdletBinding()]
     param(
-        [string]$WithVersion = '0.37.1',
+        [String]$WithVersion = '0.37.1',
 
-        [string]$WithName = 'SomeModule'
+        [String]$WithName = 'SomeModule'
     )
 
     $Global:Error.Clear()
@@ -65,9 +65,9 @@ function ThenPowerShellModuleUninstalled
 {
     [CmdLetBinding()]
     param(
-        [string]$WithVersion = '0.37.1',
+        [String]$WithVersion = '0.37.1',
 
-        [string]$WithName = 'SomeModule'
+        [String]$WithName = 'SomeModule'
     )
 
     $Name = '{0}\{1}' -f $WithName, $WithVersion

--- a/Test/Uninstall-WhiskeyPowerShellModule.Tests.ps1
+++ b/Test/Uninstall-WhiskeyPowerShellModule.Tests.ps1
@@ -9,9 +9,9 @@ function GivenAnInstalledPowerShellModule
 {
     [CmdLetBinding()]
     param(
-        [String]$WithVersion = '0.37.1',
+        [string]$WithVersion = '0.37.1',
 
-        [String]$WithName = 'SomeModule'
+        [string]$WithName = 'SomeModule'
     )
 
     $moduleRoot = Join-Path -Path $testRoot -ChildPath $PSModulesDirectoryName
@@ -40,11 +40,9 @@ function WhenUninstallingPowerShellModule
 {
     [CmdletBinding()]
     param(
-        [String]
-        $WithVersion = '0.37.1',
+        [string]$WithVersion = '0.37.1',
 
-        [String]
-        $WithName = 'SomeModule'
+        [string]$WithName = 'SomeModule'
     )
 
     $Global:Error.Clear()
@@ -67,9 +65,9 @@ function ThenPowerShellModuleUninstalled
 {
     [CmdLetBinding()]
     param(
-        [String]$WithVersion = '0.37.1',
+        [string]$WithVersion = '0.37.1',
 
-        [String]$WithName = 'SomeModule'
+        [string]$WithName = 'SomeModule'
     )
 
     $Name = '{0}\{1}' -f $WithName, $WithVersion

--- a/Test/Uninstall-WhiskeyTool.Tests.ps1
+++ b/Test/Uninstall-WhiskeyTool.Tests.ps1
@@ -12,9 +12,9 @@ function GivenAnInstalledNuGetPackage
 {
     [CmdLetBinding()]
     param(
-        [string]$WithVersion = '2.6.4',
+        [String]$WithVersion = '2.6.4',
 
-        [string]$WithName = 'NUnit.Runners'
+        [String]$WithName = 'NUnit.Runners'
 
     )
     $WithVersion = Resolve-WhiskeyNuGetPackageVersion -NuGetPackageName $WithName -Version $WithVersion
@@ -78,9 +78,9 @@ function ThenNuGetPackageUninstalled
 {
     [CmdLetBinding()]
     param(
-        [string]$WithVersion = '2.6.4',
+        [String]$WithVersion = '2.6.4',
 
-        [string]$WithName = 'NUnit.Runners'
+        [String]$WithName = 'NUnit.Runners'
     )
 
     $Name = '{0}.{1}' -f $WithName, $WithVersion
@@ -96,13 +96,13 @@ function ThenNuGetPackageNotUninstalled
 {
     [CmdLetBinding()]
     param(
-        [string]$WithVersion = '2.6.4',
+        [String]$WithVersion = '2.6.4',
 
-        [string]$WithName = 'NUnit.Runners',
+        [String]$WithName = 'NUnit.Runners',
 
         [switch]$PackageShouldExist,
 
-        [string]$WithError
+        [String]$WithError
     )
 
     $Name = '{0}.{1}' -f $WithName, $WithVersion
@@ -136,9 +136,9 @@ function WhenUninstallingNuGetPackage
 {
     [CmdletBinding()]
     param(
-        [string]$WithVersion = '2.6.4',
+        [String]$WithVersion = '2.6.4',
 
-        [string]$WithName = 'NUnit.Runners'
+        [String]$WithName = 'NUnit.Runners'
     )
 
     $Global:Error.Clear()

--- a/Test/Uninstall-WhiskeyTool.Tests.ps1
+++ b/Test/Uninstall-WhiskeyTool.Tests.ps1
@@ -12,11 +12,9 @@ function GivenAnInstalledNuGetPackage
 {
     [CmdLetBinding()]
     param(
-        [String]
-        $WithVersion = '2.6.4',
+        [string]$WithVersion = '2.6.4',
 
-        [String]
-        $WithName = 'NUnit.Runners'
+        [string]$WithName = 'NUnit.Runners'
 
     )
     $WithVersion = Resolve-WhiskeyNuGetPackageVersion -NuGetPackageName $WithName -Version $WithVersion
@@ -57,10 +55,8 @@ function ThenFile
 {
     param(
         $Path,
-        [Switch]
-        $Not,
-        [Switch]
-        $Exists
+        [switch]$Not,
+        [switch]$Exists
     )
 
     if( $Not )
@@ -82,11 +78,9 @@ function ThenNuGetPackageUninstalled
 {
     [CmdLetBinding()]
     param(
-        [String]
-        $WithVersion = '2.6.4',
+        [string]$WithVersion = '2.6.4',
 
-        [String]
-        $WithName = 'NUnit.Runners'
+        [string]$WithName = 'NUnit.Runners'
     )
 
     $Name = '{0}.{1}' -f $WithName, $WithVersion
@@ -102,9 +96,9 @@ function ThenNuGetPackageNotUninstalled
 {
     [CmdLetBinding()]
     param(
-        [String]$WithVersion = '2.6.4',
+        [string]$WithVersion = '2.6.4',
 
-        [String]$WithName = 'NUnit.Runners',
+        [string]$WithName = 'NUnit.Runners',
 
         [switch]$PackageShouldExist,
 
@@ -142,11 +136,9 @@ function WhenUninstallingNuGetPackage
 {
     [CmdletBinding()]
     param(
-        [String]
-        $WithVersion = '2.6.4',
+        [string]$WithVersion = '2.6.4',
 
-        [String]
-        $WithName = 'NUnit.Runners'
+        [string]$WithName = 'NUnit.Runners'
     )
 
     $Global:Error.Clear()

--- a/Test/Version.Tests.ps1
+++ b/Test/Version.Tests.ps1
@@ -103,7 +103,7 @@ function ThenTaskFailed
 function ThenVersionIs
 {
     param(
-        [version]$ExpectedVersion
+        [Version]$ExpectedVersion
     )
 
     It ('should set Version') {
@@ -117,7 +117,7 @@ function WhenRunningTask
     param(
         [switch]$AsDeveloper,
 
-        [string]$WithYaml
+        [String]$WithYaml
     )
 
     $forParam = @{ ForBuildServer = $true }
@@ -535,5 +535,5 @@ description 'Installs/Configures cookbook_name'
     GivenProperty @{ Path = 'metadata.rb' }
     WhenRunningTask -ErrorAction SilentlyContinue
     ThenTaskFailed
-    ThenErrorIs ([Regex]::Escape('Unable to locate property "version ''x.x.x''" in metadata.rb file'))
+    ThenErrorIs ([regex]::Escape('Unable to locate property "version ''x.x.x''" in metadata.rb file'))
 }

--- a/Test/Version.Tests.ps1
+++ b/Test/Version.Tests.ps1
@@ -69,8 +69,7 @@ function GivenCurrentVersion
 function ThenSemVer2Is
 {
     param(
-        [SemVersion.SemanticVersion]
-        $ExpectedVersion
+        [SemVersion.SemanticVersion]$ExpectedVersion
     )
 
     It ('should set SemVer2') {
@@ -86,8 +85,7 @@ function ThenSemVer2Is
 function ThenSemVer1Is
 {
     param(
-        [SemVersion.SemanticVersion]
-        $ExpectedVersion
+        [SemVersion.SemanticVersion]$ExpectedVersion
     )
 
     It ('should set SemVer1') {
@@ -105,8 +103,7 @@ function ThenTaskFailed
 function ThenVersionIs
 {
     param(
-        [version]
-        $ExpectedVersion
+        [version]$ExpectedVersion
     )
 
     It ('should set Version') {
@@ -118,11 +115,9 @@ function WhenRunningTask
 {
     [CmdletBinding()]
     param(
-        [Switch]
-        $AsDeveloper,
+        [switch]$AsDeveloper,
 
-        [string]
-        $WithYaml
+        [string]$WithYaml
     )
 
     $forParam = @{ ForBuildServer = $true }

--- a/Test/WhiskeyTest.psm1
+++ b/Test/WhiskeyTest.psm1
@@ -31,12 +31,12 @@ function ConvertTo-Yaml
     Param(
         [Parameter(ValueFromPipeline)]
         [System.Object]$Data,
-        [string]$OutFile,
+        [String]$OutFile,
         [switch]$JsonCompatible=$false,
         [switch]$Force=$false
     )
     BEGIN {
-        $d = [System.Collections.Generic.List[object]](New-Object "System.Collections.Generic.List[object]")
+        $d = [System.Collections.Generic.List[Object]](New-Object "System.Collections.Generic.List[Object]")
     }
     PROCESS {
         if($data -ne $null) {
@@ -88,7 +88,7 @@ function Import-WhiskeyTestModule
 {
     param(
         [Parameter(Mandatory)]
-        [string[]]$Name,
+        [String[]]$Name,
         
         [switch]$Force
     )
@@ -110,9 +110,9 @@ function Initialize-WhiskeyTestPSModule
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$BuildRoot,
+        [String]$BuildRoot,
 
-        [string[]]$Name
+        [String[]]$Name
     )
 
     $destinationRoot = Join-Path -Path $BuildRoot -ChildPath $PSModulesDirectoryName
@@ -151,9 +151,9 @@ function Initialize-WhiskeyTestPSModule
 function Install-Node
 {
     param(
-        [string[]]$WithModule,
+        [String[]]$WithModule,
 
-        [string]$BuildRoot
+        [String]$BuildRoot
     )
 
     $toolAttr = New-Object 'Whiskey.RequiresToolAttribute' 'Node'
@@ -229,7 +229,7 @@ function Invoke-WhiskeyPrivateCommand
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$Name,
+        [String]$Name,
         [hashtable]$Parameter = @{}
     )
 
@@ -258,7 +258,7 @@ function Invoke-WhiskeyPrivateCommand
 function New-AssemblyInfo
 {
     param(
-        [string]$RootPath
+        [String]$RootPath
     )
 
     @'
@@ -304,11 +304,11 @@ using System.Runtime.InteropServices;
 function New-MSBuildProject
 {
     param(
-        [string[]]$FileName,
+        [String[]]$FileName,
 
         [switch]$ThatFails,
 
-        [string]$BuildRoot
+        [String]$BuildRoot
     )
 
     if( -not $BuildRoot )
@@ -354,11 +354,11 @@ function New-MSBuildProject
 function New-WhiskeyTestContext
 {
     param(
-        [string]$ForBuildRoot,
+        [String]$ForBuildRoot,
 
-        [string]$ForTaskName,
+        [String]$ForTaskName,
 
-        [string]$ForOutputDirectory,
+        [String]$ForOutputDirectory,
 
         [switch]$InReleaseMode,
 
@@ -372,13 +372,13 @@ function New-WhiskeyTestContext
 
         [SemVersion.SemanticVersion]$ForVersion = [SemVersion.SemanticVersion]'1.2.3-rc.1+build',
 
-        [string]$ConfigurationPath,
+        [String]$ConfigurationPath,
 
-        [string]$ForYaml,
+        [String]$ForYaml,
 
         [hashtable]$TaskParameter = @{},
 
-        [string]$DownloadRoot,
+        [String]$DownloadRoot,
 
         [switch]$IgnoreExistingOutputDirectory,
 
@@ -386,7 +386,7 @@ function New-WhiskeyTestContext
 
         [switch]$InInitMode,
 
-        [string[]]$IncludePSModule
+        [String[]]$IncludePSModule
     )
 
     Set-StrictMode -Version 'Latest'
@@ -477,7 +477,7 @@ function New-WhiskeyTestContext
         $context.Version.SemVer2 = $ForVersion
         $context.Version.SemVer2NoBuildMetadata = New-Object 'SemVersion.SemanticVersion' $ForVersion.Major,$ForVersion.Minor,$ForVersion.Patch,$ForVersion.Prerelease,$null
         $context.Version.SemVer1 = New-Object 'SemVersion.SemanticVersion' $ForVersion.Major,$ForVersion.Minor,$ForVersion.Patch,($ForVersion.Prerelease -replace '[^A-Za-z0-9]',''),$null
-        $context.Version.Version = [version]('{0}.{1}.{2}' -f $ForVersion.Major,$ForVersion.Minor,$ForVersion.Patch)
+        $context.Version.Version = [Version]('{0}.{1}.{2}' -f $ForVersion.Major,$ForVersion.Minor,$ForVersion.Patch)
     }
 
     if( -not $IgnoreExistingOutputDirectory -and (Test-Path -Path $context.OutputDirectory) )
@@ -507,7 +507,7 @@ function New-WhiskeyTestRoot
 function Remove-Node
 {
     param(
-        [string]$BuildRoot
+        [String]$BuildRoot
     )
 
     if( -not $BuildRoot )
@@ -523,7 +523,7 @@ function Remove-Node
 function Remove-DotNet
 {
     param(
-        [string]$BuildRoot
+        [String]$BuildRoot
     )
 
     if( -not $BuildRoot )
@@ -554,11 +554,11 @@ function Reset-WhiskeyTestPSModule
 function ThenModuleInstalled
 {
     param(
-        [string]$InBuildRoot,
+        [String]$InBuildRoot,
 
-        [string]$Named,
+        [String]$Named,
 
-        [string]$AtVersion
+        [String]$AtVersion
     )
 
     Join-Path -Path $InBuildRoot -ChildPath ('{0}\{1}\{2}' -f $PSModulesDirectoryName,$Named,$AtVersion) | 
@@ -569,7 +569,7 @@ function Write-WhiskeyTestTiming
 {
     param(
         [Parameter(Mandatory)]
-        [string]$Message
+        [String]$Message
     )
 
     Invoke-WhiskeyPrivateCommand -Name 'Write-WhiskeyTiming' -Parameter @{ Message = $Message } 

--- a/Test/WhiskeyTest.psm1
+++ b/Test/WhiskeyTest.psm1
@@ -29,9 +29,8 @@ function ConvertTo-Yaml
 {
     [CmdletBinding()]
     Param(
-        [Parameter(Mandatory=$false,ValueFromPipeline=$true)]
+        [Parameter(ValueFromPipeline)]
         [System.Object]$Data,
-        [Parameter(Mandatory=$false)]
         [string]$OutFile,
         [switch]$JsonCompatible=$false,
         [switch]$Force=$false
@@ -91,7 +90,7 @@ function Import-WhiskeyTestModule
         [Parameter(Mandatory)]
         [string[]]$Name,
         
-        [Switch]$Force
+        [switch]$Force
     )
 
     $modulesRoot = Join-Path -Path $PSScriptRoot -ChildPath ('..\{0}' -f $PSModulesDirectoryName) -Resolve
@@ -259,8 +258,7 @@ function Invoke-WhiskeyPrivateCommand
 function New-AssemblyInfo
 {
     param(
-        [string]
-        $RootPath
+        [string]$RootPath
     )
 
     @'
@@ -306,14 +304,11 @@ using System.Runtime.InteropServices;
 function New-MSBuildProject
 {
     param(
-        [string[]]
-        $FileName,
+        [string[]]$FileName,
 
-        [Switch]
-        $ThatFails,
+        [switch]$ThatFails,
 
-        [string]
-        $BuildRoot
+        [string]$BuildRoot
     )
 
     if( -not $BuildRoot )
@@ -367,13 +362,13 @@ function New-WhiskeyTestContext
 
         [switch]$InReleaseMode,
 
-        [Parameter(Mandatory=$true,ParameterSetName='ByBuildServer')]
+        [Parameter(Mandatory,ParameterSetName='ByBuildServer')]
         [Alias('ByBuildServer')]
-        [Switch]$ForBuildServer,
+        [switch]$ForBuildServer,
 
-        [Parameter(Mandatory=$true,ParameterSetName='ByDeveloper')]
+        [Parameter(Mandatory,ParameterSetName='ByDeveloper')]
         [Alias('ByDeveloper')]
-        [Switch]$ForDeveloper,
+        [switch]$ForDeveloper,
 
         [SemVersion.SemanticVersion]$ForVersion = [SemVersion.SemanticVersion]'1.2.3-rc.1+build',
 
@@ -385,11 +380,11 @@ function New-WhiskeyTestContext
 
         [string]$DownloadRoot,
 
-        [Switch]$IgnoreExistingOutputDirectory,
+        [switch]$IgnoreExistingOutputDirectory,
 
-        [Switch]$InCleanMode,
+        [switch]$InCleanMode,
 
-        [Switch]$InInitMode,
+        [switch]$InInitMode,
 
         [string[]]$IncludePSModule
     )

--- a/Test/Zip.Tests.ps1
+++ b/Test/Zip.Tests.ps1
@@ -31,7 +31,7 @@ function Init
 function GivenARepositoryWithItems
 {
     param(
-        [string[]]$Path,
+        [String[]]$Path,
 
         $ItemType = 'File'
     )
@@ -69,7 +69,7 @@ function ThenArchiveShouldInclude
         $ArchivePath,
 
         [Parameter(Position=0)]
-        [string[]]$Path
+        [String[]]$Path
     )
 
     if( -not $Path )
@@ -114,7 +114,7 @@ function ThenArchiveShouldBeCompressed
 function ThenArchiveShouldNotInclude
 {
     param(
-        [string[]]$Path
+        [String[]]$Path
     )
 
     foreach( $item in $Path )
@@ -126,7 +126,7 @@ function ThenArchiveShouldNotInclude
 function ThenTaskFails
 {
     Param(
-        [string]$error
+        [String]$error
     )
 
     $threwException | Should -BeTrue
@@ -144,9 +144,9 @@ function WhenPackaging
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$WithYaml,
+        [String]$WithYaml,
 
-        [string]$ToFile,
+        [String]$ToFile,
 
         [switch]$AndModuleNotInstalled
     )

--- a/Test/Zip.Tests.ps1
+++ b/Test/Zip.Tests.ps1
@@ -31,8 +31,7 @@ function Init
 function GivenARepositoryWithItems
 {
     param(
-        [string[]]
-        $Path,
+        [string[]]$Path,
 
         $ItemType = 'File'
     )
@@ -70,8 +69,7 @@ function ThenArchiveShouldInclude
         $ArchivePath,
 
         [Parameter(Position=0)]
-        [string[]]
-        $Path
+        [string[]]$Path
     )
 
     if( -not $Path )
@@ -92,11 +90,9 @@ function ThenArchiveShouldBeCompressed
     param(
         $Path,
 
-        [Int]
-        $GreaterThan,
+        [int]$GreaterThan,
 
-        [int]
-        $LessThanOrEqualTo
+        [int]$LessThanOrEqualTo
     )
 
     $archivePath = Join-Path -Path (Get-BuildRoot) -ChildPath $Path
@@ -118,8 +114,7 @@ function ThenArchiveShouldBeCompressed
 function ThenArchiveShouldNotInclude
 {
     param(
-        [string[]]
-        $Path
+        [string[]]$Path
     )
 
     foreach( $item in $Path )
@@ -131,8 +126,7 @@ function ThenArchiveShouldNotInclude
 function ThenTaskFails
 {
     Param(
-        [String]
-        $error
+        [string]$error
     )
 
     $threwException | Should -BeTrue

--- a/Test/build.ps1.Tests.ps1
+++ b/Test/build.ps1.Tests.ps1
@@ -32,7 +32,7 @@ function ThenModule
         [switch]$Not,
 
         [Parameter(Mandatory)]
-        [Switch]$Loaded
+        [switch]$Loaded
     )
 
     if( $Not )

--- a/Test/build.ps1.Tests.ps1
+++ b/Test/build.ps1.Tests.ps1
@@ -27,7 +27,7 @@ function ThenModule
 {
     param(
         [Parameter(Mandatory)]
-        [string[]]$Named,
+        [String[]]$Named,
 
         [switch]$Not,
 

--- a/Whiskey/Functions/Add-WhiskeyApiKey.ps1
+++ b/Whiskey/Functions/Add-WhiskeyApiKey.ps1
@@ -23,17 +23,15 @@ function Add-WhiskeyApiKey
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
+        [Parameter(Mandatory)]
         # The context of the build that needs the API key.
-        $Context,
+        [Whiskey.Context]$Context,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The ID of the API key. This should match the ID given in your `whiskey.yml` for the API key ID property of the task that needs it.
-        $ID,
+        [string]$ID,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         # The value of the API key. Can be a string or a SecureString.
         $Value
     )

--- a/Whiskey/Functions/Add-WhiskeyApiKey.ps1
+++ b/Whiskey/Functions/Add-WhiskeyApiKey.ps1
@@ -29,7 +29,7 @@ function Add-WhiskeyApiKey
 
         [Parameter(Mandatory)]
         # The ID of the API key. This should match the ID given in your `whiskey.yml` for the API key ID property of the task that needs it.
-        [string]$ID,
+        [String]$ID,
 
         [Parameter(Mandatory)]
         # The value of the API key. Can be a string or a SecureString.

--- a/Whiskey/Functions/Add-WhiskeyCredential.ps1
+++ b/Whiskey/Functions/Add-WhiskeyCredential.ps1
@@ -29,7 +29,7 @@ function Add-WhiskeyCredential
 
         [Parameter(Mandatory)]
         # The ID of the credential. This should match the ID given in your `whiskey.yml` of credential ID property of the task that needs it.
-        [string]$ID,
+        [String]$ID,
 
         [Parameter(Mandatory)]
         # The value of the credential.

--- a/Whiskey/Functions/Add-WhiskeyCredential.ps1
+++ b/Whiskey/Functions/Add-WhiskeyCredential.ps1
@@ -23,20 +23,17 @@ function Add-WhiskeyCredential
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
+        [Parameter(Mandatory)]
         # The context of the build that needs the API key.
-        $Context,
+        [Whiskey.Context]$Context,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The ID of the credential. This should match the ID given in your `whiskey.yml` of credential ID property of the task that needs it.
-        $ID,
+        [string]$ID,
 
-        [Parameter(Mandatory=$true)]
-        [pscredential]
+        [Parameter(Mandatory)]
         # The value of the credential.
-        $Credential
+        [pscredential]$Credential
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Add-WhiskeyTaskDefault.ps1
+++ b/Whiskey/Functions/Add-WhiskeyTaskDefault.ps1
@@ -24,28 +24,24 @@ function Add-WhiskeyTaskDefault
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
-        [object]
+        [Parameter(Mandatory,ValueFromPipeline)]
         # The current build context. Use `New-WhiskeyContext` to create context objects.
-        $Context,
+        [Whiskey.Context]$Context,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The name of the task that a default parameter value will be set.
-        $TaskName,
+        [string]$TaskName,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The name of the task parameter to set a default value for.
-        $PropertyName,
+        [string]$PropertyName,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         # The default value for the task parameter.
         $Value,
 
-        [switch]
         # Overwrite an existing task default with a new value.
-        $Force
+        [switch]$Force
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Add-WhiskeyTaskDefault.ps1
+++ b/Whiskey/Functions/Add-WhiskeyTaskDefault.ps1
@@ -30,11 +30,11 @@ function Add-WhiskeyTaskDefault
 
         [Parameter(Mandatory)]
         # The name of the task that a default parameter value will be set.
-        [string]$TaskName,
+        [String]$TaskName,
 
         [Parameter(Mandatory)]
         # The name of the task parameter to set a default value for.
-        [string]$PropertyName,
+        [String]$PropertyName,
 
         [Parameter(Mandatory)]
         # The default value for the task parameter.

--- a/Whiskey/Functions/Add-WhiskeyVariable.ps1
+++ b/Whiskey/Functions/Add-WhiskeyVariable.ps1
@@ -21,11 +21,11 @@ function Add-WhiskeyVariable
 
         [Parameter(Mandatory)]
         # The name of the variable.
-        [string]$Name,
+        [String]$Name,
 
         [Parameter(Mandatory)]
         [AllowEmptyString()]
-        [object]$Value
+        [Object]$Value
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Add-WhiskeyVariable.ps1
+++ b/Whiskey/Functions/Add-WhiskeyVariable.ps1
@@ -15,20 +15,17 @@ function Add-WhiskeyVariable
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
+        [Parameter(Mandatory)]
         # The context of the build here you want to add a variable.
-        $Context,
+        [Whiskey.Context]$Context,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The name of the variable.
-        $Name,
+        [string]$Name,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         [AllowEmptyString()]
-        [object]
-        $Value
+        [object]$Value
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Assert-WhiskeyNodeModulePath.ps1
+++ b/Whiskey/Functions/Assert-WhiskeyNodeModulePath.ps1
@@ -24,10 +24,10 @@ function Assert-WhiskeyNodeModulePath
     param(
         [Parameter(Mandatory)]
         # The path to check.
-        [string]$Path,
+        [String]$Path,
 
         # The path to a command inside the module path.
-        [string]$CommandPath
+        [String]$CommandPath
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Assert-WhiskeyNodeModulePath.ps1
+++ b/Whiskey/Functions/Assert-WhiskeyNodeModulePath.ps1
@@ -22,14 +22,12 @@ function Assert-WhiskeyNodeModulePath
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The path to check.
-        $Path,
+        [string]$Path,
 
-        [string]
         # The path to a command inside the module path.
-        $CommandPath
+        [string]$CommandPath
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Assert-WhiskeyNodePath.ps1
+++ b/Whiskey/Functions/Assert-WhiskeyNodePath.ps1
@@ -24,7 +24,7 @@ function Assert-WhiskeyNodePath
     param(
         [Parameter(Mandatory)]
         # The path to check.
-        [string]$Path
+        [String]$Path
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Assert-WhiskeyNodePath.ps1
+++ b/Whiskey/Functions/Assert-WhiskeyNodePath.ps1
@@ -22,10 +22,9 @@ function Assert-WhiskeyNodePath
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The path to check.
-        $Path
+        [string]$Path
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/ConvertFrom-WhiskeyContext.ps1
+++ b/Whiskey/Functions/ConvertFrom-WhiskeyContext.ps1
@@ -29,9 +29,8 @@ function ConvertFrom-WhiskeyContext
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,ValueFromPipeline)]
-        [Whiskey.Context]
         # The context to convert. You can pass an existing context via the pipeline.
-        $Context
+        [Whiskey.Context]$Context
     )
 
     begin 

--- a/Whiskey/Functions/ConvertFrom-WhiskeyYamlScalar.ps1
+++ b/Whiskey/Functions/ConvertFrom-WhiskeyYamlScalar.ps1
@@ -26,12 +26,11 @@ function ConvertFrom-WhiskeyYamlScalar
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
+        [Parameter(Mandatory,ValueFromPipeline)]
         [AllowEmptyString()]
         [AllowNull()]
-        [string]
         # The object to convert.
-        $InputObject
+        [string]$InputObject
     )
 
     process

--- a/Whiskey/Functions/ConvertFrom-WhiskeyYamlScalar.ps1
+++ b/Whiskey/Functions/ConvertFrom-WhiskeyYamlScalar.ps1
@@ -30,7 +30,7 @@ function ConvertFrom-WhiskeyYamlScalar
         [AllowEmptyString()]
         [AllowNull()]
         # The object to convert.
-        [string]$InputObject
+        [String]$InputObject
     )
 
     process
@@ -38,7 +38,7 @@ function ConvertFrom-WhiskeyYamlScalar
         Set-StrictMode -Version 'Latest'
         Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
-        if( [string]::IsNullOrEmpty($InputObject)  -or $InputObject -match '^(~|null)' )
+        if( [String]::IsNullOrEmpty($InputObject)  -or $InputObject -match '^(~|null)' )
         {
             return $null
         }
@@ -98,23 +98,23 @@ function ConvertFrom-WhiskeyYamlScalar
         if( [Text.RegularExpressions.Regex]::IsMatch($InputObject, $regex, [Text.RegularExpressions.RegexOptions]::IgnorePatternWhitespace) ) 
         {
             $value = $InputObject -replace '_',''
-            [double]$double = 0.0
+            [Double]$double = 0.0
             if( $value -eq '.NaN' )
             {
-                return [double]::NaN
+                return [Double]::NaN
             }
 
             if( $value -match '-\.inf' )
             {
-                return [double]::NegativeInfinity
+                return [Double]::NegativeInfinity
             }
 
             if( $value -match '\+?.inf' )
             {
-                return [double]::PositiveInfinity
+                return [Double]::PositiveInfinity
             }
 
-            if( [double]::TryParse($value,[ref]$double) )
+            if( [Double]::TryParse($value,[ref]$double) )
             {
                 return $double
             }

--- a/Whiskey/Functions/ConvertTo-WhiskeyContext.ps1
+++ b/Whiskey/Functions/ConvertTo-WhiskeyContext.ps1
@@ -27,9 +27,8 @@ function ConvertTo-WhiskeyContext
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,ValueFromPipeline)]
-        [object]
         # The context to convert. You can pass an existing context via the pipeline.
-        $InputObject
+        [object]$InputObject
     )
 
     process 
@@ -42,16 +41,13 @@ function ConvertTo-WhiskeyContext
             function Sync-ObjectProperty
             {
                 param(
-                    [Parameter(Mandatory=$true)]
-                    [object]
-                    $Source,
+                    [Parameter(Mandatory)]
+                    [object]$Source,
 
-                    [Parameter(Mandatory=$true)]
-                    [object]
-                    $Destination,
+                    [Parameter(Mandatory)]
+                    [object]$Destination,
 
-                    [string[]]
-                    $ExcludeProperty
+                    [string[]]$ExcludeProperty
                 )
 
                 $destinationType = $Destination.GetType()

--- a/Whiskey/Functions/ConvertTo-WhiskeyContext.ps1
+++ b/Whiskey/Functions/ConvertTo-WhiskeyContext.ps1
@@ -28,7 +28,7 @@ function ConvertTo-WhiskeyContext
     param(
         [Parameter(Mandatory,ValueFromPipeline)]
         # The context to convert. You can pass an existing context via the pipeline.
-        [object]$InputObject
+        [Object]$InputObject
     )
 
     process 
@@ -42,12 +42,12 @@ function ConvertTo-WhiskeyContext
             {
                 param(
                     [Parameter(Mandatory)]
-                    [object]$Source,
+                    [Object]$Source,
 
                     [Parameter(Mandatory)]
-                    [object]$Destination,
+                    [Object]$Destination,
 
-                    [string[]]$ExcludeProperty
+                    [String[]]$ExcludeProperty
                 )
 
                 $destinationType = $Destination.GetType()

--- a/Whiskey/Functions/ConvertTo-WhiskeySemanticVersion.ps1
+++ b/Whiskey/Functions/ConvertTo-WhiskeySemanticVersion.ps1
@@ -15,10 +15,9 @@ function ConvertTo-WhiskeySemanticVersion
     #>
     [CmdletBinding()]
     param(
-        [Parameter(ValueFromPipeline=$true)]
-        [object]
+        [Parameter(ValueFromPipeline)]
         # The object to convert to a semantic version. Can be a version string, number, or date/time.
-        $InputObject
+        [object]$InputObject
     )
 
     process

--- a/Whiskey/Functions/ConvertTo-WhiskeySemanticVersion.ps1
+++ b/Whiskey/Functions/ConvertTo-WhiskeySemanticVersion.ps1
@@ -17,7 +17,7 @@ function ConvertTo-WhiskeySemanticVersion
     param(
         [Parameter(ValueFromPipeline)]
         # The object to convert to a semantic version. Can be a version string, number, or date/time.
-        [object]$InputObject
+        [Object]$InputObject
     )
 
     process
@@ -25,18 +25,18 @@ function ConvertTo-WhiskeySemanticVersion
         Set-StrictMode -Version 'Latest'
         Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
-        [version]$asVersion = $null
-        if( $InputObject -is [string] )
+        [Version]$asVersion = $null
+        if( $InputObject -is [String] )
         {
             [int]$asInt = 0
-            [double]$asDouble = 0.0
+            [Double]$asDouble = 0.0
             [SemVersion.SemanticVersion]$semVersion = $null
             if( [SemVersion.SemanticVersion]::TryParse($InputObject,[ref]$semVersion) )
             {
                 return $semVersion
             }
 
-            if( [version]::TryParse($InputObject,[ref]$asVersion) )
+            if( [Version]::TryParse($InputObject,[ref]$asVersion) )
             {
                 $InputObject = $asVersion
             }
@@ -54,7 +54,7 @@ function ConvertTo-WhiskeySemanticVersion
         {
             $InputObject = '{0}.{1}.{2}' -f $InputObject.Month,$InputObject.Day,$InputObject.Year
         }
-        elseif( $InputObject -is [double] )
+        elseif( $InputObject -is [Double] )
         {
             $major,$minor = $InputObject.ToString('g') -split '\.'
             if( -not $minor )
@@ -67,7 +67,7 @@ function ConvertTo-WhiskeySemanticVersion
         {
             $InputObject = '{0}.0.0' -f $InputObject
         }
-        elseif( $InputObject -is [version] )
+        elseif( $InputObject -is [Version] )
         {
             if( $InputObject.Build -le -1 )
             {

--- a/Whiskey/Functions/ConvertTo-WhiskeySemanticVersion.ps1
+++ b/Whiskey/Functions/ConvertTo-WhiskeySemanticVersion.ps1
@@ -50,7 +50,7 @@ function ConvertTo-WhiskeySemanticVersion
         {
             return $InputObject
         }
-        elseif( $InputObject -is [datetime] )
+        elseif( $InputObject -is [DateTime] )
         {
             $InputObject = '{0}.{1}.{2}' -f $InputObject.Month,$InputObject.Day,$InputObject.Year
         }

--- a/Whiskey/Functions/ConvertTo-WhiskeyTask.ps1
+++ b/Whiskey/Functions/ConvertTo-WhiskeyTask.ps1
@@ -15,13 +15,13 @@ function ConvertTo-WhiskeyTask
     param(
         [Parameter(Mandatory)]
         [AllowNull()]
-        [object]$InputObject
+        [Object]$InputObject
     )
 
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
     
-    if( $InputObject -is [string] )
+    if( $InputObject -is [String] )
     {
         $InputObject
         @{ }

--- a/Whiskey/Functions/ConvertTo-WhiskeyTask.ps1
+++ b/Whiskey/Functions/ConvertTo-WhiskeyTask.ps1
@@ -13,10 +13,9 @@ function ConvertTo-WhiskeyTask
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         [AllowNull()]
-        [object]
-        $InputObject
+        [object]$InputObject
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Format-WhiskeyMessage.ps1
+++ b/Whiskey/Functions/Format-WhiskeyMessage.ps1
@@ -3,10 +3,10 @@ function Format-WhiskeyMessage
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         [Whiskey.Context]$Context,
 
-        [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
+        [Parameter(Mandatory,ValueFromPipeline)]
         [AllowEmptyString()]
         [AllowNull()]
         [string]$Message,

--- a/Whiskey/Functions/Format-WhiskeyMessage.ps1
+++ b/Whiskey/Functions/Format-WhiskeyMessage.ps1
@@ -9,7 +9,7 @@ function Format-WhiskeyMessage
         [Parameter(Mandatory,ValueFromPipeline)]
         [AllowEmptyString()]
         [AllowNull()]
-        [string]$Message,
+        [String]$Message,
 
         [int]$Indent = 0
     )

--- a/Whiskey/Functions/Get-MSBuild.ps1
+++ b/Whiskey/Functions/Get-MSBuild.ps1
@@ -11,8 +11,7 @@ function Get-MSBuild
     function Resolve-MSBuildToolsPath
     {
         param(
-            [Microsoft.Win32.RegistryKey]
-            $Key
+            [Microsoft.Win32.RegistryKey]$Key
         )
 
         $toolsPath = Get-ItemProperty -Path $Key.PSPath -Name 'MSBuildToolsPath' -ErrorAction Ignore | Select-Object -ExpandProperty 'MSBuildToolsPath' -ErrorAction Ignore

--- a/Whiskey/Functions/Get-MSBuild.ps1
+++ b/Whiskey/Functions/Get-MSBuild.ps1
@@ -33,7 +33,7 @@ function Get-MSBuild
     filter Test-Version
     {
         param(
-            [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
+            [Parameter(Mandatory,ValueFromPipeline)]
             $InputObject
         )
 

--- a/Whiskey/Functions/Get-MSBuild.ps1
+++ b/Whiskey/Functions/Get-MSBuild.ps1
@@ -36,8 +36,8 @@ function Get-MSBuild
             $InputObject
         )
 
-        [version]$version = $null
-        [version]::TryParse($InputObject,[ref]$version)
+        [Version]$version = $null
+        [Version]::TryParse($InputObject,[ref]$version)
 
     }
 
@@ -75,7 +75,7 @@ function Get-MSBuild
 
         [pscustomobject]@{
             Name = $name;
-            Version = [version]$name;
+            Version = [Version]$name;
             Path = $msbuildPath;
             Path32 = $msbuildPath32;
         }
@@ -114,7 +114,7 @@ function Get-MSBuild
 
             [pscustomobject]@{
                                 Name =  $versionRoot.Name;
-                                Version = [version]$versionRoot.Name;
+                                Version = [Version]$versionRoot.Name;
                                 Path = $path;
                                 Path32 = $path32;
                             }

--- a/Whiskey/Functions/Get-TaskParameter.ps1
+++ b/Whiskey/Functions/Get-TaskParameter.ps1
@@ -36,7 +36,7 @@ function Get-TaskParameter
         $value = $TaskProperty[$propertyName]
 
         # PowerShell can't implicitly convert strings to bool/switch values so we have to do it.
-        if( $cmdParameter.ParameterType -eq [Switch] -or $cmdParameter.ParameterType -eq [bool] )
+        if( $cmdParameter.ParameterType -eq [switch] -or $cmdParameter.ParameterType -eq [bool] )
         {
             $value = $value | ConvertFrom-WhiskeyYamlScalar
         }

--- a/Whiskey/Functions/Get-TaskParameter.ps1
+++ b/Whiskey/Functions/Get-TaskParameter.ps1
@@ -5,7 +5,7 @@ function Get-TaskParameter
     param(
         # The name of the command.
         [Parameter(Mandatory)]
-        [string]$Name,
+        [String]$Name,
 
         # The properties from the tasks's YAML.
         [Parameter(Mandatory)]

--- a/Whiskey/Functions/Get-WhiskeyApiKey.ps1
+++ b/Whiskey/Functions/Get-WhiskeyApiKey.ps1
@@ -18,20 +18,17 @@ function Get-WhiskeyApiKey
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
+        [Parameter(Mandatory)]
         # The current build context. Use `New-WhiskeyContext` to create context objects.
-        $Context,
+        [Whiskey.Context]$Context,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The ID of the API key. You make this up.
-        $ID,
+        [string]$ID,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The property name in the task that needs this API key. Used in error messages to help users pinpoint what task and property might be misconfigured.
-        $PropertyName
+        [string]$PropertyName
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Get-WhiskeyApiKey.ps1
+++ b/Whiskey/Functions/Get-WhiskeyApiKey.ps1
@@ -24,11 +24,11 @@ function Get-WhiskeyApiKey
 
         [Parameter(Mandatory)]
         # The ID of the API key. You make this up.
-        [string]$ID,
+        [String]$ID,
 
         [Parameter(Mandatory)]
         # The property name in the task that needs this API key. Used in error messages to help users pinpoint what task and property might be misconfigured.
-        [string]$PropertyName
+        [String]$PropertyName
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Get-WhiskeyCredential.ps1
+++ b/Whiskey/Functions/Get-WhiskeyCredential.ps1
@@ -16,24 +16,20 @@ function Get-WhiskeyCredential
     Demonstrates how to get a credential. IN this case, retrieves the credential that was added with the ID `bitbucketserver.example.com`.    #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
+        [Parameter(Mandatory)]
         # The current build context. Use `New-WhiskeyContext` to create context objects.
-        $Context,
+        [Whiskey.Context]$Context,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The ID of the credential. You make this up.
-        $ID,
+        [string]$ID,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The property name in the task that needs this credential. Used in error messages to help users pinpoint what task and property might be misconfigured.
-        $PropertyName,
+        [string]$PropertyName,
 
-        [string]
         # INTERNAL. DO NOT USE.
-        $PropertyDescription
+        [string]$PropertyDescription
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Get-WhiskeyCredential.ps1
+++ b/Whiskey/Functions/Get-WhiskeyCredential.ps1
@@ -22,14 +22,14 @@ function Get-WhiskeyCredential
 
         [Parameter(Mandatory)]
         # The ID of the credential. You make this up.
-        [string]$ID,
+        [String]$ID,
 
         [Parameter(Mandatory)]
         # The property name in the task that needs this credential. Used in error messages to help users pinpoint what task and property might be misconfigured.
-        [string]$PropertyName,
+        [String]$PropertyName,
 
         # INTERNAL. DO NOT USE.
-        [string]$PropertyDescription
+        [String]$PropertyDescription
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Get-WhiskeyMSBuildConfiguration.ps1
+++ b/Whiskey/Functions/Get-WhiskeyMSBuildConfiguration.ps1
@@ -17,10 +17,9 @@ function Get-WhiskeyMSBuildConfiguration
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
+        [Parameter(Mandatory)]
         # The context of the current build.
-        $Context
+        [Whiskey.Context]$Context
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Get-WhiskeyTasks.ps1
+++ b/Whiskey/Functions/Get-WhiskeyTasks.ps1
@@ -22,7 +22,7 @@ function Get-WhiskeyTask
     [OutputType([Whiskey.TaskAttribute])]
     param(
         # Return tasks that are obsolete. Otherwise, no obsolete tasks are returned.
-        [Switch]$Force
+        [switch]$Force
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Get-WhiskeyTasks.ps1
+++ b/Whiskey/Functions/Get-WhiskeyTasks.ps1
@@ -21,9 +21,8 @@ function Get-WhiskeyTask
     [CmdLetBinding()]
     [OutputType([Whiskey.TaskAttribute])]
     param(
-        [Switch]
         # Return tasks that are obsolete. Otherwise, no obsolete tasks are returned.
-        $Force
+        [Switch]$Force
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Import-WhiskeyPowerShellModule.ps1
+++ b/Whiskey/Functions/Import-WhiskeyPowerShellModule.ps1
@@ -26,11 +26,11 @@ function Import-WhiskeyPowerShellModule
     param(
         [Parameter(Mandatory)]
         # The module names to import.
-        [string[]]$Name,
+        [String[]]$Name,
 
         [Parameter(Mandatory)]
         # The path to the build root, where the PSModules directory can be found.
-        [string]$BuildRoot
+        [String]$BuildRoot
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Import-WhiskeyYaml.ps1
+++ b/Whiskey/Functions/Import-WhiskeyYaml.ps1
@@ -3,13 +3,11 @@ function Import-WhiskeyYaml
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true,ParameterSetName='FromFile')]
-        [string]
-        $Path,
+        [Parameter(Mandatory,ParameterSetName='FromFile')]
+        [string]$Path,
 
-        [Parameter(Mandatory=$true,ParameterSetName='FromString')]
-        [string]
-        $Yaml
+        [Parameter(Mandatory,ParameterSetName='FromString')]
+        [string]$Yaml
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Import-WhiskeyYaml.ps1
+++ b/Whiskey/Functions/Import-WhiskeyYaml.ps1
@@ -4,10 +4,10 @@ function Import-WhiskeyYaml
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,ParameterSetName='FromFile')]
-        [string]$Path,
+        [String]$Path,
 
         [Parameter(Mandatory,ParameterSetName='FromString')]
-        [string]$Yaml
+        [String]$Yaml
     )
 
     Set-StrictMode -Version 'Latest'
@@ -37,7 +37,7 @@ function Import-WhiskeyYaml
         $config = @{} 
     }
 
-    if( $config -is [string] )
+    if( $config -is [String] )
     {
         $config = @{ $config = '' }
     }

--- a/Whiskey/Functions/Install-WhiskeyDotNetSdk.ps1
+++ b/Whiskey/Functions/Install-WhiskeyDotNetSdk.ps1
@@ -22,11 +22,11 @@ function Install-WhiskeyDotNetSdk
     param(
         [Parameter(Mandatory)]
         # Directory where the .NET Core SDK will be installed.
-        [string]$InstallRoot,
+        [String]$InstallRoot,
 
         [Parameter(Mandatory)]
         # Version of the .NET Core SDK to install.
-        [string]$Version,
+        [String]$Version,
 
         # Search for the desired version from existing global installs of the .NET Core SDK. If found, the install is skipped and the path to the global install is returned.
         [switch]$Global

--- a/Whiskey/Functions/Install-WhiskeyDotNetSdk.ps1
+++ b/Whiskey/Functions/Install-WhiskeyDotNetSdk.ps1
@@ -20,19 +20,16 @@ function Install-WhiskeyDotNetSdk
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # Directory where the .NET Core SDK will be installed.
-        $InstallRoot,
+        [string]$InstallRoot,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # Version of the .NET Core SDK to install.
-        $Version,
+        [string]$Version,
 
-        [switch]
         # Search for the desired version from existing global installs of the .NET Core SDK. If found, the install is skipped and the path to the global install is returned.
-        $Global
+        [switch]$Global
     )
 
     Set-StrictMode -version 'Latest'

--- a/Whiskey/Functions/Install-WhiskeyDotNetTool.ps1
+++ b/Whiskey/Functions/Install-WhiskeyDotNetTool.ps1
@@ -27,16 +27,16 @@ function Install-WhiskeyDotNetTool
     param(
         [Parameter(Mandatory)]
         # Path where the `.dotnet` directory will be installed containing the .NET Core SDK.
-        [string]$InstallRoot,
+        [String]$InstallRoot,
 
         [Parameter(Mandatory)]
         # The working directory of the task requiring the .NET Core SDK tool. This path is used for searching for an existing `global.json` file containing an SDK version value.
-        [string]$WorkingDirectory,
+        [String]$WorkingDirectory,
 
         [AllowEmptyString()]
         [AllowNull()]
         # The version of the .NET Core SDK to install. Accepts wildcards.
-        [string]$Version
+        [String]$Version
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Install-WhiskeyDotNetTool.ps1
+++ b/Whiskey/Functions/Install-WhiskeyDotNetTool.ps1
@@ -25,21 +25,18 @@ function Install-WhiskeyDotNetTool
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # Path where the `.dotnet` directory will be installed containing the .NET Core SDK.
-        $InstallRoot,
+        [string]$InstallRoot,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The working directory of the task requiring the .NET Core SDK tool. This path is used for searching for an existing `global.json` file containing an SDK version value.
-        $WorkingDirectory,
+        [string]$WorkingDirectory,
 
         [AllowEmptyString()]
         [AllowNull()]
-        [string]
         # The version of the .NET Core SDK to install. Accepts wildcards.
-        $Version
+        [string]$Version
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Install-WhiskeyNode.ps1
+++ b/Whiskey/Functions/Install-WhiskeyNode.ps1
@@ -5,13 +5,13 @@ function Install-WhiskeyNode
     param(
         [Parameter(Mandatory)]
         # The directory where Node should be installed. Will actually be installed into `Join-Path -Path $InstallRoot -ChildPath '.node'`.
-        [string]$InstallRoot,
+        [String]$InstallRoot,
 
         # Are we running in clean mode? If so, don't re-install the tool.
         [switch]$InCleanMode,
 
         # The version of Node to install. If not provided, will use the version defined in the package.json file. If that isn't supplied, will install the latest LTS version.
-        [string]$Version
+        [String]$Version
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Install-WhiskeyNode.ps1
+++ b/Whiskey/Functions/Install-WhiskeyNode.ps1
@@ -8,7 +8,7 @@ function Install-WhiskeyNode
         [string]$InstallRoot,
 
         # Are we running in clean mode? If so, don't re-install the tool.
-        [Switch]$InCleanMode,
+        [switch]$InCleanMode,
 
         # The version of Node to install. If not provided, will use the version defined in the package.json file. If that isn't supplied, will install the latest LTS version.
         [string]$Version

--- a/Whiskey/Functions/Install-WhiskeyNode.ps1
+++ b/Whiskey/Functions/Install-WhiskeyNode.ps1
@@ -4,17 +4,14 @@ function Install-WhiskeyNode
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]
         # The directory where Node should be installed. Will actually be installed into `Join-Path -Path $InstallRoot -ChildPath '.node'`.
-        $InstallRoot,
+        [string]$InstallRoot,
 
-        [Switch]
         # Are we running in clean mode? If so, don't re-install the tool.
-        $InCleanMode,
+        [Switch]$InCleanMode,
 
-        [string]
         # The version of Node to install. If not provided, will use the version defined in the package.json file. If that isn't supplied, will install the latest LTS version.
-        $Version
+        [string]$Version
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Install-WhiskeyNodeModule.ps1
+++ b/Whiskey/Functions/Install-WhiskeyNodeModule.ps1
@@ -25,17 +25,17 @@ function Install-WhiskeyNodeModule
     param(
         [Parameter(Mandatory)]
         # The name of the module to install.
-        [string]$Name,
+        [String]$Name,
 
         # The version of the module to install.
-        [string]$Version,
+        [String]$Version,
 
         # Node modules are being installed on a developer computer.
         [switch]$ForDeveloper,
 
         [Parameter(Mandatory)]
         # The path to the build root.
-        [string]$BuildRootPath,
+        [String]$BuildRootPath,
 
         # Whether or not to install the module globally.
         [switch]$Global,

--- a/Whiskey/Functions/Install-WhiskeyNodeModule.ps1
+++ b/Whiskey/Functions/Install-WhiskeyNodeModule.ps1
@@ -38,10 +38,10 @@ function Install-WhiskeyNodeModule
         [string]$BuildRootPath,
 
         # Whether or not to install the module globally.
-        [Switch]$Global,
+        [switch]$Global,
 
         # Are we running in clean mode?
-        [Switch]$InCleanMode
+        [switch]$InCleanMode
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Install-WhiskeyNodeModule.ps1
+++ b/Whiskey/Functions/Install-WhiskeyNodeModule.ps1
@@ -23,31 +23,25 @@ function Install-WhiskeyNodeModule
     
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The name of the module to install.
-        $Name,
+        [string]$Name,
 
-        [string]
         # The version of the module to install.
-        $Version,
+        [string]$Version,
 
-        [switch]
         # Node modules are being installed on a developer computer.
-        $ForDeveloper,
+        [switch]$ForDeveloper,
 
         [Parameter(Mandatory)]
-        [string]
         # The path to the build root.
-        $BuildRootPath,
+        [string]$BuildRootPath,
 
-        [Switch]
         # Whether or not to install the module globally.
-        $Global,
+        [Switch]$Global,
 
-        [Switch]
         # Are we running in clean mode?
-        $InCleanMode
+        [Switch]$InCleanMode
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Install-WhiskeyNuGet.ps1
+++ b/Whiskey/Functions/Install-WhiskeyNuGet.ps1
@@ -12,10 +12,10 @@ function Install-WhiskeyNuGet
     param(
         [Parameter(Mandatory)]
         # Where to install NuGet.
-        [string]$DownloadRoot,
+        [String]$DownloadRoot,
 
         # The version to download.
-        [string]$Version
+        [String]$Version
     )
 
     Set-StrictMode -version 'Latest'  

--- a/Whiskey/Functions/Install-WhiskeyNuGet.ps1
+++ b/Whiskey/Functions/Install-WhiskeyNuGet.ps1
@@ -10,14 +10,12 @@ function Install-WhiskeyNuGet
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # Where to install NuGet.
-        $DownloadRoot,
+        [string]$DownloadRoot,
 
-        [string]
         # The version to download.
-        $Version
+        [string]$Version
     )
 
     Set-StrictMode -version 'Latest'  

--- a/Whiskey/Functions/Install-WhiskeyPowerShellModule.ps1
+++ b/Whiskey/Functions/Install-WhiskeyPowerShellModule.ps1
@@ -28,14 +28,14 @@ function Install-WhiskeyPowerShellModule
     param(
         [Parameter(Mandatory)]
         # The name of the module to install.
-        [string]$Name,
+        [String]$Name,
 
         # The version of the module to install.
-        [string]$Version,
+        [String]$Version,
 
         [Parameter(Mandatory)]
         # Modules are saved into a PSModules directory. This is the directory where PSModules directory should created, *not* the path to the PSModules directory itself, i.e. this is the path to the "PSModules" directory's parent directory.
-        [string]$BuildRoot,
+        [String]$BuildRoot,
 
         # Don't import the module.
         [switch]$SkipImport

--- a/Whiskey/Functions/Install-WhiskeyPowerShellModule.ps1
+++ b/Whiskey/Functions/Install-WhiskeyPowerShellModule.ps1
@@ -26,7 +26,7 @@ function Install-WhiskeyPowerShellModule
 
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         # The name of the module to install.
         [string]$Name,
 

--- a/Whiskey/Functions/Install-WhiskeyPowerShellModule.ps1
+++ b/Whiskey/Functions/Install-WhiskeyPowerShellModule.ps1
@@ -38,7 +38,7 @@ function Install-WhiskeyPowerShellModule
         [string]$BuildRoot,
 
         # Don't import the module.
-        [Switch]$SkipImport
+        [switch]$SkipImport
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Install-WhiskeyTool.ps1
+++ b/Whiskey/Functions/Install-WhiskeyTool.ps1
@@ -33,7 +33,7 @@ function Install-WhiskeyTool
 
         [Parameter(ParameterSetName='Tool')]
         # Running in clean mode, so don't install the tool if it isn't installed.
-        [Switch]$InCleanMode,
+        [switch]$InCleanMode,
 
         [Parameter(Mandatory,ParameterSetName='NuGet')]
         # The name of the NuGet package to download.

--- a/Whiskey/Functions/Install-WhiskeyTool.ps1
+++ b/Whiskey/Functions/Install-WhiskeyTool.ps1
@@ -25,7 +25,7 @@ function Install-WhiskeyTool
 
         [Parameter(Mandatory,ParameterSetName='Tool')]
         # The directory where you want the tools installed.
-        [string]$InstallRoot,
+        [String]$InstallRoot,
 
         [Parameter(Mandatory,ParameterSetName='Tool')]
         # The task parameters for the currently running task.
@@ -37,11 +37,11 @@ function Install-WhiskeyTool
 
         [Parameter(Mandatory,ParameterSetName='NuGet')]
         # The name of the NuGet package to download.
-        [string]$NuGetPackageName,
+        [String]$NuGetPackageName,
 
         [Parameter(ParameterSetName='NuGet')]
         # The version of the package to download. Must be a three part number, i.e. it must have a MAJOR, MINOR, and BUILD number.
-        [string]$Version,
+        [String]$Version,
 
         [Parameter(Mandatory,ParameterSetName='NuGet')]
         # The root directory where the tools should be downloaded. The default is your build root.
@@ -49,7 +49,7 @@ function Install-WhiskeyTool
         # PowerShell modules are saved to `$DownloadRoot\Modules`.
         #
         # NuGet packages are saved to `$DownloadRoot\packages`.
-        [string]$DownloadRoot
+        [String]$DownloadRoot
     )
 
     Set-StrictMode -Version 'Latest'
@@ -74,7 +74,7 @@ function Install-WhiskeyTool
     {
         try
         {
-            [void]$installLock.WaitOne()
+            [Void]$installLock.WaitOne()
         }
         catch [Threading.AbandonedMutexException]
         {

--- a/Whiskey/Functions/Invoke-WhiskeyBuild.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyBuild.ps1
@@ -61,7 +61,7 @@ function Invoke-WhiskeyBuild
         # The name(s) of any pipelines to run. Default behavior is to run the `Build` pipeline and, if on a publishing branch, the `Publish` pipeline.
         #
         # If you pass a value to this parameter, the `Publish` pipeline is *not* run implicitly. You must pass its name to run it.
-        [string[]]$PipelineName,
+        [String[]]$PipelineName,
 
         [Parameter(Mandatory,ParameterSetName='Clean')]
         # Runs the build in clean mode. In clean mode, tasks delete any artifacts they create, including downloaded tools and dependencies. This is opt-in, so if a task is not deleting its artifacts, it needs to be updated to support clean mode.

--- a/Whiskey/Functions/Invoke-WhiskeyBuild.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyBuild.ps1
@@ -65,11 +65,11 @@ function Invoke-WhiskeyBuild
 
         [Parameter(Mandatory,ParameterSetName='Clean')]
         # Runs the build in clean mode. In clean mode, tasks delete any artifacts they create, including downloaded tools and dependencies. This is opt-in, so if a task is not deleting its artifacts, it needs to be updated to support clean mode.
-        [Switch]$Clean,
+        [switch]$Clean,
 
         [Parameter(Mandatory,ParameterSetName='Initialize')]
         # Runs the build in initialize mode. In initialize mode, tasks download/install/configure any tools/dependencies they use/need during the build. Initialize mode is intended to be used by developers so that any tools/dependencies they need can be downloaded/installe/configured without needing to run an entire build, which can sometimes take a long time.
-        [Switch]$Initialize
+        [switch]$Initialize
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Invoke-WhiskeyBuild.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyBuild.ps1
@@ -54,26 +54,22 @@ function Invoke-WhiskeyBuild
     #>
     [CmdletBinding(DefaultParameterSetName='Build')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
+        [Parameter(Mandatory)]
         # The context for the build. Use `New-WhiskeyContext` to create context objects.
-        $Context,
+        [Whiskey.Context]$Context,
 
-        [string[]]
         # The name(s) of any pipelines to run. Default behavior is to run the `Build` pipeline and, if on a publishing branch, the `Publish` pipeline.
         #
         # If you pass a value to this parameter, the `Publish` pipeline is *not* run implicitly. You must pass its name to run it.
-        $PipelineName,
+        [string[]]$PipelineName,
 
-        [Parameter(Mandatory=$true,ParameterSetName='Clean')]
-        [Switch]
+        [Parameter(Mandatory,ParameterSetName='Clean')]
         # Runs the build in clean mode. In clean mode, tasks delete any artifacts they create, including downloaded tools and dependencies. This is opt-in, so if a task is not deleting its artifacts, it needs to be updated to support clean mode.
-        $Clean,
+        [Switch]$Clean,
 
-        [Parameter(Mandatory=$true,ParameterSetName='Initialize')]
-        [Switch]
+        [Parameter(Mandatory,ParameterSetName='Initialize')]
         # Runs the build in initialize mode. In initialize mode, tasks download/install/configure any tools/dependencies they use/need during the build. Initialize mode is intended to be used by developers so that any tools/dependencies they need can be downloaded/installe/configured without needing to run an entire build, which can sometimes take a long time.
-        $Initialize
+        [Switch]$Initialize
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Invoke-WhiskeyDotNetCommand.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyDotNetCommand.ps1
@@ -17,28 +17,23 @@ function Invoke-WhiskeyDotNetCommand
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
+        [Parameter(Mandatory)]
         # The `Whiskey.Context` object for the task running the command.
-        $TaskContext,
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The path to the `dotnet` executable to run the SDK command with.
-        $DotNetPath,
+        [string]$DotNetPath,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The name of the .NET Core SDK command to run.
-        $Name,
+        [string]$Name,
 
-        [string[]]
         # A list of arguments to pass to the .NET Core SDK command.
-        $ArgumentList,
+        [string[]]$ArgumentList,
 
-        [string]
         # The path to a .NET Core solution or project file to pass to the .NET Core SDK command.
-        $ProjectPath
+        [string]$ProjectPath
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Invoke-WhiskeyDotNetCommand.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyDotNetCommand.ps1
@@ -23,17 +23,17 @@ function Invoke-WhiskeyDotNetCommand
 
         [Parameter(Mandatory)]
         # The path to the `dotnet` executable to run the SDK command with.
-        [string]$DotNetPath,
+        [String]$DotNetPath,
 
         [Parameter(Mandatory)]
         # The name of the .NET Core SDK command to run.
-        [string]$Name,
+        [String]$Name,
 
         # A list of arguments to pass to the .NET Core SDK command.
-        [string[]]$ArgumentList,
+        [String[]]$ArgumentList,
 
         # The path to a .NET Core solution or project file to pass to the .NET Core SDK command.
-        [string]$ProjectPath
+        [String]$ProjectPath
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Invoke-WhiskeyNpmCommand.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyNpmCommand.ps1
@@ -27,22 +27,18 @@ function Invoke-WhiskeyNpmCommand
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The NPM command to execute, e.g. `install`, `prune`, `run-script`, etc.
-        $Name,
+        [string]$Name,
         
-        [string[]]
         # An array of arguments to be given to the NPM command being executed.
-        $ArgumentList,
+        [string[]]$ArgumentList,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $BuildRootPath,
+        [Parameter(Mandatory)]
+        [string]$BuildRootPath,
 
-        [switch]
         # NPM commands are being run on a developer computer.
-        $ForDeveloper
+        [switch]$ForDeveloper
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Invoke-WhiskeyNpmCommand.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyNpmCommand.ps1
@@ -29,13 +29,13 @@ function Invoke-WhiskeyNpmCommand
     param(
         [Parameter(Mandatory)]
         # The NPM command to execute, e.g. `install`, `prune`, `run-script`, etc.
-        [string]$Name,
+        [String]$Name,
         
         # An array of arguments to be given to the NPM command being executed.
-        [string[]]$ArgumentList,
+        [String[]]$ArgumentList,
 
         [Parameter(Mandatory)]
-        [string]$BuildRootPath,
+        [String]$BuildRootPath,
 
         # NPM commands are being run on a developer computer.
         [switch]$ForDeveloper

--- a/Whiskey/Functions/Invoke-WhiskeyNuGetPush.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyNuGetPush.ps1
@@ -4,16 +4,16 @@ function Invoke-WhiskeyNuGetPush
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$Path,
+        [String]$Path,
 
         [Parameter(Mandatory)]
-        [string]$Uri,
+        [String]$Uri,
 
         [Parameter(Mandatory)]
-        [string]$ApiKey,
+        [String]$ApiKey,
 
         [Parameter(Mandatory)]
-        [string]$NuGetPath
+        [String]$NuGetPath
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Invoke-WhiskeyNuGetPush.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyNuGetPush.ps1
@@ -3,21 +3,17 @@ function Invoke-WhiskeyNuGetPush
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
-        $Path,
+        [Parameter(Mandatory)]
+        [string]$Path,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $Uri,
+        [Parameter(Mandatory)]
+        [string]$Uri,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $ApiKey,
+        [Parameter(Mandatory)]
+        [string]$ApiKey,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $NuGetPath
+        [Parameter(Mandatory)]
+        [string]$NuGetPath
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Invoke-WhiskeyPipeline.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyPipeline.ps1
@@ -24,15 +24,13 @@ function Invoke-WhiskeyPipeline
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
+        [Parameter(Mandatory)]
         # The current build context. Use the `New-WhiskeyContext` function to create a context object.
-        $Context,
+        [Whiskey.Context]$Context,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The name of pipeline to run, e.g. `Build` would run all the tasks under a property named `Build`. Pipelines are properties in your `whiskey.yml` file that are lists of Whiskey tasks to run.
-        $Name
+        [string]$Name
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Invoke-WhiskeyPipeline.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyPipeline.ps1
@@ -30,7 +30,7 @@ function Invoke-WhiskeyPipeline
 
         [Parameter(Mandatory)]
         # The name of pipeline to run, e.g. `Build` would run all the tasks under a property named `Build`. Pipelines are properties in your `whiskey.yml` file that are lists of Whiskey tasks to run.
-        [string]$Name
+        [String]$Name
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Invoke-WhiskeyRobocopy.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyRobocopy.ps1
@@ -4,16 +4,16 @@ function Invoke-WhiskeyRobocopy
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$Source,
+        [String]$Source,
 
         [Parameter(Mandatory)]
-        [string]$Destination,
+        [String]$Destination,
 
-        [string[]]$WhiteList,
+        [String[]]$WhiteList,
 
-        [string[]]$Exclude,
+        [String[]]$Exclude,
 
-        [string]$LogPath
+        [String]$LogPath
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Invoke-WhiskeyRobocopy.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyRobocopy.ps1
@@ -3,22 +3,17 @@ function Invoke-WhiskeyRobocopy
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
-        $Source,
+        [Parameter(Mandatory)]
+        [string]$Source,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $Destination,
+        [Parameter(Mandatory)]
+        [string]$Destination,
 
-        [string[]]
-        $WhiteList,
+        [string[]]$WhiteList,
 
-        [string[]]
-        $Exclude,
+        [string[]]$Exclude,
 
-        [string]
-        $LogPath
+        [string]$LogPath
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Invoke-WhiskeyTask.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyTask.ps1
@@ -16,7 +16,7 @@ function Invoke-WhiskeyTask
 
         [Parameter(Mandatory)]
         # The name of the task.
-        [string]$Name,
+        [String]$Name,
 
         [Parameter(Mandatory)]
         # The parameters/configuration to use to run the task.

--- a/Whiskey/Functions/Invoke-WhiskeyTask.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyTask.ps1
@@ -10,20 +10,17 @@ function Invoke-WhiskeyTask
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
+        [Parameter(Mandatory)]
         # The context this task is operating in. Use `New-WhiskeyContext` to create context objects.
-        $TaskContext,
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The name of the task.
-        $Name,
+        [string]$Name,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
+        [Parameter(Mandatory)]
         # The parameters/configuration to use to run the task.
-        $Parameter
+        [hashtable]$Parameter
     )
 
     Set-StrictMode -Version 'Latest'
@@ -71,11 +68,9 @@ function Invoke-WhiskeyTask
     function Merge-Parameter
     {
         param(
-            [hashtable]
-            $SourceParameter,
+            [hashtable]$SourceParameter,
 
-            [hashtable]
-            $TargetParameter
+            [hashtable]$TargetParameter
         )
 
         foreach( $key in $SourceParameter.Keys )

--- a/Whiskey/Functions/New-WhiskeyContext.ps1
+++ b/Whiskey/Functions/New-WhiskeyContext.ps1
@@ -55,19 +55,16 @@ function New-WhiskeyContext
     [CmdletBinding()]
     [OutputType([Whiskey.Context])]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The environment you're building in.
-        $Environment,
+        [string]$Environment,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The path to the `whiskey.yml` file that defines build settings and tasks.
-        $ConfigurationPath,
+        [string]$ConfigurationPath,
 
-        [string]
         # The place where downloaded tools should be cached. The default is the build root.
-        $DownloadRoot
+        [string]$DownloadRoot
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/New-WhiskeyContext.ps1
+++ b/Whiskey/Functions/New-WhiskeyContext.ps1
@@ -57,14 +57,14 @@ function New-WhiskeyContext
     param(
         [Parameter(Mandatory)]
         # The environment you're building in.
-        [string]$Environment,
+        [String]$Environment,
 
         [Parameter(Mandatory)]
         # The path to the `whiskey.yml` file that defines build settings and tasks.
-        [string]$ConfigurationPath,
+        [String]$ConfigurationPath,
 
         # The place where downloaded tools should be cached. The default is the build root.
-        [string]$DownloadRoot
+        [String]$DownloadRoot
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/New-WhiskeyVersionObject.ps1
+++ b/Whiskey/Functions/New-WhiskeyVersionObject.ps1
@@ -4,8 +4,7 @@ function New-WhiskeyVersionObject
     [CmdletBinding()]
     [OutputType([Whiskey.BuildVersion])]
     param(
-        [SemVersion.SemanticVersion]
-        $SemVer
+        [SemVersion.SemanticVersion]$SemVer
     )
 
     $whiskeyVersion = New-Object -TypeName 'Whiskey.BuildVersion'

--- a/Whiskey/Functions/Publish-WhiskeyPesterTestResult.ps1
+++ b/Whiskey/Functions/Publish-WhiskeyPesterTestResult.ps1
@@ -3,10 +3,9 @@ function Publish-WhiskeyPesterTestResult
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The path to the Pester test resut.
-        $Path
+        [string]$Path
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Publish-WhiskeyPesterTestResult.ps1
+++ b/Whiskey/Functions/Publish-WhiskeyPesterTestResult.ps1
@@ -5,7 +5,7 @@ function Publish-WhiskeyPesterTestResult
     param(
         [Parameter(Mandatory)]
         # The path to the Pester test resut.
-        [string]$Path
+        [String]$Path
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Register-WhiskeyEvent.ps1
+++ b/Whiskey/Functions/Register-WhiskeyEvent.ps1
@@ -16,17 +16,14 @@ function Register-WhiskeyEvent
         function Invoke-WhiskeyTaskEvent
         {
             param(
-                [Parameter(Mandatory=$true)]
-                [object]
-                $TaskContext,
+                [Parameter(Mandatory)]
+                [Whiskey.Context]$TaskContext,
 
-                [Parameter(Mandatory=$true)]
-                [string]
-                $TaskName,
+                [Parameter(Mandatory)]
+                [string]$TaskName,
 
-                [Parameter(Mandatory=$true)]
-                [hashtable]
-                $TaskParameter
+                [Parameter(Mandatory)]
+                [hashtable]$TaskParameter
             )
         }
 
@@ -34,20 +31,17 @@ function Register-WhiskeyEvent
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The name of the command to run during the event.
-        $CommandName,
+        [string]$CommandName,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         [ValidateSet('BeforeTask','AfterTask')]
         # When the command should be run; what events does it respond to?
-        $Event,
+        [string]$Event,
 
-        [string]
         # Only fire the event for a specific task.
-        $TaskName
+        [string]$TaskName
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Register-WhiskeyEvent.ps1
+++ b/Whiskey/Functions/Register-WhiskeyEvent.ps1
@@ -20,7 +20,7 @@ function Register-WhiskeyEvent
                 [Whiskey.Context]$TaskContext,
 
                 [Parameter(Mandatory)]
-                [string]$TaskName,
+                [String]$TaskName,
 
                 [Parameter(Mandatory)]
                 [hashtable]$TaskParameter
@@ -33,15 +33,15 @@ function Register-WhiskeyEvent
     param(
         [Parameter(Mandatory)]
         # The name of the command to run during the event.
-        [string]$CommandName,
+        [String]$CommandName,
 
         [Parameter(Mandatory)]
         [ValidateSet('BeforeTask','AfterTask')]
         # When the command should be run; what events does it respond to?
-        [string]$Event,
+        [String]$Event,
 
         # Only fire the event for a specific task.
-        [string]$TaskName
+        [String]$TaskName
     )
 
     Set-StrictMode -Version 'Latest'
@@ -55,7 +55,7 @@ function Register-WhiskeyEvent
 
     if( -not $events[$eventName] )
     {
-        $events[$eventName] = New-Object -TypeName 'Collections.Generic.List[string]'
+        $events[$eventName] = New-Object -TypeName 'Collections.Generic.List[String]'
     }
 
     $events[$eventName].Add( $CommandName )

--- a/Whiskey/Functions/Remove-WhiskeyFileSystemItem.ps1
+++ b/Whiskey/Functions/Remove-WhiskeyFileSystemItem.ps1
@@ -32,7 +32,7 @@ function Remove-WhiskeyFileSystemItem
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$Path
+        [String]$Path
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Remove-WhiskeyFileSystemItem.ps1
+++ b/Whiskey/Functions/Remove-WhiskeyFileSystemItem.ps1
@@ -32,8 +32,7 @@ function Remove-WhiskeyFileSystemItem
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]
-        $Path
+        [string]$Path
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Resolve-WhiskeyDotNetSdkVersion.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyDotNetSdkVersion.ps1
@@ -31,7 +31,7 @@ function Resolve-WhiskeyDotNetSdkVersion
 
         [Parameter(Mandatory, ParameterSetName='Version')]
         # Version of the .NET Core SDK to search for and resolve. Accepts wildcards.
-        [string]$Version
+        [String]$Version
     )
 
     Set-StrictMode -version 'Latest'

--- a/Whiskey/Functions/Resolve-WhiskeyNodeModulePath.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyNodeModulePath.ps1
@@ -30,24 +30,20 @@ function Resolve-WhiskeyNodeModulePath
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]
         # The name of the Node module whose path to get.
-        $Name,
+        [string]$Name,
 
         [Parameter(Mandatory,ParameterSetName='FromBuildRoot')]
-        [string]
         # The path to the build root. This will return the path to Node modules's directory from the "node_modules" directory in the build root. If you want the path to a global node module, installed in the local Node directory Whiskey installs in the repository, use the `-Global` switch.
-        $BuildRootPath,
+        [string]$BuildRootPath,
 
         [Parameter(ParameterSetName='FromBuildRoot')]
-        [Switch]
         # Get the path to a Node module in the global "node_modules" directory. The default is to get the path to the copy in the local node_modules directory.
-        $Global,
+        [Switch]$Global,
 
         [Parameter(Mandatory,ParameterSetName='FromNodeRoot')]
-        [string]
         # The path to the root of a Node package, as downloaded and expanded from the Node.js project.
-        $NodeRootPath
+        [string]$NodeRootPath
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Resolve-WhiskeyNodeModulePath.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyNodeModulePath.ps1
@@ -39,7 +39,7 @@ function Resolve-WhiskeyNodeModulePath
 
         [Parameter(ParameterSetName='FromBuildRoot')]
         # Get the path to a Node module in the global "node_modules" directory. The default is to get the path to the copy in the local node_modules directory.
-        [Switch]$Global,
+        [switch]$Global,
 
         [Parameter(Mandatory,ParameterSetName='FromNodeRoot')]
         # The path to the root of a Node package, as downloaded and expanded from the Node.js project.

--- a/Whiskey/Functions/Resolve-WhiskeyNodeModulePath.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyNodeModulePath.ps1
@@ -31,11 +31,11 @@ function Resolve-WhiskeyNodeModulePath
     param(
         [Parameter(Mandatory)]
         # The name of the Node module whose path to get.
-        [string]$Name,
+        [String]$Name,
 
         [Parameter(Mandatory,ParameterSetName='FromBuildRoot')]
         # The path to the build root. This will return the path to Node modules's directory from the "node_modules" directory in the build root. If you want the path to a global node module, installed in the local Node directory Whiskey installs in the repository, use the `-Global` switch.
-        [string]$BuildRootPath,
+        [String]$BuildRootPath,
 
         [Parameter(ParameterSetName='FromBuildRoot')]
         # Get the path to a Node module in the global "node_modules" directory. The default is to get the path to the copy in the local node_modules directory.
@@ -43,7 +43,7 @@ function Resolve-WhiskeyNodeModulePath
 
         [Parameter(Mandatory,ParameterSetName='FromNodeRoot')]
         # The path to the root of a Node package, as downloaded and expanded from the Node.js project.
-        [string]$NodeRootPath
+        [String]$NodeRootPath
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Resolve-WhiskeyNodePath.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyNodePath.ps1
@@ -25,14 +25,12 @@ function Resolve-WhiskeyNodePath
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,ParameterSetName='FromBuildRoot')]
-        [string]
         # The path to the build root. This will return the path to Node where Whiskey installs a local copy.
-        $BuildRootPath,
+        [string]$BuildRootPath,
 
         [Parameter(Mandatory,ParameterSetName='FromNodeRoot')]
-        [string]
         # The path to the root of an Node package, as downloaded and expanded from the Node.js download page.
-        $NodeRootPath
+        [string]$NodeRootPath
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Resolve-WhiskeyNodePath.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyNodePath.ps1
@@ -26,11 +26,11 @@ function Resolve-WhiskeyNodePath
     param(
         [Parameter(Mandatory,ParameterSetName='FromBuildRoot')]
         # The path to the build root. This will return the path to Node where Whiskey installs a local copy.
-        [string]$BuildRootPath,
+        [String]$BuildRootPath,
 
         [Parameter(Mandatory,ParameterSetName='FromNodeRoot')]
         # The path to the root of an Node package, as downloaded and expanded from the Node.js download page.
-        [string]$NodeRootPath
+        [String]$NodeRootPath
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Resolve-WhiskeyNuGetPackageVersion.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyNuGetPackageVersion.ps1
@@ -5,12 +5,12 @@ function Resolve-WhiskeyNuGetPackageVersion
 
         [Parameter(Mandatory)]
         # The name of the NuGet package to download.
-        [string]$NuGetPackageName,
+        [String]$NuGetPackageName,
 
         # The version of the package to download. Must be a three part number, i.e. it must have a MAJOR, MINOR, and BUILD number.
-        [string]$Version,
+        [String]$Version,
 
-        [string]$NugetPath = ($whiskeyNuGetExePath)
+        [String]$NugetPath = ($whiskeyNuGetExePath)
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Resolve-WhiskeyNuGetPackageVersion.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyNuGetPackageVersion.ps1
@@ -3,17 +3,14 @@ function Resolve-WhiskeyNuGetPackageVersion
     [CmdletBinding()]
     param(
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The name of the NuGet package to download.
-        $NuGetPackageName,
+        [string]$NuGetPackageName,
 
-        [string]
         # The version of the package to download. Must be a three part number, i.e. it must have a MAJOR, MINOR, and BUILD number.
-        $Version,
+        [string]$Version,
 
-        [string]
-        $NugetPath = ($whiskeyNuGetExePath)
+        [string]$NugetPath = ($whiskeyNuGetExePath)
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Resolve-WhiskeyPowerShellModule.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyPowerShellModule.ps1
@@ -23,7 +23,7 @@ function Resolve-WhiskeyPowerShellModule
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         # The name of the PowerShell module.
         [string]$Name,
 

--- a/Whiskey/Functions/Resolve-WhiskeyPowerShellModule.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyPowerShellModule.ps1
@@ -25,14 +25,14 @@ function Resolve-WhiskeyPowerShellModule
     param(
         [Parameter(Mandatory)]
         # The name of the PowerShell module.
-        [string]$Name,
+        [String]$Name,
 
         # The version of the PowerShell module to search for. Must be a three part number, i.e. it must have a MAJOR, MINOR, and BUILD number.
-        [string]$Version,
+        [String]$Version,
 
         [Parameter(Mandatory)]
         # The path to the directory where the PSModules directory should be created.
-        [string]$BuildRoot
+        [String]$BuildRoot
     )
 
     Set-StrictMode -Version 'Latest'
@@ -73,7 +73,7 @@ function Resolve-WhiskeyPowerShellModule
         {
             Write-WhiskeyTiming -Message ('Module "{0}" version {1} does not exist at {2}.' -f $packageName,$packageVersion,($moduleManifestPath | Split-Path))
             $module = [pscustomobject]@{ 'Name' = $packageName ; 'Version' = $packageVersion }
-            [void]$modulesToInstall.Add($module)
+            [Void]$modulesToInstall.Add($module)
         }
     }
 
@@ -116,7 +116,7 @@ function Resolve-WhiskeyPowerShellModule
             $tempVersion = [Version]$Version
             if( $TempVersion -and ($TempVersion.Build -lt 0) )
             {
-                $Version = [version]('{0}.{1}.0' -f $TempVersion.Major, $TempVersion.Minor)
+                $Version = [Version]('{0}.{1}.0' -f $TempVersion.Major, $TempVersion.Minor)
             }
         }
 

--- a/Whiskey/Functions/Resolve-WhiskeyTaskPath.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyTaskPath.ps1
@@ -17,7 +17,7 @@ function Resolve-WhiskeyTaskPath
         [string]$ParentPath,
 
         # Create the path if it doesn't exist. By default, the path will be created as a directory. To create the path as a file, pass `File` to the `PathType` parameter.
-        [Switch]$Force,
+        [switch]$Force,
 
         [ValidateSet('Directory','File')]
         # The type of item to create when using the `Force` parameter to create paths that don't exist. The default is to create the path as a directory. Pass `File` to create the path as a file.

--- a/Whiskey/Functions/Resolve-WhiskeyTaskPath.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyTaskPath.ps1
@@ -3,31 +3,25 @@ function Resolve-WhiskeyTaskPath
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
+        [Parameter(Mandatory)]
         # An object that holds context about the current build and executing task.
-        $TaskContext,
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
-        [string]
-        $Path,
+        [Parameter(Mandatory,ValueFromPipeline)]
+        [string]$Path,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $PropertyName,
+        [Parameter(Mandatory)]
+        [string]$PropertyName,
 
-        [string]
         # The root directory to use when resolving paths. The default is to use the `$TaskContext.BuildRoot` directory. Each path must be relative to this path.
-        $ParentPath,
+        [string]$ParentPath,
 
-        [Switch]
         # Create the path if it doesn't exist. By default, the path will be created as a directory. To create the path as a file, pass `File` to the `PathType` parameter.
-        $Force,
+        [Switch]$Force,
 
-        [string]
         [ValidateSet('Directory','File')]
         # The type of item to create when using the `Force` parameter to create paths that don't exist. The default is to create the path as a directory. Pass `File` to create the path as a file.
-        $PathType = 'Directory'
+        [string]$PathType = 'Directory'
     )
 
     begin

--- a/Whiskey/Functions/Resolve-WhiskeyTaskPath.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyTaskPath.ps1
@@ -8,20 +8,20 @@ function Resolve-WhiskeyTaskPath
         [Whiskey.Context]$TaskContext,
 
         [Parameter(Mandatory,ValueFromPipeline)]
-        [string]$Path,
+        [String]$Path,
 
         [Parameter(Mandatory)]
-        [string]$PropertyName,
+        [String]$PropertyName,
 
         # The root directory to use when resolving paths. The default is to use the `$TaskContext.BuildRoot` directory. Each path must be relative to this path.
-        [string]$ParentPath,
+        [String]$ParentPath,
 
         # Create the path if it doesn't exist. By default, the path will be created as a directory. To create the path as a file, pass `File` to the `PathType` parameter.
         [switch]$Force,
 
         [ValidateSet('Directory','File')]
         # The type of item to create when using the `Force` parameter to create paths that don't exist. The default is to create the path as a directory. Pass `File` to create the path as a file.
-        [string]$PathType = 'Directory'
+        [String]$PathType = 'Directory'
     )
 
     begin

--- a/Whiskey/Functions/Resolve-WhiskeyTaskPathParameter.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyTaskPathParameter.ps1
@@ -7,7 +7,7 @@ function Resolve-WhiskeyTaskPathParameter
         [Whiskey.Context]$TaskContext,
 
         [Parameter(ValueFromPipeline)]
-        [string]$Path,
+        [String]$Path,
 
         [Parameter(Mandatory)]
         [Management.Automation.ParameterMetadata]$CmdParameter,
@@ -130,12 +130,12 @@ Found {1} paths that should be to a {0}, but aren''t:
         }
 
         $pathCount = $result | Measure-Object | Select-Object -ExpandProperty 'Count'
-        if( $CmdParameter.ParameterType -ne ([string[]]) -and $pathCount -gt 1 )
+        if( $CmdParameter.ParameterType -ne ([String[]]) -and $pathCount -gt 1 )
         {
             Stop-WhiskeyTask -TaskContext $TaskContext -PropertyName $CmdParameter.Name -Message (@'
 The value "{1}" resolved to {2} paths [1] but this task requires a single path. Please change "{1}" to a value that resolves to a single item.
 
-If you are this task''s author, and you want this property to accept multiple paths, please update the "{3}" command''s "{0}" property so it''s type is "[string[]]".
+If you are this task''s author, and you want this property to accept multiple paths, please update the "{3}" command''s "{0}" property so it''s type is "[String[]]".
 
 [1] The {1} path resolved to:
 

--- a/Whiskey/Functions/Resolve-WhiskeyVariable.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyVariable.ps1
@@ -62,9 +62,8 @@ function Resolve-WhiskeyVariable
         [string]$Name,
 
         [Parameter(Mandatory)]
-        [Whiskey.Context]
         # The context of the current build. Necessary to lookup any variables.
-        $Context
+        [Whiskey.Context]$Context
     )
 
     begin

--- a/Whiskey/Functions/Resolve-WhiskeyVariable.ps1
+++ b/Whiskey/Functions/Resolve-WhiskeyVariable.ps1
@@ -55,11 +55,11 @@ function Resolve-WhiskeyVariable
         # If the value is a hashtable, variable replcement is done on each value of the hashtable. 
         #
         # Variable expansion is performed on any arrays and hashtables found in other arrays and hashtables, i.e. arrays and hashtables are searched recursively.
-        [object]$InputObject,
+        [Object]$InputObject,
 
         [Parameter(ParameterSetName='ByName')]
         # The name of a single Whiskey variable to resolve.
-        [string]$Name,
+        [String]$Name,
 
         [Parameter(Mandatory)]
         # The context of the current build. Necessary to lookup any variables.
@@ -137,7 +137,7 @@ function Resolve-WhiskeyVariable
         if( (Get-Member -Name 'Keys' -InputObject $InputObject) )
         {
             $newValues = @{ }
-            $toRemove = New-Object 'Collections.Generic.List[string]'
+            $toRemove = New-Object 'Collections.Generic.List[String]'
             # Can't modify a collection while enumerating it.
             foreach( $key in $InputObject.Keys )
             {
@@ -248,7 +248,7 @@ function Resolve-WhiskeyVariable
                                             {
                                                 if( $nextChar -eq $currentChar )
                                                 {
-                                                    [void]$currentArg.Append($currentChar)
+                                                    [Void]$currentArg.Append($currentChar)
                                                     $idx++
                                                     continue
                                                 }
@@ -261,13 +261,13 @@ function Resolve-WhiskeyVariable
                                         if( $currentChar -eq ',' -and -not $inString )
                                         {
                                             $currentArg.ToString()
-                                            [void]$currentArg.Clear()
+                                            [Void]$currentArg.Clear()
                                             continue
                                         }
 
-                                        if( $inString -or -not [string]::IsNullOrWhiteSpace($currentChar) )
+                                        if( $inString -or -not [String]::IsNullOrWhiteSpace($currentChar) )
                                         {
-                                            [void]$currentArg.Append($currentChar)
+                                            [Void]$currentArg.Append($currentChar)
                                         }
                                     }
                                     if( $currentArg.Length )

--- a/Whiskey/Functions/Set-WhiskeyBuildStatus.ps1
+++ b/Whiskey/Functions/Set-WhiskeyBuildStatus.ps1
@@ -9,7 +9,7 @@ function Set-WhiskeyBuildStatus
         [Parameter(Mandatory)]
         [ValidateSet('Started','Completed','Failed')]
         # The build status. Should be one of `Started`, `Completed`, or `Failed`.
-        [string]$Status
+        [String]$Status
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Set-WhiskeyBuildStatus.ps1
+++ b/Whiskey/Functions/Set-WhiskeyBuildStatus.ps1
@@ -3,10 +3,10 @@ function Set-WhiskeyBuildStatus
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         [Whiskey.Context]$Context,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         [ValidateSet('Started','Completed','Failed')]
         # The build status. Should be one of `Started`, `Completed`, or `Failed`.
         [string]$Status

--- a/Whiskey/Functions/Set-WhiskeyDotNetGlobalJson.ps1
+++ b/Whiskey/Functions/Set-WhiskeyDotNetGlobalJson.ps1
@@ -15,15 +15,13 @@ function Set-WhiskeyDotNetGlobalJson
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The directory where the `global.json` will be created/modified.
-        $Directory,
+        [string]$Directory,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The version of the SDK to set within the `global.json` file.
-        $SdkVersion
+        [string]$SdkVersion
     )
 
     Set-StrictMode -version 'Latest'

--- a/Whiskey/Functions/Set-WhiskeyDotNetGlobalJson.ps1
+++ b/Whiskey/Functions/Set-WhiskeyDotNetGlobalJson.ps1
@@ -17,11 +17,11 @@ function Set-WhiskeyDotNetGlobalJson
     param(
         [Parameter(Mandatory)]
         # The directory where the `global.json` will be created/modified.
-        [string]$Directory,
+        [String]$Directory,
 
         [Parameter(Mandatory)]
         # The version of the SDK to set within the `global.json` file.
-        [string]$SdkVersion
+        [String]$SdkVersion
     )
 
     Set-StrictMode -version 'Latest'

--- a/Whiskey/Functions/Set-WhiskeyMSBuildConfiguration.ps1
+++ b/Whiskey/Functions/Set-WhiskeyMSBuildConfiguration.ps1
@@ -17,15 +17,13 @@ function Set-WhiskeyMSBuildConfiguration
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
+        [Parameter(Mandatory)]
         # The context of the build whose MSBuild configuration you want to set. Use `New-WhiskeyContext` to create a context.
-        $Context,
+        [Whiskey.Context]$Context,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The configuration to use.
-        $Value
+        [string]$Value
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Set-WhiskeyMSBuildConfiguration.ps1
+++ b/Whiskey/Functions/Set-WhiskeyMSBuildConfiguration.ps1
@@ -23,7 +23,7 @@ function Set-WhiskeyMSBuildConfiguration
 
         [Parameter(Mandatory)]
         # The configuration to use.
-        [string]$Value
+        [String]$Value
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Stop-Whiskey.ps1
+++ b/Whiskey/Functions/Stop-Whiskey.ps1
@@ -3,14 +3,12 @@ function Stop-Whiskey
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
+        [Parameter(Mandatory)]
         # An object
-        $Context,
+        [Whiskey.Context]$Context,
               
-        [Parameter(Mandatory=$true)]
-        [string]
-        $Message
+        [Parameter(Mandatory)]
+        [string]$Message
     )
               
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Stop-Whiskey.ps1
+++ b/Whiskey/Functions/Stop-Whiskey.ps1
@@ -8,7 +8,7 @@ function Stop-Whiskey
         [Whiskey.Context]$Context,
               
         [Parameter(Mandatory)]
-        [string]$Message
+        [String]$Message
     )
               
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Stop-WhiskeyTask.ps1
+++ b/Whiskey/Functions/Stop-WhiskeyTask.ps1
@@ -7,11 +7,11 @@ function Stop-WhiskeyTask
         [Whiskey.Context]$TaskContext,
 
         [Parameter(Mandatory)]
-        [string]$Message,
+        [String]$Message,
 
-        [string]$PropertyName,
+        [String]$PropertyName,
 
-        [string]$PropertyDescription
+        [String]$PropertyDescription
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Stop-WhiskeyTask.ps1
+++ b/Whiskey/Functions/Stop-WhiskeyTask.ps1
@@ -3,20 +3,15 @@ function Stop-WhiskeyTask
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
-        # An object
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $Message,
+        [Parameter(Mandatory)]
+        [string]$Message,
 
-        [string]
-        $PropertyName,
+        [string]$PropertyName,
 
-        [string]
-        $PropertyDescription
+        [string]$PropertyDescription
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Test-WhiskeyTaskSkip.ps1
+++ b/Whiskey/Functions/Test-WhiskeyTaskSkip.ps1
@@ -10,15 +10,13 @@ function Test-WhiskeyTaskSkip
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
+        [Parameter(Mandatory)]
         # The context for the build.
-        $Context,
+        [Whiskey.Context]$Context,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
+        [Parameter(Mandatory)]
         # The common task properties defined for the current task.
-        $Properties
+        [hashtable]$Properties
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Test-WhiskeyTaskSkip.ps1
+++ b/Whiskey/Functions/Test-WhiskeyTaskSkip.ps1
@@ -30,9 +30,9 @@ function Test-WhiskeyTaskSkip
     elseif( $Properties['OnlyBy'] )
     {
         [Whiskey.RunBy]$onlyBy = [Whiskey.RunBy]::Developer
-        if( -not ([enum]::TryParse($Properties['OnlyBy'], [ref]$onlyBy)) )
+        if( -not ([Enum]::TryParse($Properties['OnlyBy'], [ref]$onlyBy)) )
         {
-            Stop-WhiskeyTask -TaskContext $Context -PropertyName 'OnlyBy' -Message ('invalid value: ''{0}''. Valid values are ''{1}''.' -f $Properties['OnlyBy'],([enum]::GetValues([Whiskey.RunBy]) -join ''', '''))
+            Stop-WhiskeyTask -TaskContext $Context -PropertyName 'OnlyBy' -Message ('invalid value: ''{0}''. Valid values are ''{1}''.' -f $Properties['OnlyBy'],([Enum]::GetValues([Whiskey.RunBy]) -join ''', '''))
             return
         }
 
@@ -45,9 +45,9 @@ function Test-WhiskeyTaskSkip
     elseif( $Properties['ExceptBy'] )
     {
         [Whiskey.RunBy]$exceptBy = [Whiskey.RunBy]::Developer
-        if( -not ([enum]::TryParse($Properties['ExceptBy'], [ref]$exceptBy)) )
+        if( -not ([Enum]::TryParse($Properties['ExceptBy'], [ref]$exceptBy)) )
         {
-            Stop-WhiskeyTask -TaskContext $Context -PropertyName 'ExceptBy' -Message ('invalid value: ''{0}''. Valid values are ''{1}''.' -f $Properties['ExceptBy'],([enum]::GetValues([Whiskey.RunBy]) -join ''', '''))
+            Stop-WhiskeyTask -TaskContext $Context -PropertyName 'ExceptBy' -Message ('invalid value: ''{0}''. Valid values are ''{1}''.' -f $Properties['ExceptBy'],([Enum]::GetValues([Whiskey.RunBy]) -join ''', '''))
             return
         }
 
@@ -164,9 +164,9 @@ function Test-WhiskeyTaskSkip
     if( $Properties['OnlyIfBuild'] )
     {
         [Whiskey.BuildStatus]$buildStatus = [Whiskey.BuildStatus]::Succeeded
-        if( -not ([enum]::TryParse($Properties['OnlyIfBuild'], [ref]$buildStatus)) )
+        if( -not ([Enum]::TryParse($Properties['OnlyIfBuild'], [ref]$buildStatus)) )
         {
-            Stop-WhiskeyTask -TaskContext $Context -PropertyName 'OnlyIfBuild' -Message ('invalid value: ''{0}''. Valid values are ''{1}''.' -f $Properties['OnlyIfBuild'],([enum]::GetValues([Whiskey.BuildStatus]) -join ''', '''))
+            Stop-WhiskeyTask -TaskContext $Context -PropertyName 'OnlyIfBuild' -Message ('invalid value: ''{0}''. Valid values are ''{1}''.' -f $Properties['OnlyIfBuild'],([Enum]::GetValues([Whiskey.BuildStatus]) -join ''', '''))
             return
         }
 
@@ -183,7 +183,7 @@ function Test-WhiskeyTaskSkip
         [Whiskey.Platform]$platform = [Whiskey.Platform]::Unknown
         foreach( $item in $Properties['OnlyOnPlatform'] )
         {
-            if( -not [enum]::TryParse($item,[ref]$platform) )
+            if( -not [Enum]::TryParse($item,[ref]$platform) )
             {
                 $validValues = [Enum]::GetValues([Whiskey.Platform]) | Where-Object { $_ -notin @( 'Unknown', 'All' ) }
                 Stop-WhiskeyTask -TaskContext $Context -PropertyName 'OnlyOnPlatform' -Message ('Invalid platform "{0}". Valid values are "{1}".' -f $item,($validValues -join '", "'))
@@ -211,7 +211,7 @@ function Test-WhiskeyTaskSkip
         [Whiskey.Platform]$platform = [Whiskey.Platform]::Unknown
         foreach( $item in $Properties['ExceptOnPlatform'] )
         {
-            if( -not [enum]::TryParse($item,[ref]$platform) )
+            if( -not [Enum]::TryParse($item,[ref]$platform) )
             {
                 $validValues = [Enum]::GetValues([Whiskey.Platform]) | Where-Object { $_ -notin @( 'Unknown', 'All' ) }
                 Stop-WhiskeyTask -TaskContext $Context -PropertyName 'ExceptOnPlatform' -Message ('Invalid platform "{0}". Valid values are "{1}".' -f $item,($validValues -join '", "'))

--- a/Whiskey/Functions/Uninstall-WhiskeyNode.ps1
+++ b/Whiskey/Functions/Uninstall-WhiskeyNode.ps1
@@ -5,7 +5,7 @@ function Uninstall-WhiskeyNode
     param(
         [Parameter(Mandatory)]
         # The directory where node is installed and from which it should be removed.
-        [string]$InstallRoot
+        [String]$InstallRoot
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Uninstall-WhiskeyNodeModule.ps1
+++ b/Whiskey/Functions/Uninstall-WhiskeyNodeModule.ps1
@@ -23,27 +23,22 @@ function Uninstall-WhiskeyNodeModule
     
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The name of the module to uninstall.
-        $Name,
+        [string]$Name,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The path to the build root directory.
-        $BuildRootPath,
+        [string]$BuildRootPath,
 
-        [switch]
         # Node modules are being uninstalled on a developer computer.
-        $ForDeveloper,
+        [switch]$ForDeveloper,
 
-        [switch]
         # Remove the module manually if NPM fails to uninstall it
-        $Force,
+        [switch]$Force,
 
-        [Switch]
         # Uninstall the module from the global cache.
-        $Global
+        [Switch]$Global
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Uninstall-WhiskeyNodeModule.ps1
+++ b/Whiskey/Functions/Uninstall-WhiskeyNodeModule.ps1
@@ -25,11 +25,11 @@ function Uninstall-WhiskeyNodeModule
     param(
         [Parameter(Mandatory)]
         # The name of the module to uninstall.
-        [string]$Name,
+        [String]$Name,
 
         [Parameter(Mandatory)]
         # The path to the build root directory.
-        [string]$BuildRootPath,
+        [String]$BuildRootPath,
 
         # Node modules are being uninstalled on a developer computer.
         [switch]$ForDeveloper,

--- a/Whiskey/Functions/Uninstall-WhiskeyNodeModule.ps1
+++ b/Whiskey/Functions/Uninstall-WhiskeyNodeModule.ps1
@@ -38,7 +38,7 @@ function Uninstall-WhiskeyNodeModule
         [switch]$Force,
 
         # Uninstall the module from the global cache.
-        [Switch]$Global
+        [switch]$Global
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Uninstall-WhiskeyPowerShellModule.ps1
+++ b/Whiskey/Functions/Uninstall-WhiskeyPowerShellModule.ps1
@@ -22,13 +22,13 @@ function Uninstall-WhiskeyPowerShellModule
     param(
         [Parameter(Mandatory)]
         # The name of the module to uninstall.
-        [string]$Name,
+        [String]$Name,
 
-        [string]$Version = '*.*.*',
+        [String]$Version = '*.*.*',
 
         [Parameter(Mandatory)]
         # Modules are saved into a PSModules directory. This is the path where the PSModules directory was created and should be the same path passed to `Install-WhiskeyPowerShellModule`.
-        [string]$BuildRoot
+        [String]$BuildRoot
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Uninstall-WhiskeyPowerShellModule.ps1
+++ b/Whiskey/Functions/Uninstall-WhiskeyPowerShellModule.ps1
@@ -20,7 +20,7 @@ function Uninstall-WhiskeyPowerShellModule
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         # The name of the module to uninstall.
         [string]$Name,
 

--- a/Whiskey/Functions/Uninstall-WhiskeyTool.ps1
+++ b/Whiskey/Functions/Uninstall-WhiskeyTool.ps1
@@ -54,13 +54,13 @@ function Uninstall-WhiskeyTool
 
         [Parameter(Mandatory,ParameterSetName='NuGet')]
         # The name of the NuGet package to uninstall.
-        [string]$NuGetPackageName,
+        [String]$NuGetPackageName,
 
         # The version of the package to uninstall. Must be a three part number, i.e. it must have a MAJOR, MINOR, and BUILD number.
-        [string]$Version,
+        [String]$Version,
 
         # The build root where the build is currently running. Tools are installed here.
-        [string]$BuildRoot
+        [String]$BuildRoot
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Unregister-WhiskeyEvent.ps1
+++ b/Whiskey/Functions/Unregister-WhiskeyEvent.ps1
@@ -12,15 +12,15 @@ function Unregister-WhiskeyEvent
     param(
         [Parameter(Mandatory)]
         # The name of the command to run during the event.
-        [string]$CommandName,
+        [String]$CommandName,
 
         [Parameter(Mandatory)]
         [ValidateSet('BeforeTask','AfterTask')]
         # When the command should be run; what events does it respond to?
-        [string]$Event,
+        [String]$Event,
 
         # The specific task whose events to unregister.
-        [string]$TaskName
+        [String]$TaskName
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Unregister-WhiskeyEvent.ps1
+++ b/Whiskey/Functions/Unregister-WhiskeyEvent.ps1
@@ -10,20 +10,17 @@ function Unregister-WhiskeyEvent
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         # The name of the command to run during the event.
-        $CommandName,
+        [string]$CommandName,
 
-        [Parameter(Mandatory=$true)]
-        [string]
+        [Parameter(Mandatory)]
         [ValidateSet('BeforeTask','AfterTask')]
         # When the command should be run; what events does it respond to?
-        $Event,
+        [string]$Event,
 
-        [string]
         # The specific task whose events to unregister.
-        $TaskName
+        [string]$TaskName
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Use-CallerPreference.ps1
+++ b/Whiskey/Functions/Use-CallerPreference.ps1
@@ -56,17 +56,16 @@ function Use-CallerPreference
     #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         #[Management.Automation.PSScriptCmdlet]
         # The module function's `$PSCmdlet` object. Requires the function be decorated with the `[CmdletBinding()]` attribute.
         $Cmdlet,
 
-        [Parameter(Mandatory = $true)]
-        [Management.Automation.SessionState]
+        [Parameter(Mandatory)]
         # The module function's `$ExecutionContext.SessionState` object.  Requires the function be decorated with the `[CmdletBinding()]` attribute. 
         #
         # Used to set variables in its callers' scope, even if that caller is in a different script module.
-        $SessionState
+        [Management.Automation.SessionState]$SessionState
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Write-CommandOutput.ps1
+++ b/Whiskey/Functions/Write-CommandOutput.ps1
@@ -1,33 +1,29 @@
-    Set-StrictMode -version 'latest'
-    
-    function Write-CommandOutput
+function Write-CommandOutput
+{
+    param(
+        [Parameter(ValueFromPipeline)]
+        [string]$InputObject,
+
+        [Parameter(Mandatory)]
+        [string]$Description
+    )
+
+    process
     {
-        param(
-            [Parameter(ValueFromPipeline=$true)]
-            [string]
-            $InputObject,
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
-            [Parameter(Mandatory=$true)]
-            [string]
-            $Description
-        )
-
-        process
+        if( $InputObject -match '^WARNING\b' )
         {
-            Set-StrictMode -Version 'Latest'
-            Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
-
-            if( $InputObject -match '^WARNING\b' )
-            {
-                $InputObject | Write-Warning 
-            }
-            elseif( $InputObject -match '^ERROR\b' )
-            {
-                $InputObject | Write-Error
-            }
-            else
-            {
-                $InputObject | ForEach-Object { Write-Verbose -Message ('[{0}] {1}' -f $Description,$InputObject) }
-            }
+            $InputObject | Write-Warning 
+        }
+        elseif( $InputObject -match '^ERROR\b' )
+        {
+            $InputObject | Write-Error
+        }
+        else
+        {
+            $InputObject | ForEach-Object { Write-Verbose -Message ('[{0}] {1}' -f $Description,$InputObject) }
         }
     }
+}

--- a/Whiskey/Functions/Write-CommandOutput.ps1
+++ b/Whiskey/Functions/Write-CommandOutput.ps1
@@ -2,10 +2,10 @@ function Write-CommandOutput
 {
     param(
         [Parameter(ValueFromPipeline)]
-        [string]$InputObject,
+        [String]$InputObject,
 
         [Parameter(Mandatory)]
-        [string]$Description
+        [String]$Description
     )
 
     process

--- a/Whiskey/Functions/Write-WhiskeyCommand.ps1
+++ b/Whiskey/Functions/Write-WhiskeyCommand.ps1
@@ -3,15 +3,12 @@ function Write-WhiskeyCommand
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $Context,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$Context,
 
-        [string]
-        $Path,
+        [string]$Path,
 
-        [string[]]
-        $ArgumentList
+        [string[]]$ArgumentList
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Write-WhiskeyCommand.ps1
+++ b/Whiskey/Functions/Write-WhiskeyCommand.ps1
@@ -6,9 +6,9 @@ function Write-WhiskeyCommand
         [Parameter(Mandatory)]
         [Whiskey.Context]$Context,
 
-        [string]$Path,
+        [String]$Path,
 
-        [string[]]$ArgumentList
+        [String[]]$ArgumentList
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Functions/Write-WhiskeyInfo.ps1
+++ b/Whiskey/Functions/Write-WhiskeyInfo.ps1
@@ -24,11 +24,11 @@ function Write-WhiskeyInfo
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         # The current context.
         [Whiskey.Context]$Context,
 
-        [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
+        [Parameter(Mandatory,ValueFromPipeline)]
         [AllowEmptyString()]
         [AllowNull()]
         # The message to write.

--- a/Whiskey/Functions/Write-WhiskeyInfo.ps1
+++ b/Whiskey/Functions/Write-WhiskeyInfo.ps1
@@ -32,7 +32,7 @@ function Write-WhiskeyInfo
         [AllowEmptyString()]
         [AllowNull()]
         # The message to write.
-        [string]$Message,
+        [String]$Message,
 
         [int]$Indent = 0
     )

--- a/Whiskey/Functions/Write-WhiskeyVerbose.ps1
+++ b/Whiskey/Functions/Write-WhiskeyVerbose.ps1
@@ -19,11 +19,11 @@ function Write-WhiskeyVerbose
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         # The current context.
         [Whiskey.Context]$Context,
 
-        [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
+        [Parameter(Mandatory,ValueFromPipeline)]
         [AllowEmptyString()]
         [AllowNull()]
         # The message to write.

--- a/Whiskey/Functions/Write-WhiskeyVerbose.ps1
+++ b/Whiskey/Functions/Write-WhiskeyVerbose.ps1
@@ -27,7 +27,7 @@ function Write-WhiskeyVerbose
         [AllowEmptyString()]
         [AllowNull()]
         # The message to write.
-        [string]$Message,
+        [String]$Message,
 
         [int]$Indent = 0
     )

--- a/Whiskey/Functions/Write-WhiskeyWarning.ps1
+++ b/Whiskey/Functions/Write-WhiskeyWarning.ps1
@@ -19,11 +19,11 @@ function Write-WhiskeyWarning
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         # The current context.
         [Whiskey.Context]$Context,
 
-        [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
+        [Parameter(Mandatory,ValueFromPipeline)]
         # The message to write.
         [string]$Message,
 

--- a/Whiskey/Functions/Write-WhiskeyWarning.ps1
+++ b/Whiskey/Functions/Write-WhiskeyWarning.ps1
@@ -25,7 +25,7 @@ function Write-WhiskeyWarning
 
         [Parameter(Mandatory,ValueFromPipeline)]
         # The message to write.
-        [string]$Message,
+        [String]$Message,
 
         [int]$Indent = 0
     )

--- a/Whiskey/Tasks/AppVeyorWaitForBuildJobs.ps1
+++ b/Whiskey/Tasks/AppVeyorWaitForBuildJobs.ps1
@@ -7,15 +7,15 @@ function Wait-WhiskeyAppVeyorBuildJob
         [Parameter(Mandatory)]
         [Whiskey.Context]$TaskContext,
 
-        [string]$ApiKeyID,
+        [String]$ApiKeyID,
 
         [TimeSpan]$CheckInterval = '00:00:10',
 
         [TimeSpan]$ReportInterval = '00:01:00',
 
-        [string[]]$InProgressStatus = @('running','queued'),
+        [String[]]$InProgressStatus = @('running','queued'),
 
-        [string[]]$SuccessStatus = @('success')
+        [String[]]$SuccessStatus = @('success')
     )
 
     Set-StrictMode -Version 'Latest'
@@ -92,7 +92,7 @@ function Wait-WhiskeyAppVeyorBuildJob
             }
             $jobDescriptions = $failedJobs | ForEach-Object { '{0} (status: {1})' -f $_.name,$_.status}
             $jobDescriptions = $jobDescriptions -join ('{0} * ' -f [Environment]::NewLine)
-            $errorMsg = 'This build''s other job{0} did not succeed.{1} {1} * {2} {1} ' -f $suffix, [environment]::NewLine, $jobDescriptions
+            $errorMsg = 'This build''s other job{0} did not succeed.{1} {1} * {2} {1} ' -f $suffix, [Environment]::NewLine, $jobDescriptions
             Stop-WhiskeyTask -TaskContext $TaskContext -Message $errorMsg
             return
         }

--- a/Whiskey/Tasks/CopyFile.ps1
+++ b/Whiskey/Tasks/CopyFile.ps1
@@ -4,13 +4,11 @@ function Copy-WhiskeyFile
     [Whiskey.Task("CopyFile")]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/Delete.ps1
+++ b/Whiskey/Tasks/Delete.ps1
@@ -1,15 +1,13 @@
 function Remove-WhiskeyItem
 {
-    [Whiskey.TaskAttribute('Delete', SupportsClean=$true)]
+    [Whiskey.TaskAttribute('Delete',SupportsClean)]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/DotNet.ps1
+++ b/Whiskey/Tasks/DotNet.ps1
@@ -5,13 +5,11 @@ function Invoke-WhiskeyDotNet
     [Whiskey.Task("DotNet")]
     [Whiskey.RequiresTool('DotNet',PathParameterName='DotNetPath',VersionParameterName='SdkVersion')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/DotNetBuild.ps1
+++ b/Whiskey/Tasks/DotNetBuild.ps1
@@ -5,13 +5,11 @@ function Invoke-WhiskeyDotNetBuild
     [Whiskey.Task("DotNetBuild",Obsolete,ObsoleteMessage='The "DotNetTest" task is obsolete and will be removed in a future version of Whiskey. Please use the "DotNet" task instead.')]
     [Whiskey.RequiresTool('DotNet',PathParameterName='DotNetPath',VersionParameterName='SdkVersion')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/DotNetPack.ps1
+++ b/Whiskey/Tasks/DotNetPack.ps1
@@ -5,13 +5,11 @@ function Invoke-WhiskeyDotNetPack
     [Whiskey.Task("DotNetPack",Obsolete,ObsoleteMessage='The "DotNetTest" task is obsolete and will be removed in a future version of Whiskey. Please use the "DotNet" task instead.')]
     [Whiskey.RequiresTool('DotNet',PathParameterName='DotNetPath',VersionParameterName='SdkVersion')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/DotNetPublish.ps1
+++ b/Whiskey/Tasks/DotNetPublish.ps1
@@ -5,13 +5,11 @@ function Invoke-WhiskeyDotNetPublish
     [Whiskey.Task("DotNetPublish",Obsolete,ObsoleteMessage='The "DotNetPublish" task is obsolete and will be removed in a future version of Whiskey. Please use the "DotNet" task instead.')]
     [Whiskey.RequiresTool('DotNet',PathParameterName='DotNetPath',VersionParameterName='SdkVersion')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/DotNetTest.ps1
+++ b/Whiskey/Tasks/DotNetTest.ps1
@@ -5,13 +5,11 @@ function Invoke-WhiskeyDotNetTest
     [Whiskey.Task("DotNetTest",Obsolete,ObsoleteMessage='The "DotNetTest" task is obsolete and will be removed in a future version of Whiskey. Please use the "DotNet" task instead.')]
     [Whiskey.RequiresTool('DotNet',PathParameterName='DotNetPath',VersionParameterName='SdkVersion')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/Exec.ps1
+++ b/Whiskey/Tasks/Exec.ps1
@@ -1,7 +1,7 @@
 function Invoke-WhiskeyExec
 {
     [CmdletBinding()]
-    [Whiskey.Task("Exec",SupportsClean,SupportsInitialize)]
+    [Whiskey.Task('Exec',SupportsClean,SupportsInitialize)]
     param(
         [Parameter(Mandatory)]
         [Whiskey.Context]$TaskContext,

--- a/Whiskey/Tasks/Exec.ps1
+++ b/Whiskey/Tasks/Exec.ps1
@@ -1,15 +1,13 @@
 function Invoke-WhiskeyExec
 {
     [CmdletBinding()]
-    [Whiskey.Task("Exec",SupportsClean=$true,SupportsInitialize=$true)]
+    [Whiskey.Task("Exec",SupportsClean,SupportsInitialize)]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/File.ps1
+++ b/Whiskey/Tasks/File.ps1
@@ -7,9 +7,9 @@ function New-WhiskeyFile
         [Whiskey.Context]$TaskContext,
 
         [Whiskey.Tasks.ValidatePath(Mandatory,PathType='File',AllowNonexistent)]
-        [string[]]$Path,
+        [String[]]$Path,
 
-        [string]$Content,
+        [String]$Content,
 
         [switch]$Touch
     )

--- a/Whiskey/Tasks/GetPowerShellModule.ps1
+++ b/Whiskey/Tasks/GetPowerShellModule.ps1
@@ -1,49 +1,13 @@
 function Get-WhiskeyPowerShellModule
 {
-    <#
-    .SYNOPSIS
-    Downloads a PowerShell module.
-
-    .DESCRIPTION
-    The `GetPowerShellModule` task downloads a PowerShell module  and saves it into a `Modules` directory in the build root. Use the `Name` property to specify the name of the module to download. By default, it downloads the most recent version of the module. Use the `Version` property to download a specific version.
-
-    The module is downloaded from any of the repositories that are configured on the current machine. Those repositories must be trusted and initialized, otherwise the module will fail to download.
-
-    ## Property
-
-    * `Name` (mandatory): a list of module names you want installed.
-    * `Version`: the version number to download. The default behavior is to download the latest version. Wildcards allowed, e.g. use `2.*` to pin to major version `2`.
-
-    .EXAMPLE
-
-    ## Example 1
-
-        Build:
-        - GetPowerShellModule:
-            Name: Whiskey
-
-    This example demonstrates how to download the latest version of a PowerShell module. In this case, the latest version of Whiskey is downloaded and saved into the `.\Modules` directory in your build root.
-
-    ## Example 2
-
-        Build:
-        - GetPowerShellModule:
-            Name: Whiskey
-            Version: "0.14.*"
-
-    This example demonstrates how to pin to a specific version of a module. In this case, the latest `0.14.x` version will be downloaded. When version 0.15.0 comes out, you'll still download the latest `0.14.x` version.
-
-    #>
     [CmdletBinding()]
-    [Whiskey.Task("GetPowerShellModule",SupportsClean=$true, SupportsInitialize=$true)]
+    [Whiskey.Task("GetPowerShellModule",SupportsClean, SupportsInitialize)]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/GetPowerShellModule.ps1
+++ b/Whiskey/Tasks/GetPowerShellModule.ps1
@@ -1,7 +1,7 @@
 function Get-WhiskeyPowerShellModule
 {
     [CmdletBinding()]
-    [Whiskey.Task("GetPowerShellModule",SupportsClean, SupportsInitialize)]
+    [Whiskey.Task('GetPowerShellModule',SupportsClean,SupportsInitialize)]
     param(
         [Parameter(Mandatory)]
         [Whiskey.Context]$TaskContext,

--- a/Whiskey/Tasks/GitHubRelease.ps1
+++ b/Whiskey/Tasks/GitHubRelease.ps1
@@ -38,7 +38,7 @@ function New-WhiskeyGitHubRelease
         return
     }
 
-    $baseUri = [uri]'https://api.github.com/repos/{0}' -f $repositoryName
+    $baseUri = [Uri]'https://api.github.com/repos/{0}' -f $repositoryName
 
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
@@ -47,13 +47,13 @@ function New-WhiskeyGitHubRelease
         [CmdletBinding(DefaultParameterSetName='NoBody')]
         param(
             [Parameter(Mandatory)]
-            [uri]$Uri,
+            [Uri]$Uri,
 
             [Parameter(Mandatory,ParameterSetName='FileUpload')]
-            [string]$ContentType,
+            [String]$ContentType,
 
             [Parameter(Mandatory,ParameterSetName='FileUpload')]
-            [string]$InFile,
+            [String]$InFile,
 
             [Parameter(Mandatory,ParameterSetName='JsonRequest')]
             $Parameter,
@@ -97,7 +97,7 @@ function New-WhiskeyGitHubRelease
         Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Property "Tag" is mandatory. It should be the tag to create in your repository for this release. This is usually a version number. We recommend using the `$(WHISKEY_SEMVER2_NO_BUILD_METADATA)` variable to use the version number of the current build.')
         return
     }
-    $release = Invoke-GitHubApi -Uri ('{0}/releases/tags/{1}' -f $baseUri,[uri]::EscapeUriString($tag)) -Method Get -ErrorAction Ignore
+    $release = Invoke-GitHubApi -Uri ('{0}/releases/tags/{1}' -f $baseUri,[Uri]::EscapeUriString($tag)) -Method Get -ErrorAction Ignore
 
     $createOrEditMethod = [Microsoft.PowerShell.Commands.WebRequestMethod]::Post
     $actionDescription = 'Creating'
@@ -162,10 +162,10 @@ function New-WhiskeyGitHubRelease
             else
             {
                 $uri = $release.upload_url -replace '{[^}]+}$'
-                $uri = '{0}?name={1}' -f $uri,[uri]::EscapeDataString($assetName)
+                $uri = '{0}?name={1}' -f $uri,[Uri]::EscapeDataString($assetName)
                 if( $assetLabel )
                 {
-                    $uri = '{0}&label={1}' -f $uri,[uri]::EscapeDataString($assetLabel)
+                    $uri = '{0}&label={1}' -f $uri,[Uri]::EscapeDataString($assetLabel)
                 }
                 Write-WhiskeyInfo -Context $TaskContext -Message ('Uploading file "{0}".' -f $assetPath)
                 $contentType = $asset['ContentType']

--- a/Whiskey/Tasks/GitHubRelease.ps1
+++ b/Whiskey/Tasks/GitHubRelease.ps1
@@ -58,7 +58,7 @@ function New-WhiskeyGitHubRelease
             [Parameter(Mandatory,ParameterSetName='JsonRequest')]
             $Parameter,
 
-            [Microsoft.PowerShell.Commands.WebRequestMethod]$Method = [Microsoft.PowerShell.Commands.WebRequestMethod]::Post
+            [Microsoft.PowerShell.Commands.WebRequestMethod]$Method = 'Post'
         )
 
         $optionalParams = @{ }

--- a/Whiskey/Tasks/GitHubRelease.ps1
+++ b/Whiskey/Tasks/GitHubRelease.ps1
@@ -4,13 +4,11 @@ function New-WhiskeyGitHubRelease
     [CmdletBinding()]
     [Whiskey.Task('GitHubRelease')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'
@@ -48,23 +46,19 @@ function New-WhiskeyGitHubRelease
     {
         [CmdletBinding(DefaultParameterSetName='NoBody')]
         param(
-            [Parameter(Mandatory=$true)]
-            [uri]
-            $Uri,
+            [Parameter(Mandatory)]
+            [uri]$Uri,
 
-            [Parameter(Mandatory=$true,ParameterSetName='FileUpload')]
-            [string]
-            $ContentType,
+            [Parameter(Mandatory,ParameterSetName='FileUpload')]
+            [string]$ContentType,
 
-            [Parameter(Mandatory=$true,ParameterSetName='FileUpload')]
-            [string]
-            $InFile,
+            [Parameter(Mandatory,ParameterSetName='FileUpload')]
+            [string]$InFile,
 
-            [Parameter(Mandatory=$true,ParameterSetName='JsonRequest')]
+            [Parameter(Mandatory,ParameterSetName='JsonRequest')]
             $Parameter,
 
-            [Microsoft.PowerShell.Commands.WebRequestMethod]
-            $Method = [Microsoft.PowerShell.Commands.WebRequestMethod]::Post
+            [Microsoft.PowerShell.Commands.WebRequestMethod]$Method = [Microsoft.PowerShell.Commands.WebRequestMethod]::Post
         )
 
         $optionalParams = @{ }

--- a/Whiskey/Tasks/LoadTask.ps1
+++ b/Whiskey/Tasks/LoadTask.ps1
@@ -4,13 +4,11 @@ function Import-WhiskeyTask
     [Whiskey.Task("LoadTask")]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/MSBuild.ps1
+++ b/Whiskey/Tasks/MSBuild.ps1
@@ -5,15 +5,13 @@ function Invoke-WhiskeyMSBuild
     [Whiskey.RequiresPowerShellModule('VSSetup',Version='2.*',VersionParameterName='VSSetupVersion')]
     [CmdletBinding()]
     param(
-        [Whiskey.Context]
         # The context this task is operating in. Use `New-WhiskeyContext` to create context objects.
-        $TaskContext,
+        [Whiskey.Context]$TaskContext,
 
-        [hashtable]
         # The parameters/configuration to use to run the task. Should be a hashtable that contains the following item(s):
         #
         # * `Path` (Mandatory): the relative paths to the files/directories to include in the build. Paths should be relative to the whiskey.yml file they were taken from.
-        $TaskParameter
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -version 'Latest'

--- a/Whiskey/Tasks/MergeFile.ps1
+++ b/Whiskey/Tasks/MergeFile.ps1
@@ -8,19 +8,19 @@ function Merge-WhiskeyFile
         [Whiskey.Context]$TaskContext,
 
         [Whiskey.Tasks.ValidatePath(Mandatory,PathType='File')]
-        [string[]]$Path,
+        [String[]]$Path,
 
-        [string]$DestinationPath,
+        [String]$DestinationPath,
 
         [switch]$DeleteSourceFiles,
 
-        [string]$TextSeparator,
+        [String]$TextSeparator,
 
-        [byte[]]$BinarySeparator,
+        [Byte[]]$BinarySeparator,
 
         [switch]$Clear,
 
-        [string[]]$Exclude
+        [String[]]$Exclude
     )
 
     Set-StrictMode -Version 'Latest'
@@ -52,7 +52,7 @@ function Merge-WhiskeyFile
         return
     }
 
-    [byte[]]$separatorBytes = $BinarySeparator
+    [Byte[]]$separatorBytes = $BinarySeparator
     if( $TextSeparator )
     {
         $separatorBytes = [Text.Encoding]::UTF8.GetBytes($TextSeparator)
@@ -109,7 +109,7 @@ function Merge-WhiskeyFile
             try
             {
                 $bufferSize = 4kb
-                [byte[]]$buffer = New-Object 'byte[]' ($bufferSize)
+                [Byte[]]$buffer = New-Object 'byte[]' ($bufferSize)
                 while( $bytesRead = $reader.Read($buffer,0,$bufferSize) )
                 {
                     $writer.Write($buffer,0,$bytesRead)

--- a/Whiskey/Tasks/NUnit2.ps1
+++ b/Whiskey/Tasks/NUnit2.ps1
@@ -3,13 +3,11 @@ function Invoke-WhiskeyNUnit2Task
     [Whiskey.Task("NUnit2",SupportsClean, SupportsInitialize,Platform='Windows')]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -version 'latest'

--- a/Whiskey/Tasks/NUnit3.ps1
+++ b/Whiskey/Tasks/NUnit3.ps1
@@ -4,13 +4,11 @@ function Invoke-WhiskeyNUnit3Task
     [CmdletBinding()]
     [Whiskey.Task("NUnit3",SupportsClean,SupportsInitialize,Platform='Windows')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/Node.ps1
+++ b/Whiskey/Tasks/Node.ps1
@@ -42,7 +42,7 @@ function Invoke-WhiskeyNodeTask
     {
         param(
             [Parameter(Mandatory)]
-            [string]$Status,
+            [String]$Status,
 
             [int]$Step
         )
@@ -124,10 +124,11 @@ Build:
         Write-WhiskeyTiming -Message ('Converting license report.')
         # The default license checker report has a crazy format. It is an object with properties for each module.
         # Let's transform it to a more sane format: an array of objects.
-        [object[]]$newReport = $report |
-                                    Get-Member -MemberType NoteProperty |
-                                    Select-Object -ExpandProperty 'Name' |
-                                    ForEach-Object { $report.$_ | Add-Member -MemberType NoteProperty -Name 'name' -Value $_ -PassThru }
+        [Object[]]$newReport = 
+            $report |
+            Get-Member -MemberType NoteProperty |
+            Select-Object -ExpandProperty 'Name' |
+            ForEach-Object { $report.$_ | Add-Member -MemberType NoteProperty -Name 'name' -Value $_ -PassThru }
 
         # show the report
         $newReport | Sort-Object -Property 'licenses','name' | Format-Table -Property 'licenses','name' -AutoSize | Out-String | Write-WhiskeyVerbose -Context $TaskContext

--- a/Whiskey/Tasks/Node.ps1
+++ b/Whiskey/Tasks/Node.ps1
@@ -7,18 +7,16 @@ function Invoke-WhiskeyNodeTask
     [Whiskey.RequiresTool('NodeModule::nsp',PathParameterName='NspPath',VersionParameterName='PINNED_TO_NSP_2_7_0',Version='2.7.0')]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
+        [Parameter(Mandatory)]
         # The context the task is running under.
-        $TaskContext,
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
+        [Parameter(Mandatory)]
         # The task parameters, which are:
         #
         # * `NpmScript`: a list of one or more NPM scripts to run, e.g. `npm run $SCRIPT_NAME`. Each script is run indepently.
         # * `WorkingDirectory`: the directory where all the build commands should be run. Defaults to the directory where the build's `whiskey.yml` file was found. Must be relative to the `whiskey.yml` file.
-        $TaskParameter
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'
@@ -43,12 +41,10 @@ function Invoke-WhiskeyNodeTask
     function Update-Progress
     {
         param(
-            [Parameter(Mandatory=$true)]
-            [string]
-            $Status,
+            [Parameter(Mandatory)]
+            [string]$Status,
 
-            [int]
-            $Step
+            [int]$Step
         )
 
         Write-Progress -Activity $activity -Status $Status.TrimEnd('.') -PercentComplete ($Step/$numSteps*100)

--- a/Whiskey/Tasks/NodeLicenseChecker.ps1
+++ b/Whiskey/Tasks/NodeLicenseChecker.ps1
@@ -38,10 +38,11 @@ function Invoke-WhiskeyNodeLicenseChecker
     Write-WhiskeyTiming -Message 'Converting license report.'
     # The default license checker report has a crazy format. It is an object with properties for each module.
     # Let's transform it to a more sane format: an array of objects.
-    [object[]]$newReport = $report |
-                                Get-Member -MemberType NoteProperty |
-                                Select-Object -ExpandProperty 'Name' |
-                                ForEach-Object { $report.$_ | Add-Member -MemberType NoteProperty -Name 'name' -Value $_ -PassThru }
+    [Object[]]$newReport = 
+        $report |
+        Get-Member -MemberType NoteProperty |
+        Select-Object -ExpandProperty 'Name' |
+        ForEach-Object { $report.$_ | Add-Member -MemberType NoteProperty -Name 'name' -Value $_ -PassThru }
 
     # show the report
     $newReport | Sort-Object -Property 'licenses','name' | Format-Table -Property 'licenses','name' -AutoSize | Out-String | Write-WhiskeyVerbose -Context $TaskContext

--- a/Whiskey/Tasks/NodeLicenseChecker.ps1
+++ b/Whiskey/Tasks/NodeLicenseChecker.ps1
@@ -6,13 +6,11 @@ function Invoke-WhiskeyNodeLicenseChecker
     [Whiskey.RequiresTool('Node',PathParameterName='NodePath',VersionParameterName='NodeVersion')]
     [Whiskey.RequiresTool('NodeModule::license-checker',PathParameterName='LicenseCheckerPath',VersionParameterName='Version')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/NodeNspCheck.ps1
+++ b/Whiskey/Tasks/NodeNspCheck.ps1
@@ -6,13 +6,11 @@ function Invoke-WhiskeyNodeNspCheck
     [Whiskey.RequiresTool('NodeModule::nsp',PathParameterName='NspPath',VersionParameterName='Version')]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/Npm.ps1
+++ b/Whiskey/Tasks/Npm.ps1
@@ -6,13 +6,11 @@ function Invoke-WhiskeyNpm
     [Whiskey.RequiresTool('NodeModule::npm',PathParameterName='NpmPath',VersionParameterName='NpmVersion')]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/NpmConfig.ps1
+++ b/Whiskey/Tasks/NpmConfig.ps1
@@ -4,13 +4,11 @@ function Invoke-WhiskeyNpmConfig
     [Whiskey.Task('NpmConfig',Obsolete,ObsoleteMessage='The "NpmConfig" task is obsolete. It will be removed in a future version of Whiskey. Please use the "Npm" task instead.')]
     [Whiskey.RequiresTool('Node',PathParameterName='NodePath',VersionParameterName='NodeVersion')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/NpmInstall.ps1
+++ b/Whiskey/Tasks/NpmInstall.ps1
@@ -5,13 +5,11 @@ function Invoke-WhiskeyNpmInstall
     [Whiskey.RequiresTool('Node',PathParameterName='NodePath',VersionParameterName='NodeVersion')]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/NpmPrune.ps1
+++ b/Whiskey/Tasks/NpmPrune.ps1
@@ -5,15 +5,13 @@ function Invoke-WhiskeyNpmPrune
     [Whiskey.RequiresTool('Node',PathParameterName='NodePath',VersionParameterName='NodeVersion')]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
+        [Parameter(Mandatory)]
         # The context the task is running under.
-        $TaskContext,
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
+        [Parameter(Mandatory)]
         # The parameters/configuration to use to run the task.
-        $TaskParameter
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/NpmRunScript.ps1
+++ b/Whiskey/Tasks/NpmRunScript.ps1
@@ -5,13 +5,11 @@ function Invoke-WhiskeyNpmRunScript
     [Whiskey.RequiresTool('Node',PathParameterName='NodePath',VersionParameterName='NodeVersion')]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/NuGetPack.ps1
+++ b/Whiskey/Tasks/NuGetPack.ps1
@@ -4,13 +4,11 @@ function New-WhiskeyNuGetPackage
     [Whiskey.Task("NuGetPack",Platform='Windows')]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/NuGetPush.ps1
+++ b/Whiskey/Tasks/NuGetPush.ps1
@@ -5,16 +5,13 @@ function Publish-WhiskeyNuGetPackage
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Whiskey.Context]$TaskContext,
 
         [Parameter(Mandatory)]
-        [hashtable]
-        $TaskParameter,
+        [hashtable]$TaskParameter,
 
         [Whiskey.Tasks.ValidatePath(PathType='File')]
-        [string[]]
-        $Path
+        [string[]]$Path
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/NuGetPush.ps1
+++ b/Whiskey/Tasks/NuGetPush.ps1
@@ -11,7 +11,7 @@ function Publish-WhiskeyNuGetPackage
         [hashtable]$TaskParameter,
 
         [Whiskey.Tasks.ValidatePath(PathType='File')]
-        [string[]]$Path
+        [String[]]$Path
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/NuGetRestore.ps1
+++ b/Whiskey/Tasks/NuGetRestore.ps1
@@ -6,18 +6,14 @@ function Restore-WhiskeyNuGetPackage
     param(
         [Parameter(Mandatory)]
         [Whiskey.Tasks.ValidatePath(Mandatory)]
-        [string[]]
-        $Path,
+        [string[]]$Path,
 
-        [string[]]
-        $Argument,
+        [string[]]$Argument,
 
-        [string]
-        $Version,
+        [string]$Version,
 
         [Whiskey.Tasks.ParameterValueFromVariable('WHISKEY_BUILD_ROOT')]
-        [IO.DirectoryInfo]
-        $BuildRoot
+        [IO.DirectoryInfo]$BuildRoot
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/NuGetRestore.ps1
+++ b/Whiskey/Tasks/NuGetRestore.ps1
@@ -6,11 +6,11 @@ function Restore-WhiskeyNuGetPackage
     param(
         [Parameter(Mandatory)]
         [Whiskey.Tasks.ValidatePath(Mandatory)]
-        [string[]]$Path,
+        [String[]]$Path,
 
-        [string[]]$Argument,
+        [String[]]$Argument,
 
-        [string]$Version,
+        [String]$Version,
 
         [Whiskey.Tasks.ParameterValueFromVariable('WHISKEY_BUILD_ROOT')]
         [IO.DirectoryInfo]$BuildRoot

--- a/Whiskey/Tasks/Parallel.ps1
+++ b/Whiskey/Tasks/Parallel.ps1
@@ -110,7 +110,7 @@ function Invoke-WhiskeyParallelTask
                 $job |
                     Add-Member -MemberType NoteProperty -Name 'QueueIndex' -Value $queueIdx -PassThru |
                     Add-Member -MemberType NoteProperty -Name 'Completed' -Value $false
-                [void]$jobs.Add($job)
+                [Void]$jobs.Add($job)
         }
 
         $lastNotice = (Get-Date).AddSeconds(-61)

--- a/Whiskey/Tasks/Parallel.ps1
+++ b/Whiskey/Tasks/Parallel.ps1
@@ -4,13 +4,11 @@ function Invoke-WhiskeyParallelTask
     [CmdletBinding()]
     [Whiskey.Task('Parallel')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/Pester3.ps1
+++ b/Whiskey/Tasks/Pester3.ps1
@@ -5,13 +5,11 @@ function Invoke-WhiskeyPester3Task
     [Whiskey.RequiresPowerShellModule('Pester',ModuleInfoParameterName='PesterModuleInfo',Version='3.*',VersionParameterName='Version',SkipImport)]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/Pester4.ps1
+++ b/Whiskey/Tasks/Pester4.ps1
@@ -5,13 +5,11 @@ function Invoke-WhiskeyPester4Task
     [Whiskey.RequiresPowerShellModule('Pester',ModuleInfoParameterName='PesterModuleInfo',Version='4.*',VersionParameterName='Version',SkipImport)]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/Pipeline.ps1
+++ b/Whiskey/Tasks/Pipeline.ps1
@@ -1,15 +1,13 @@
  function Invoke-WhiskeyPipelineTask
 {
     [CmdletBinding()]
-    [Whiskey.Task("Pipeline", SupportsClean=$true, SupportsInitialize=$true)]
+    [Whiskey.Task("Pipeline", SupportsClean, SupportsInitialize)]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/Pipeline.ps1
+++ b/Whiskey/Tasks/Pipeline.ps1
@@ -1,7 +1,7 @@
  function Invoke-WhiskeyPipelineTask
 {
     [CmdletBinding()]
-    [Whiskey.Task("Pipeline", SupportsClean, SupportsInitialize)]
+    [Whiskey.Task('Pipeline',SupportsClean,SupportsInitialize)]
     param(
         [Parameter(Mandatory)]
         [Whiskey.Context]$TaskContext,

--- a/Whiskey/Tasks/PowerShell.ps1
+++ b/Whiskey/Tasks/PowerShell.ps1
@@ -1,16 +1,14 @@
 
 function Invoke-WhiskeyPowerShell
 {
-    [Whiskey.Task("PowerShell",SupportsClean=$true,SupportsInitialize=$true)]
+    [Whiskey.Task("PowerShell",SupportsClean,SupportsInitialize)]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/PowerShell.ps1
+++ b/Whiskey/Tasks/PowerShell.ps1
@@ -1,7 +1,7 @@
 
 function Invoke-WhiskeyPowerShell
 {
-    [Whiskey.Task("PowerShell",SupportsClean,SupportsInitialize)]
+    [Whiskey.Task('PowerShell',SupportsClean,SupportsInitialize)]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]

--- a/Whiskey/Tasks/ProGetUniversalPackage.ps1
+++ b/Whiskey/Tasks/ProGetUniversalPackage.ps1
@@ -73,7 +73,7 @@ function New-WhiskeyProGetUniversalPackage
     $compressionLevel = [IO.Compression.CompressionLevel]::Optimal
     if( $TaskParameter['CompressionLevel'] )
     {
-        $expectedValues = [enum]::GetValues([IO.Compression.CompressionLevel])
+        $expectedValues = [Enum]::GetValues([IO.Compression.CompressionLevel])
         $compressionLevel = $TaskParameter['CompressionLevel']
         if( $compressionLevel -notin $expectedValues )
         {
@@ -128,7 +128,7 @@ function New-WhiskeyProGetUniversalPackage
     {
         param(
             [Parameter(Mandatory)]
-            [object[]]$Path,
+            [Object[]]$Path,
 
             [switch]$AsThirdPartyItem
         )

--- a/Whiskey/Tasks/ProGetUniversalPackage.ps1
+++ b/Whiskey/Tasks/ProGetUniversalPackage.ps1
@@ -5,13 +5,11 @@ function New-WhiskeyProGetUniversalPackage
     [Whiskey.Task('ProGetUniversalPackage')]
     [Whiskey.RequiresPowerShellModule('ProGetAutomation',Version='0.9.*',VersionParameterName='ProGetAutomationVersion')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'
@@ -129,12 +127,10 @@ function New-WhiskeyProGetUniversalPackage
     function Copy-ToPackage
     {
         param(
-            [Parameter(Mandatory=$true)]
-            [object[]]
-            $Path,
+            [Parameter(Mandatory)]
+            [object[]]$Path,
 
-            [Switch]
-            $AsThirdPartyItem
+            [Switch]$AsThirdPartyItem
         )
 
         foreach( $item in $Path )

--- a/Whiskey/Tasks/ProGetUniversalPackage.ps1
+++ b/Whiskey/Tasks/ProGetUniversalPackage.ps1
@@ -130,7 +130,7 @@ function New-WhiskeyProGetUniversalPackage
             [Parameter(Mandatory)]
             [object[]]$Path,
 
-            [Switch]$AsThirdPartyItem
+            [switch]$AsThirdPartyItem
         )
 
         foreach( $item in $Path )

--- a/Whiskey/Tasks/PublishBitbucketServerTag.ps1
+++ b/Whiskey/Tasks/PublishBitbucketServerTag.ps1
@@ -54,7 +54,7 @@ function Publish-WhiskeyBBServerTag
     }
     elseif( $TaskContext.BuildMetadata.ScmUri -and $TaskContext.BuildMetadata.ScmUri.Segments )
     {
-        $uri = [uri]$TaskContext.BuildMetadata.ScmUri
+        $uri = [Uri]$TaskContext.BuildMetadata.ScmUri
         $projectKey = $uri.Segments[-2].Trim('/')
         $repoKey = $uri.Segments[-1] -replace '\.git$',''
     }

--- a/Whiskey/Tasks/PublishBitbucketServerTag.ps1
+++ b/Whiskey/Tasks/PublishBitbucketServerTag.ps1
@@ -5,13 +5,11 @@ function Publish-WhiskeyBBServerTag
     [Whiskey.Task('PublishBitbucketServerTag')]
     [Whiskey.RequiresPowerShellModule('BitbucketServerAutomation',Version='0.9.*',VersionParameterName='BitbucketServerAutomationVersion')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/PublishBuildMasterPackage.ps1
+++ b/Whiskey/Tasks/PublishBuildMasterPackage.ps1
@@ -5,13 +5,11 @@ function Publish-WhiskeyBuildMasterPackage
     [Whiskey.Task('PublishBuildMasterPackage')]
     [Whiskey.RequiresPowerShellModule('BuildMasterAutomation',Version='0.6.*',VersionParameterName='BuildMasterAutomationVersion')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/PublishNodeModule.ps1
+++ b/Whiskey/Tasks/PublishNodeModule.ps1
@@ -8,13 +8,13 @@ function Publish-WhiskeyNodeModule
         [Parameter(Mandatory)]
         [Whiskey.Context]$TaskContext,
 
-        [string]$CredentialID,
+        [String]$CredentialID,
 
-        [string]$EmailAddress,
+        [String]$EmailAddress,
 
-        [uri]$NpmRegistryUri,
+        [Uri]$NpmRegistryUri,
 
-        [string]$Tag
+        [String]$Tag
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/PublishPowerShellModule.ps1
+++ b/Whiskey/Tasks/PublishPowerShellModule.ps1
@@ -17,7 +17,7 @@ function Publish-WhiskeyPowerShellModule
         [hashtable]$TaskParameter,
 
         [Whiskey.Tasks.ValidatePath(Mandatory,PathType='Directory')]
-        [string]$Path
+        [String]$Path
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/PublishProGetAsset.ps1
+++ b/Whiskey/Tasks/PublishProGetAsset.ps1
@@ -6,13 +6,11 @@ function Publish-WhiskeyProGetAsset
     [Whiskey.RequiresPowerShellModule('ProGetAutomation',Version='0.9.*',VersionParameterName='ProGetAutomationVersion')]
     [CmdletBinding()]
     param(
-        [Whiskey.Context]
         # The context this task is operating in. Use `New-WhiskeyContext` to create context objects.
-        $TaskContext,
+        [Whiskey.Context]$TaskContext,
 
-        [hashtable]
         # The parameters/configuration to use to run the task.
-        $TaskParameter
+        [hashtable]$TaskParameter
     )
 
 

--- a/Whiskey/Tasks/PublishProGetUniversalPackage.ps1
+++ b/Whiskey/Tasks/PublishProGetUniversalPackage.ps1
@@ -2,7 +2,7 @@
 function Publish-WhiskeyProGetUniversalPackage
 {
     [CmdletBinding()]
-    [Whiskey.Task("PublishProGetUniversalPackage")]
+    [Whiskey.Task('PublishProGetUniversalPackage')]
     [Whiskey.RequiresPowerShellModule('ProGetAutomation',Version='0.9.*',VersionParameterName='ProGetAutomationVersion')]
     param(
         [Parameter(Mandatory)]

--- a/Whiskey/Tasks/PublishProGetUniversalPackage.ps1
+++ b/Whiskey/Tasks/PublishProGetUniversalPackage.ps1
@@ -5,13 +5,11 @@ function Publish-WhiskeyProGetUniversalPackage
     [Whiskey.Task("PublishProGetUniversalPackage")]
     [Whiskey.RequiresPowerShellModule('ProGetAutomation',Version='0.9.*',VersionParameterName='ProGetAutomationVersion')]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/SetVariable.ps1
+++ b/Whiskey/Tasks/SetVariable.ps1
@@ -2,15 +2,13 @@
 function Set-WhiskeyVariable 
 {
     [CmdletBinding()]
-    [Whiskey.Task("SetVariable",SupportsClean=$true,SupportsInitialize=$true)]
+    [Whiskey.Task("SetVariable",SupportsClean,SupportsInitialize)]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/SetVariable.ps1
+++ b/Whiskey/Tasks/SetVariable.ps1
@@ -2,7 +2,7 @@
 function Set-WhiskeyVariable 
 {
     [CmdletBinding()]
-    [Whiskey.Task("SetVariable",SupportsClean,SupportsInitialize)]
+    [Whiskey.Task('SetVariable',SupportsClean,SupportsInitialize)]
     param(
         [Parameter(Mandatory)]
         [Whiskey.Context]$TaskContext,

--- a/Whiskey/Tasks/SetVariableFromPowerShellDataFile.ps1
+++ b/Whiskey/Tasks/SetVariableFromPowerShellDataFile.ps1
@@ -5,16 +5,13 @@ function Set-WhiskeyVariableFromPowerShellDataFile
     [Whiskey.Task('SetVariableFromPowerShellDataFile')]
     param(
         [Parameter(Mandatory)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Whiskey.Context]$TaskContext,
 
         [Parameter(Mandatory)]
-        [hashtable]
-        $TaskParameter,
+        [hashtable]$TaskParameter,
 
         [Whiskey.Tasks.ValidatePath(Mandatory,PathType='File')]
-        [string]
-        $Path
+        [string]$Path
     )
 
     Set-StrictMode -Version 'Latest'
@@ -30,14 +27,11 @@ function Set-WhiskeyVariableFromPowerShellDataFile
     function Set-VariableFromData
     {
         param(
-            [object]
-            $Variable,
+            [object]$Variable,
 
-            [hashtable]
-            $Data,
+            [hashtable]$Data,
             
-            [string]
-            $ParentPropertyName = ''
+            [string]$ParentPropertyName = ''
         )
 
         foreach( $propertyName in $Variable.Keys )

--- a/Whiskey/Tasks/SetVariableFromPowerShellDataFile.ps1
+++ b/Whiskey/Tasks/SetVariableFromPowerShellDataFile.ps1
@@ -11,7 +11,7 @@ function Set-WhiskeyVariableFromPowerShellDataFile
         [hashtable]$TaskParameter,
 
         [Whiskey.Tasks.ValidatePath(Mandatory,PathType='File')]
-        [string]$Path
+        [String]$Path
     )
 
     Set-StrictMode -Version 'Latest'
@@ -27,11 +27,11 @@ function Set-WhiskeyVariableFromPowerShellDataFile
     function Set-VariableFromData
     {
         param(
-            [object]$Variable,
+            [Object]$Variable,
 
             [hashtable]$Data,
             
-            [string]$ParentPropertyName = ''
+            [String]$ParentPropertyName = ''
         )
 
         foreach( $propertyName in $Variable.Keys )

--- a/Whiskey/Tasks/SetVariableFromXml.ps1
+++ b/Whiskey/Tasks/SetVariableFromXml.ps1
@@ -11,7 +11,7 @@ function Set-WhiskeyVariableFromXml
         [hashtable]$TaskParameter,
 
         [Whiskey.Tasks.ValidatePath(Mandatory,PathType='File')]
-        [string]$Path
+        [String]$Path
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/SetVariableFromXml.ps1
+++ b/Whiskey/Tasks/SetVariableFromXml.ps1
@@ -5,16 +5,13 @@ function Set-WhiskeyVariableFromXml
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Whiskey.Context]$TaskContext,
 
         [Parameter(Mandatory)]
-        [hashtable]
-        $TaskParameter,
+        [hashtable]$TaskParameter,
 
         [Whiskey.Tasks.ValidatePath(Mandatory,PathType='File')]
-        [string]
-        $Path
+        [string]$Path
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/TaskDefaults.ps1
+++ b/Whiskey/Tasks/TaskDefaults.ps1
@@ -2,15 +2,13 @@
 function Set-WhiskeyTaskDefaults
 {
     [CmdletBinding()]
-    [Whiskey.Task("TaskDefaults",SupportsClean=$true,SupportsInitialize=$true)]
+    [Whiskey.Task("TaskDefaults",SupportsClean,SupportsInitialize)]
     param(
-        [Parameter(Mandatory=$true)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Parameter(Mandatory)]
+        [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $TaskParameter
+        [Parameter(Mandatory)]
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/TaskDefaults.ps1
+++ b/Whiskey/Tasks/TaskDefaults.ps1
@@ -2,7 +2,7 @@
 function Set-WhiskeyTaskDefaults
 {
     [CmdletBinding()]
-    [Whiskey.Task("TaskDefaults",SupportsClean,SupportsInitialize)]
+    [Whiskey.Task('TaskDefaults',SupportsClean,SupportsInitialize)]
     param(
         [Parameter(Mandatory)]
         [Whiskey.Context]$TaskContext,

--- a/Whiskey/Tasks/Version.ps1
+++ b/Whiskey/Tasks/Version.ps1
@@ -5,16 +5,13 @@
     [Whiskey.Task("Version")]
     param(
         [Parameter(Mandatory)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Whiskey.Context]$TaskContext,
 
         [Parameter(Mandatory)]
-        [hashtable]
-        $TaskParameter,
+        [hashtable]$TaskParameter,
 
         [Whiskey.Tasks.ValidatePath(PathType='File')]
-        [string]
-        $Path
+        [string]$Path
     )
 
     Set-StrictMode -Version 'Latest'
@@ -23,7 +20,7 @@
     function ConvertTo-SemVer
     {
         param(
-            [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
+            [Parameter(Mandatory,ValueFromPipeline)]
             $InputObject,
             $PropertyName,
             $VersionSource

--- a/Whiskey/Tasks/Version.ps1
+++ b/Whiskey/Tasks/Version.ps1
@@ -11,7 +11,7 @@
         [hashtable]$TaskParameter,
 
         [Whiskey.Tasks.ValidatePath(PathType='File')]
-        [string]$Path
+        [String]$Path
     )
 
     Set-StrictMode -Version 'Latest'
@@ -147,7 +147,7 @@
     }
 
     $prerelease = $TaskParameter['Prerelease']
-    if( $prerelease -isnot [string] )
+    if( $prerelease -isnot [String] )
     {
         $foundLabel = $false
         foreach( $object in $prerelease )
@@ -247,7 +247,7 @@ If you want certain branches to always have certain prerelease versions, set Pre
 
     $buildVersion.SemVer2 = $semver
     Write-WhiskeyInfo -Context $TaskContext -Message ('Building version {0}' -f $semver)
-    $buildVersion.Version = [version]('{0}.{1}.{2}' -f $semver.Major,$semver.Minor,$semver.Patch)
+    $buildVersion.Version = [Version]('{0}.{1}.{2}' -f $semver.Major,$semver.Minor,$semver.Patch)
     Write-WhiskeyVerbose -Context $TaskContext -Message ('Version                 {0}' -f $buildVersion.Version)
     $buildVersion.SemVer2NoBuildMetadata = New-Object 'SemVersion.SemanticVersion' ($semver.Major,$semver.Minor,$semver.Patch,$semver.Prerelease)
     Write-WhiskeyVerbose -Context $TaskContext -Message ('SemVer2NoBuildMetadata  {0}' -f $buildVersion.SemVer2NoBuildMetadata)

--- a/Whiskey/Tasks/Version.ps1
+++ b/Whiskey/Tasks/Version.ps1
@@ -2,7 +2,7 @@
  function Set-WhiskeyVersion
 {
     [CmdletBinding()]
-    [Whiskey.Task("Version")]
+    [Whiskey.Task('Version')]
     param(
         [Parameter(Mandatory)]
         [Whiskey.Context]$TaskContext,

--- a/Whiskey/Tasks/Zip.ps1
+++ b/Whiskey/Tasks/Zip.ps1
@@ -6,12 +6,10 @@ function New-WhiskeyZipArchive
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [Whiskey.Context]
-        $TaskContext,
+        [Whiskey.Context]$TaskContext,
 
         [Parameter(Mandatory)]
-        [hashtable]
-        $TaskParameter
+        [hashtable]$TaskParameter
     )
 
     Set-StrictMode -Version 'Latest'

--- a/Whiskey/Tasks/Zip.ps1
+++ b/Whiskey/Tasks/Zip.ps1
@@ -20,9 +20,9 @@ function New-WhiskeyZipArchive
         param(
             [Parameter(Mandatory)]
             [ValidateSet('file','directory','filtered directory')]
-            [string]$What,
-            [string]$Source,
-            [string]$Destination
+            [String]$What,
+            [String]$Source,
+            [String]$Destination
         )
 
         if( $Destination )
@@ -57,7 +57,7 @@ function New-WhiskeyZipArchive
         [IO.Compression.CompressionLevel]$compressionLevel = [IO.Compression.CompressionLevel]::NoCompression
         if( -not [Enum]::TryParse($TaskParameter['CompressionLevel'], [ref]$compressionLevel) )
         {
-            Stop-WhiskeyTask -TaskContext $TaskContext -PropertyName 'CompressionLevel' -Message ('Value "{0}" is an invalid compression level. Must be one of: {1}.' -f $TaskParameter['CompressionLevel'],([enum]::GetValues([IO.Compression.CompressionLevel]) -join ', '))
+            Stop-WhiskeyTask -TaskContext $TaskContext -PropertyName 'CompressionLevel' -Message ('Value "{0}" is an invalid compression level. Must be one of: {1}.' -f $TaskParameter['CompressionLevel'],([Enum]::GetValues([IO.Compression.CompressionLevel]) -join ', '))
             return
         }
         $behaviorParams['CompressionLevel'] = $compressionLevel

--- a/Whiskey/Whiskey.psm1
+++ b/Whiskey/Whiskey.psm1
@@ -50,10 +50,10 @@ function Assert-Member
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [object]$Object,
+        [Object]$Object,
 
         [Parameter(Mandatory)]
-        [string[]]$Property
+        [String[]]$Property
     )
 
     foreach( $propertyToCheck in $Property )
@@ -74,7 +74,7 @@ Assert-Member -Object $taskAttribute -Property @( 'Aliases', 'WarnWhenUsingAlias
 
 [Type]$apiKeysType = $context.ApiKeys.GetType()
 $apiKeysDictGenericTypes = $apiKeysType.GenericTypeArguments
-if( -not $apiKeysDictGenericTypes -or $apiKeysDictGenericTypes.Count -ne 2 -or $apiKeysDictGenericTypes[1].FullName -ne [SecureString].FullName )
+if( -not $apiKeysDictGenericTypes -or $apiKeysDictGenericTypes.Count -ne 2 -or $apiKeysDictGenericTypes[1].FullName -ne [securestring].FullName )
 {
     Write-Error -Message ('You''ve got an old version of Whiskey loaded. Please open a new PowerShell session.') -ErrorAction Stop 
 }

--- a/Whiskey/Whiskey.psm1
+++ b/Whiskey/Whiskey.psm1
@@ -50,12 +50,10 @@ function Assert-Member
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [object]
-        $Object,
+        [object]$Object,
 
         [Parameter(Mandatory)]
-        [string[]]
-        $Property
+        [string[]]$Property
     )
 
     foreach( $propertyToCheck in $Property )

--- a/Whiskey/build.ps1
+++ b/Whiskey/build.ps1
@@ -59,7 +59,7 @@ if( -not (Test-Path -Path $whiskeyModuleRoot -PathType Container) )
             {
                 return $true
             }
-            [version]::TryParse($_.name,[ref]$null)
+            [Version]::TryParse($_.name,[ref]$null)
         } |
         Sort-Object -Property 'created_at' -Descending |
         Select-Object -First 1

--- a/Whiskey/build.ps1
+++ b/Whiskey/build.ps1
@@ -30,11 +30,11 @@ Demonstrates how to initialize the build root with any tools that are required b
 param(
     [Parameter(Mandatory,ParameterSetName='Clean')]
     # Runs the build in clean mode, which removes any files, tools, packages created by previous builds.
-    [Switch]$Clean,
+    [switch]$Clean,
 
     [Parameter(Mandatory,ParameterSetName='Initialize')]
     # Initializes the repository.
-    [Switch]$Initialize
+    [switch]$Initialize
 )
 
 #Requires -Version 5.1

--- a/build.ps1
+++ b/build.ps1
@@ -25,13 +25,13 @@ Starts a build and uses "Release" as the build configuration when building the W
 #>
 [CmdletBinding(DefaultParameterSetName='Build')]
 param(
-    [Parameter(Mandatory=$true,ParameterSetName='Clean')]
+    [Parameter(Mandatory,ParameterSetName='Clean')]
     # Runs the build in clean mode, which removes any files, tools, packages created by previous builds.
-    [Switch]$Clean,
+    [switch]$Clean,
 
-    [Parameter(Mandatory=$true,ParameterSetName='Initialize')]
+    [Parameter(Mandatory,ParameterSetName='Initialize')]
     # Initializes the repository.
-    [Switch]$Initialize,
+    [switch]$Initialize,
 
     [string]$PipelineName,
 

--- a/build.ps1
+++ b/build.ps1
@@ -33,9 +33,9 @@ param(
     # Initializes the repository.
     [switch]$Initialize,
 
-    [string]$PipelineName,
+    [String]$PipelineName,
 
-    [string]$MSBuildConfiguration = 'Debug'
+    [String]$MSBuildConfiguration = 'Debug'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -75,7 +75,7 @@ if( Test-Path -Path ('env:APPVEYOR') )
     $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 'true'
 }
 
-$minDotNetVersion = [version]'2.1.503'
+$minDotNetVersion = [Version]'2.1.503'
 $dotnetVersion = $null
 $dotnetInstallDir = Join-Path -Path $PSScriptRoot -ChildPath '.dotnet'
 $dotnetExeName = 'dotnet.exe'
@@ -93,7 +93,7 @@ $dotnetPath = Join-Path -Path $dotnetInstallDir -ChildPath $dotnetExeName
 
 if( (Test-Path -Path $dotnetPath -PathType Leaf) )
 {
-    $dotnetVersion = & $dotnetPath --version | ForEach-Object { [version]$_ }
+    $dotnetVersion = & $dotnetPath --version | ForEach-Object { [Version]$_ }
     Write-Verbose ('dotnet {0} installed in {1}.' -f $dotnetVersion,$dotnetInstallDir)
 }
 
@@ -170,7 +170,7 @@ $whiskeyBinPath = Join-Path -Path $PSScriptRoot -ChildPath 'Whiskey\bin'
 $whiskeyOutBinPath = Join-Path -Path $PSScriptRoot -ChildPath ('Assembly\Whiskey\bin\{0}\netstandard2.0' -f $MSBuildConfiguration)
 $whiskeyAssemblyPath = Get-Item -Path (Join-Path -Path $whiskeyOutBinPath -ChildPath 'Whiskey.dll')
 $whiskeyAssemblyVersion = $whiskeyAssemblyPath.VersionInfo
-$fileVersion = [version]('{0}.0' -f $version)
+$fileVersion = [Version]('{0}.0' -f $version)
 if( $whiskeyAssemblyVersion.FileVersion -ne $fileVersion )
 {
     Write-Error -Message ('{0}: file version not set correctly. Expected "{1}" but was "{2}".' -f $whiskeyAssemblyPath.FullName,$fileVersion,$whiskeyAssemblyVersion.FileVersion) 

--- a/build.ps1
+++ b/build.ps1
@@ -26,20 +26,16 @@ Starts a build and uses "Release" as the build configuration when building the W
 [CmdletBinding(DefaultParameterSetName='Build')]
 param(
     [Parameter(Mandatory=$true,ParameterSetName='Clean')]
-    [Switch]
     # Runs the build in clean mode, which removes any files, tools, packages created by previous builds.
-    $Clean,
+    [Switch]$Clean,
 
     [Parameter(Mandatory=$true,ParameterSetName='Initialize')]
-    [Switch]
     # Initializes the repository.
-    $Initialize,
+    [Switch]$Initialize,
 
-    [string]
-    $PipelineName,
+    [string]$PipelineName,
 
-    [string]
-    $MSBuildConfiguration = 'Debug'
+    [string]$MSBuildConfiguration = 'Debug'
 )
 
 $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
Let's get all our code to follow current standards in one big change. This should make reviewing pull requests easier since we will no longer need to distinguish what changes are important vs. formatting.

* Parameter names should be prefixed with their types (don't put parameter types on their own line).
* Use terse set-attribute-boolean-property-to-true syntax (i.e. `[Parameter(Mandatory)]` not `[Parameter(Mandatory=$true)])`.
* Whiskey's context is strongly typed so replace parameter types where it is typed as an `[object]` with `[Whiskey.Context]`.