### PR TITLE
Temporarily disable OpenCover tests until we can create an OpenCover …

### DIFF
--- a/Test/NUnit2.Tests.ps1
+++ b/Test/NUnit2.Tests.ps1
@@ -613,7 +613,7 @@ Describe 'NUnit2.when NUnit Console Path is invalid and Join-Path -resolve fails
 }
 
 Describe 'NUnit2.when running NUnit tests with coverage filters' {
-    It 'should pass coverage filters to OpenCover' {
+    It 'should pass coverage filters to OpenCover' -Skip {
         $coverageFilter = (
                         '-[NUnit2FailingTest]*',
                         '+[NUnit2PassingTest]*'
@@ -675,7 +675,7 @@ Describe 'NUnit2.when running under a custom dotNET framework' {
 }
 
 Describe 'NUnit2.when running with custom OpenCover arguments' {
-    It 'should pass custom OpenCover arguments' {
+    It 'should pass custom OpenCover arguments' -Skip {
         Init
         GivenPassingTests
         WhenRunningTask -WithParameters @{ 'OpenCoverArgument' = @( '-showunvisited' ) }

--- a/Test/NUnit3.Tests.ps1
+++ b/Test/NUnit3.Tests.ps1
@@ -697,7 +697,7 @@ Describe 'NUnit3.when running NUnit with multiple test filters' {
 }
 
 Describe 'NUnit3.when running NUnit tests with OpenCover argument' {
-    It 'should pass argument to OpenCover' {
+    It 'should pass argument to OpenCover' -Skip {
         Init
         GivenPassingPath
         GivenOpenCoverArgument '-showunvisited'
@@ -710,7 +710,7 @@ Describe 'NUnit3.when running NUnit tests with OpenCover argument' {
 }
 
 Describe 'NUnit3.when running NUnit tests with OpenCover coverage filter' {
-    It 'should pass coverage filter to OpenCover' {
+    It 'should pass coverage filter to OpenCover' -Skip {
         Init
         GivenPath (Get-FailingTestPath), (Get-PassingTestPath)
         GivenCoverageFilter '-[NUnit3FailingTest]*','+[NUnit3PassingTest]*'


### PR DESCRIPTION
…task an deprecate running OpenCover in the NUnit2 and NUnit3 tasks.