### PR TITLE
Pester4 task improvements:

### DIFF
--- a/Test/Initialize-WhiskeyTest.ps1
+++ b/Test/Initialize-WhiskeyTest.ps1
@@ -38,7 +38,7 @@ function Test-Import
     if( -not ($module | Get-Member 'ImportedAt') )
     {
         Write-Timing ('Module "{0}" not loaded by WhiskeyTest.' -f $Name)
-        return $true
+        $module | Add-Member -Name 'ImportedAt' -MemberType NoteProperty -Value (Get-Date)
     }
 
     $moduleRoot = $module.Path
@@ -74,7 +74,7 @@ try
 {
     $Global:VerbosePreference = 'SilentlyContinue'
 
-    Write-Timing ('Initialize-WhiskeyTest.ps1')
+    Write-Timing ('Initialize-WhiskeyTest.ps1  Start')
     # Some tests load ProGetAutomation from a Pester test drive. Forcibly remove the module if it is loaded to avoid errors.
 
     if( Test-Import -Name 'Whiskey' )
@@ -121,6 +121,6 @@ try
 }
 finally
 {
-    Write-Timing ('Initialize-WhiskeyTest.ps1')
+    Write-Timing ('Initialize-WhiskeyTest.ps1  End')
     $Global:VerbosePreference = $originalVerbosePreference
 }

--- a/Test/Install-WhiskeyPowerShellModule.Tests.ps1
+++ b/Test/Install-WhiskeyPowerShellModule.Tests.ps1
@@ -21,7 +21,7 @@ function Init
 }
 
 # Wrap private function so we can call it like it's public.
-function Install-WhiskeyPowerShellModule
+function Install-PowerShellModule
 {
     [CmdletBinding()]
     param(
@@ -36,7 +36,7 @@ function Install-WhiskeyPowerShellModule
     Invoke-WhiskeyPrivateCommand -Name 'Install-WhiskeyPowerShellModule' -Parameter $PSBoundParameters -ErrorAction $ErrorActionPreference
 }
 
-function Invoke-PowershellInstall
+function Invoke-PowerShellInstall
 {
     param(
         $ForModule,
@@ -57,7 +57,7 @@ function Invoke-PowershellInstall
         Remove-Module -Name $ForModule -Force -ErrorAction Ignore
     }
 
-    $result = Install-WhiskeyPowerShellModule -Name $ForModule -Version $Version -SkipImport:$SkipImport
+    $result = Install-PowerShellModule -Name $ForModule -Version $Version -SkipImport:$SkipImport
     $result | Should -BeOfType ([Management.Automation.PSModuleInfo])
 
     $errors = @()
@@ -109,8 +109,8 @@ Describe 'Install-WhiskeyPowerShellModule.when installing and re-installing a Po
     AfterEach { Reset }
     It 'should install package management modules and the module' {
         Init
-        Invoke-PowershellInstall -ForModule 'Zip' -Version '0.2.0'
-        Invoke-PowershellInstall -ForModule 'Zip' -Version '0.2.0'
+        Invoke-PowerShellInstall -ForModule 'Zip' -Version '0.2.0'
+        Invoke-PowerShellInstall -ForModule 'Zip' -Version '0.2.0'
         ThenModuleInstalled 'Zip' -AtVersion '0.2.0'
         ThenModuleImported 'Zip' -AtVersion '0.2.0'
 
@@ -127,7 +127,7 @@ Describe 'Install-WhiskeyPowerShellModule.when installing a PowerShell module an
     AfterEach { Reset }
     It 'should install at patch number 0' {
         Init
-        Invoke-PowershellInstall -ForModule 'Zip' -Version '0.2' -ActualVersion '0.2.0'
+        Invoke-PowerShellInstall -ForModule 'Zip' -Version '0.2' -ActualVersion '0.2.0'
         $Global:Error | Should -BeNullOrEmpty
         ThenModuleImported 'Zip' -AtVersion '0.2.0'
     }
@@ -137,7 +137,7 @@ Describe 'Install-WhiskeyPowerShellModule.when installing a PowerShell module om
     AfterEach { Reset }
     It 'should install the latest version' {
         Init
-        Invoke-PowershellInstall -ForModule 'Zip' -Version '' -ActualVersion $latestZip.Version
+        Invoke-PowerShellInstall -ForModule 'Zip' -Version '' -ActualVersion $latestZip.Version
         $Global:Error | Should -BeNullOrEmpty
         ThenModuleImported 'Zip' -AtVersion $latestZip.Version
     }
@@ -148,7 +148,7 @@ Describe 'Install-WhiskeyPowerShellModule.when installing a PowerShell module us
     It 'should resolve to the latest version that matches the wildcard' {
         Init
         $version = [Version]($latestZip.Version)
-        Invoke-PowershellInstall -ForModule 'Zip' -Version ('{0}.*' -f $version.Major) -ActualVersion $latestZip.Version
+        Invoke-PowerShellInstall -ForModule 'Zip' -Version ('{0}.*' -f $version.Major) -ActualVersion $latestZip.Version
         ThenModuleImported 'Zip' -AtVersion $latestZip.Version
     }
 }
@@ -157,7 +157,7 @@ Describe 'Install-WhiskeyPowerShellModule.when installing a PowerShell module' {
     AfterEach { Reset }
     It 'should install the module' {
         Init
-        Invoke-PowershellInstall -ForModule 'Zip' -Version '0.2.0'
+        Invoke-PowerShellInstall -ForModule 'Zip' -Version '0.2.0'
         ThenModuleImported 'Zip' -AtVersion '0.2.0'
     }
 }
@@ -167,7 +167,7 @@ Describe 'Install-WhiskeyPowerShellModule.when installing a PowerShell module an
     It 'should fail' {
         Init
         $InformationPreference = 'Continue'
-        $result = Install-WhiskeyPowerShellModule -Name 'Zip' -Version '0.0.1' #-ErrorAction SilentlyContinue
+        $result = Install-PowerShellModule -Name 'Zip' -Version '0.0.1' #-ErrorAction SilentlyContinue
         $result | Should -BeNullOrEmpty
         $Global:Error.Count | Should -BeGreaterThan 0
         $Global:Error | Where-Object { $_ -match 'failed to find' } | Should -Not -BeNullOrEmpty
@@ -178,7 +178,7 @@ Describe 'Install-WhiskeyPowerShellModule.when installing a PowerShell module an
     AfterEach { Reset }
     It 'should fail' {
         Init
-        $result = Install-WhiskeyPowerShellModule -Name 'Fubar' -Version '' -ErrorAction SilentlyContinue
+        $result = Install-PowerShellModule -Name 'Fubar' -Version '' -ErrorAction SilentlyContinue
         $result | Should -BeNullOrEmpty
         $Global:Error.Count | Should -BeGreaterThan 0
         $Global:Error | Where-Object { $_ -match 'failed to find' } | Should -Not -BeNullOrEmpty
@@ -189,11 +189,11 @@ Describe 'Install-WhiskeyPowerShellModule.when PowerShell module is already inst
     AfterEach { Reset }
     It 'should install the new version' {
         Init
-        Install-WhiskeyPowerShellModule -Name 'Zip' -Version $latestZip.Version
+        Install-PowerShellModule -Name 'Zip' -Version $latestZip.Version
         $info = Get-ChildItem -Path $testRoot -Filter 'Zip.psd1' -Recurse
         $manifest = Test-ModuleManifest -Path $info.FullName
         Start-Sleep -Milliseconds 333
-        Install-WhiskeyPowerShellModule -Name 'Zip' -Version $latestZip.Version
+        Install-PowerShellModule -Name 'Zip' -Version $latestZip.Version
         $newInfo = Get-ChildItem -Path $testRoot -Filter 'Zip.psd1' -Recurse
         $newManifest = Test-ModuleManifest -Path $newInfo.FullName
         $newManifest.Version | Should -Be $manifest.Version
@@ -206,7 +206,7 @@ Describe 'Install-WhiskeyPowerShellModule.when PowerShell module directory exist
         Init
         $moduleRootDir = Join-Path -Path $testRoot -ChildPath ('{0}\Zip' -f $TestPSModulesDirectoryName)
         New-Item -Path $moduleRootDir -ItemType Directory | Write-WhiskeyDebug
-        Invoke-PowershellInstall -ForModule 'Zip' -Version $latestZip.Version
+        Invoke-PowerShellInstall -ForModule 'Zip' -Version $latestZip.Version
     }
 }
 
@@ -214,12 +214,12 @@ Describe 'Install-WhiskeyPowerShellModule.when PowerShell module can''t be impor
     AfterEach { Reset }
     It 'should re-download the module' {
         Init
-        Install-WhiskeyPowerShellModule -Name 'Zip' -Version $latestZip.Version
+        Install-PowerShellModule -Name 'Zip' -Version $latestZip.Version
         $moduleManifest = Join-Path -Path $testRoot -ChildPath ('{0}\Zip\{1}\Zip.psd1' -f $TestPSModulesDirectoryName,$latestZip.Version) -Resolve
         '@{ }' | Set-Content -Path $moduleManifest
         { Test-ModuleManifest -Path $moduleManifest -ErrorAction Ignore } | Should -Throw
         $Global:Error.Clear()
-        Invoke-PowershellInstall -ForModule 'Zip' -Version $latestZip.Version
+        Invoke-PowerShellInstall -ForModule 'Zip' -Version $latestZip.Version
     }
 }
 
@@ -227,7 +227,7 @@ Describe 'Install-WhiskeyPowerShellModule.when skipping import' {
     AfterEach { Reset }
     It 'should not import the module' {
         Init
-        Install-WhiskeyPowerShellModule 'Zip' -SkipImport
+        Install-PowerShellModule 'Zip' -SkipImport
         ThenModuleNotImported 'Zip'
     }
 }
@@ -236,8 +236,8 @@ Describe 'Install-WhiskeyPowerShellModule.when previous version installed and us
     AfterEach { Reset }
     It 'should install the latest version' {
         Init
-        Install-WhiskeyPowerShellModule -Name 'Zip' -Version '0.1.*'
-        Install-WhiskeyPowerShellModule -Name 'Zip'
+        Install-PowerShellModule -Name 'Zip' -Version '0.1.*'
+        Install-PowerShellModule -Name 'Zip'
         ThenModuleInstalled 'Zip' -AtVersion '0.1.0'
         ThenModuleInstalled 'Zip' -AtVersion $latestZip.Version
         ThenModuleImported 'Zip' -AtVersion $latestZip.Version
@@ -250,12 +250,12 @@ Describe 'Install-WhiskeyPowerShellModule.when multiple modules already installe
         Init
         $newestVersion = $allZipVersions | Select-Object -First 1
         $previousVersion = $allZipVersions | Select-Object -Skip 1 | Select-Object -First 1
-        Install-WhiskeyPowerShellModule -Name 'Zip' -Version $newestVersion.Version
-        Install-WhiskeyPowerShellModule -Name 'Zip' -Version $previousVersion.Version
+        Install-PowerShellModule -Name 'Zip' -Version $newestVersion.Version
+        Install-PowerShellModule -Name 'Zip' -Version $previousVersion.Version
         ThenModuleInstalled 'Zip' -AtVersion $newestVersion.Version
         ThenModuleInstalled 'Zip' -AtVersion $previousVersion.Version
         Mock -CommandName 'Save-Module' -ModuleName 'Whiskey'
-        $result = Install-WhiskeyPowerShellModule -Name 'Zip' -Version '*'
+        $result = Install-PowerShellModule -Name 'Zip' -Version '*'
         Assert-MockCalled -CommandName 'Save-Module' -ModuleName 'Whiskey' -Times 0
         $Global:Error | Should -BeNullOrEmpty
         $result.Version | Should -Be $newestVersion.Version

--- a/Test/Pester4.Tests.ps1
+++ b/Test/Pester4.Tests.ps1
@@ -108,17 +108,23 @@ function WhenPesterTaskIsInvoked
     param(
         [switch]$WithClean,
 
-        [switch]$CaptureOutput
+        [switch]$NoJob,
+
+        [hashtable]$WithArgument = @{ }
     )
 
     $failed = $false
     $Global:Error.Clear()
 
     Mock -CommandName 'Publish-WhiskeyPesterTestResult' -ModuleName 'Whiskey'
-    if( -not $CaptureOutput )
+
+    if( $NoJob )
     {
-        Mock -CommandName 'Receive-Job' -ModuleName 'Whiskey'
+        $taskParameter['NoJob'] = 'true'
     }
+
+    $WithArgument['Show'] = 'None'
+    $taskParameter['Argument'] = $WithArgument
 
     try
     {
@@ -187,11 +193,16 @@ function ThenPesterShouldHaveRun
         [int]$FailureCount,
             
         [Parameter(Mandatory)]
-        [int]$PassingCount
+        [int]$PassingCount,
+
+        [Switch]$AsJUnitXml,
+
+        [String]$ResultFileName = 'pester+*.xml'
     )
+
     $reportsIn =  $context.outputDirectory
-    $testReports = Get-ChildItem -Path $reportsIn -Filter 'pester+*.xml' |
-                        Where-Object { $_.Name -match '^pester\+.{8}\..{3}\.xml$' }
+    $testReports = Get-ChildItem -Path $reportsIn -Filter $ResultFileName
+
     #check to see if we were supposed to run any tests.
     if( ($FailureCount + $PassingCount) -gt 0 )
     {
@@ -204,8 +215,13 @@ function ThenPesterShouldHaveRun
     foreach( $testReport in $testReports )
     {
         $xml = [xml](Get-Content -Path $testReport.FullName -Raw)
-        $thisTotal = [int]($xml.'test-results'.'total')
-        $thisFailed = [int]($xml.'test-results'.'failures')
+        $totalAttrName = 'total'
+        if( $AsJUnitXml )
+        {
+            $totalAttrName = 'tests'
+        }
+        $thisTotal = [int]($xml.DocumentElement.$totalAttrName)
+        $thisFailed = [int]($xml.DocumentElement.'failures')
         $thisPassed = ($thisTotal - $thisFailed)
         $total += $thisTotal
         $failed += $thisFailed
@@ -226,6 +242,10 @@ function ThenPesterShouldHaveRun
         Assert-MockCalled -CommandName 'Publish-WhiskeyPesterTestResult' `
                           -ModuleName 'Whiskey' `
                           -ParameterFilter { 
+                                if( -not [IO.Path]::IsPathRooted($Path) )
+                                {
+                                    $Path = Join-Path -Path $testRoot -ChildPath $Path
+                                }
                                 Write-WhiskeyDebug ('{0}  -eq  {1}' -f $Path,$reportPath) 
                                 $result = $Path -eq $reportPath 
                                 Write-WhiskeyDebug ('  {0}' -f $result) 
@@ -351,23 +371,20 @@ Describe 'Pester4.when missing path' {
         Init
         WhenPesterTaskIsInvoked -ErrorAction SilentlyContinue
         ThenPesterShouldHaveRun -PassingCount 0 -FailureCount 0
-        ThenTestShouldFail -failureMessage 'Property "Path" is mandatory.'
+        ThenTestShouldFail -failureMessage 'Property "Path": Path is mandatory.'
     }
 }
 
 Describe 'Pester4.when a task path is absolute' {
     AfterEach { Reset }
     It 'should fail' {
-        $pesterPath = 'C:\FubarSnafu'
-        if( -not $IsWindows )
-        {
-            $pesterPath = '/FubarSnafu'
-        }
+        $pesterPath = Join-Path -Path $TestDrive.FullName -ChildPath 'SomeFile'
+        New-Item -Path $pesterPath
         Init
         GivenTestFile $pesterPath
         WhenPesterTaskIsInvoked -ErrorAction SilentlyContinue
         ThenPesterShouldHaveRun -PassingCount 0 -FailureCount 0
-        ThenTestShouldFail -failureMessage 'absolute'
+        ThenTestShouldFail -failureMessage 'outside\ the\ build\ root'
     }
 }
 
@@ -384,7 +401,7 @@ Describe 'PassingTests' {
 '@
         GivenDescribeDurationReportCount 1
         GivenItDurationReportCount 1
-        WhenPesterTaskIsInvoked -CaptureOutput
+        WhenPesterTaskIsInvoked
         ThenDescribeDurationReportHasRows 1
         ThenItDurationReportHasRows 1
     }
@@ -437,5 +454,77 @@ Describe 'FailingTests' {
         ThenNoPesterTestFileShouldExist
         ThenTestShouldFail ([regex]::Escape('Found no tests to run. Property "Exclude" matched all paths in the "Path" property.'))
         ThenPesterShouldHaveRun -FailureCount 0 -PassingCount 0
+    }
+}
+
+Describe 'Pester4.when not running task in job' {
+    AfterEach { Reset }
+    It 'should pass' {
+        Init
+        GivenTestFile 'PassingTests.ps1' @"
+Describe 'PassingTests' {
+    It 'should run inside Whiskey' {
+        Test-Path -Path 'variable:powershellModulesDirectoryName' | Should -BeTrue
+        `$powerShellModulesDirectoryName | Should -Be "$($TestPSModulesDirectoryName)"
+    }
+}
+"@
+        Mock -CommandName 'Import-Module' -ModuleName 'Whiskey'
+        Mock -CommandName 'Invoke-Pester' -ModuleName 'Whiskey' -MockWith {
+            @'
+<test-results errors="0" failures="0" />
+'@ | Set-Content -Path $OutputFile
+            return ([pscustomobject]@{ 'TestResult' = [pscustomobject]@{ 'Time' = [TimeSpan]::Zero } })
+        }
+        WhenPesterTaskIsInvoked -NoJob
+        Assert-MockCalled -CommandName 'Import-Module' -ModuleName 'Whiskey' -ParameterFilter {
+            $Name | Should -BeLike (Join-Path -Path $testRoot -ChildPath ('{0}\Pester\4.*.*\Pester.psd1' -f $TestPSModulesDirectoryName))
+            return $true
+        }
+        Assert-MockCalled -CommandName 'Invoke-Pester' -ModuleName 'Whiskey' -ParameterFilter { 
+            Push-Location $testRoot
+            try
+            {
+                $Script | Should -Be (Resolve-Path -Path (Join-Path -Path $testRoot -ChildPath 'PassingTests.ps1') -Relative)
+                $Outputfile | Should -BeLike (Resolve-Path -Path (Join-Path -Path $testRoot -ChildPath '.output\pester*.xml') -Relative)
+                $OutputFormat | Should -Be 'NUnitXml'
+                $PassThru | Should -BeTrue
+                return $true
+            }
+            finally
+            {
+                Pop-Location
+            }
+        }
+    }
+}
+
+Describe 'Pester4.when passing custom arguments' {
+    AfterEach { Reset }
+    It 'should pass the arguments' {
+        Init
+        GivenTestFile 'PassingTests.ps1' @'
+Describe 'PassingTests' {
+    It 'should pass' {
+        $true | Should -BeTrue
+    }
+}
+Describe 'FailingTests' {
+    It 'should fail' {
+        $false | Should -BeTrue
+    }
+}
+'@
+        WhenPesterTaskIsInvoked -WithArgument @{
+            # Make sure the Pester4 task's default values for these get overwritten
+            'OutputFile' = '.output\pester.xml';
+            'OutputFormat' = 'JUnitXml';
+            # Make sure these do *not* get overwritten.
+            'Script' = 'filethatdoesnotexist.ps1'
+            'PassThru' = $false;
+            # Make sure this gets passed.
+            'TestName' = 'PassingTests'
+        }
+        ThenPesterShouldHaveRun -FailureCount 0 -PassingCount 1 -AsJUnitXml -ResultFileName 'pester.xml'
     }
 }

--- a/Test/PowerShell.Tests.ps1
+++ b/Test/PowerShell.Tests.ps1
@@ -432,25 +432,3 @@ Describe 'PowerShell.when run in Initialize mode' {
         ThenTheScriptRan
     }
 }
-
-Describe 'PowerShell.when Whiskey stored in a directory that doesn''t match module name' {
-    It 'should import Whiskey correctly' {
-        Init
-        $whiskeyRoot = Join-Path -Path $testRoot -ChildPath '.whiskey'
-        Copy-Item -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\Whiskey' -Resolve) `
-                -Recurse `
-                -Destination $whiskeyRoot
-        & (Join-Path -Path $whiskeyRoot -ChildPath 'Import-Whiskey.ps1' -Resolve)
-        try
-        {
-            GivenAScript
-            WhenTheTaskRuns
-            ThenTheTaskPasses
-            ThenTheScriptRan
-        }
-        finally
-        {
-            Remove-Module -Name 'Whiskey' -Force
-        }
-    }
-}

--- a/Test/WhiskeyTest.psm1
+++ b/Test/WhiskeyTest.psm1
@@ -245,8 +245,8 @@ function Invoke-WhiskeyPrivateCommand
         [hashtable]$Parameter = @{}
     )
 
-    $Global:Name = $Name
-    $Global:Parameter = $Parameter
+    $Global:WTName = $Name
+    $Global:WTParameter = $Parameter
 
     if( $VerbosePreference -eq 'Continue' )
     {
@@ -258,13 +258,13 @@ function Invoke-WhiskeyPrivateCommand
     try
     {
         InModuleScope 'Whiskey' { 
-            & $Name @Parameter 
+            & $WTName @WTParameter 
         }
     }
     finally
     {
-        Remove-Variable -Name 'Parameter' -Scope 'Global'
-        Remove-Variable -Name 'Name' -Scope 'Global'
+        Remove-Variable -Name 'WTParameter' -Scope 'Global'
+        Remove-Variable -Name 'WTName' -Scope 'Global'
     }
 }
 function New-AssemblyInfo

--- a/Whiskey/Functions/Write-WhiskeyObject.ps1
+++ b/Whiskey/Functions/Write-WhiskeyObject.ps1
@@ -1,0 +1,86 @@
+
+function Write-WhiskeyObject
+{
+    <#
+    .SYNOPSIS
+    Writes objects as recognizable strings.
+
+    .DESCRIPTION
+    The `Write-WhiskeyObject` function writes objects as recognizable strings. Use the `Level` parameter to control what write function to use (see the help for `Write-WhiskeyInfo` for more information). It supports hashtables and dictionaries. It writes the keys and values in separate columns. If a value contains multiple values, each value is aligned with previous values. For example:
+
+        VERBOSE: [13:34:39.15]
+        VERBOSE:     OutputFile    .output\pester.xml
+        VERBOSE:     OutputFormat  JUnitXml
+        VERBOSE:     PassThru      True
+        VERBOSE:     Script        .\PassingTests.ps1
+        VERBOSE:                   .\OtherPassingTests.ps1
+        VERBOSE:     Show          None
+        VERBOSE:     TestName      PassingTests
+        VERBOSE: [13:34:39.15]
+
+    .EXAMPLE
+    $hashtable | Write-WhiskeyObject -Context $Context -Level Verbose
+
+    Demonstrates how to print the value of a hashtable in a recognizable format. 
+
+    .EXAMPLE
+    $hashtable | Write-WhiskeyObject -Level Verbose
+
+    Demonstrates that the `Context` parameter is optional. Whiskey searches up the call stack to find one if you don't pass it.
+    #>
+    [CmdletBinding()]
+    param(
+        # The context for the current build. If not provided, Whiskey will search up the call stack looking for it.
+        [Whiskey.Context]$Context,
+
+        [ValidateSet('Error','Warning','Info','Verbose','Debug')]
+        # INTERNAL. DO NOT USE. To log at different levels, use `Write-WhiskeyError`, `Write-WhiskeyWarning`, `Write-WhiskeyVerbose`, or `Write-WhiskeyDebug`
+        [String]$Level = 'Info',
+
+        [Parameter(Mandatory,ValueFromPipeline,Position=0)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        # The message/object to write. Before being written, the message will be prefixed with the duration of the current build and the current task name (if any). If the current duration can't be determined, then the current time is used.
+        #
+        # If you pipe multiple messages, they are grouped together.
+        [Object]$InputObject
+    )
+
+    begin
+    {
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+        
+        $objects = [Collections.ArrayList]::new()
+    }
+
+    process
+    {
+        $objects.Add($InputObject)
+    }
+
+    end
+    {
+        & {
+            foreach( $object in $objects )
+            {
+                if( $object | Get-Member 'Keys' )
+                {
+                    $maxKeyLength = $object.Keys | ForEach-Object { $_.ToString().Length } | Sort-Object -Descending | Select-Object -First 1
+                    $formatString = '{{0,-{0}}}  {{1}}' -f $maxKeyLength
+                    foreach( $key in ($object.Keys | Sort-Object) )
+                    {
+                        $value = $object[$key]
+                        $firstValue = $value | Select-Object -First 1
+                        Write-Output ($formatString -f $key,$firstValue)
+                        $value | Select-Object -Skip 1 | ForEach-Object { $formatString -f ' ',$_ }
+                    }
+                }
+                else 
+                {
+                    $object | Out-String
+                }
+            }
+        } | Write-WhiskeyInfo -Context $Context -Level $Level
+    }
+}

--- a/Whiskey/Functions/Write-WhiskeyObject.ps1
+++ b/Whiskey/Functions/Write-WhiskeyObject.ps1
@@ -34,7 +34,7 @@ function Write-WhiskeyObject
         [Whiskey.Context]$Context,
 
         [ValidateSet('Error','Warning','Info','Verbose','Debug')]
-        # INTERNAL. DO NOT USE. To log at different levels, use `Write-WhiskeyError`, `Write-WhiskeyWarning`, `Write-WhiskeyVerbose`, or `Write-WhiskeyDebug`
+        # The level at which to write the object. The default is `Info`.
         [String]$Level = 'Info',
 
         [Parameter(Mandatory,ValueFromPipeline,Position=0)]

--- a/Whiskey/Tasks/Pester4.ps1
+++ b/Whiskey/Tasks/Pester4.ps1
@@ -8,32 +8,30 @@ function Invoke-WhiskeyPester4Task
         [Parameter(Mandatory)]
         [Whiskey.Context]$TaskContext,
 
-        [Parameter(Mandatory)]
-        [hashtable]$TaskParameter
+        [Whiskey.Tasks.ValidatePath(Mandatory)]
+        [String[]]$Path,
+
+        [String[]]$Exclude,
+
+        [int]$DescribeDurationReportCount = 0,
+
+        [int]$ItDurationReportCount = 0,
+
+        [Management.Automation.PSModuleInfo]$PesterModuleInfo,
+
+        [Object]$Argument = @{},
+
+        [switch]$NoJob
     )
 
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
-    if( -not ($TaskParameter.ContainsKey('Path')))
-    {
-        Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Property "Path" is mandatory. It should be one or more paths, which should be a list of Pester test scripts (e.g. Invoke-WhiskeyPester4Task.Tests.ps1) or directories that contain Pester test scripts, e.g.
-
-        Build:
-        - Pester4:
-            Path:
-            - My.Tests.ps1
-            - Tests')
-        return
-    }
-
-    $path = $TaskParameter['Path'] | Resolve-WhiskeyTaskPath -TaskContext $TaskContext -PropertyName 'Path'
-
-    if( $TaskParameter['Exclude'] )
+    if( $Exclude )
     {
         $path = $path |
                     Where-Object {
-                        foreach( $exclusion in $TaskParameter['Exclude'] )
+                        foreach( $exclusion in $Exclude )
                         {
                             if( $_ -like $exclusion )
                             {
@@ -54,81 +52,109 @@ function Invoke-WhiskeyPester4Task
         }
     }
 
-    [int]$describeDurationCount = 0
-    $describeDurationCount = $TaskParameter['DescribeDurationReportCount']
-    [int]$itDurationCount = 0
-    $itDurationCount = $TaskParameter['ItDurationReportCount']
 
-    $outputFile = Join-Path -Path $TaskContext.OutputDirectory -ChildPath ('pester+{0}.xml' -f [IO.Path]::GetRandomFileName())
+    $pesterManifestPath = $PesterModuleInfo.Path
 
-    $moduleInfo = $TaskParameter['PesterModuleInfo']
-    $pesterManifestPath = $moduleInfo.Path
-    Write-WhiskeyVerbose -Context $TaskContext -Message $pesterManifestPath
-    Write-WhiskeyVerbose -Context $TaskContext -Message ('  Script      {0}' -f ($Path | Select-Object -First 1))
-    $Path | Select-Object -Skip 1 | ForEach-Object { Write-WhiskeyVerbose -Context $TaskContext -Message ('              {0}' -f $_) }
-    Write-WhiskeyVerbose -Message ('  OutputFile  {0}' -f $outputFile)
-    # We do this in the background so we can test this with Pester.
-    $job = Start-Job -ScriptBlock {
-        $VerbosePreference = $using:VerbosePreference
-        $DebugPreference = $using:DebugPreference
-        $ProgressPreference = $using:ProgressPreference
-        $WarningPreference = $using:WarningPreference
-        $ErrorActionPreference = $using:ErrorActionPreference
+    $Argument['Script'] = $Path | Resolve-Path -Relative
+    $Argument['PassThru'] = $true
 
-        $script = $using:Path
-        $pesterManifestPath = $using:pesterManifestPath
-        $outputFile = $using:outputFile
-        [int]$describeCount = $using:describeDurationCount
-        [int]$itCount = $using:itDurationCount
-
-        Invoke-Command -ScriptBlock {
-                                        $VerbosePreference = 'SilentlyContinue'
-                                        Import-Module -Name $pesterManifestPath
-                                    }
-
-        $result = Invoke-Pester -Script $script -OutputFile $outputFile -OutputFormat NUnitXml -PassThru
-
-        $result.TestResult |
-            Group-Object 'Describe' |
-            ForEach-Object {
-                $totalTime = [TimeSpan]::Zero
-                $_.Group | ForEach-Object { $totalTime += $_.Time }
-                [pscustomobject]@{
-                                    Describe = $_.Name;
-                                    Duration = $totalTime
-                                }
-            } | Sort-Object -Property 'Duration' -Descending |
-            Select-Object -First $describeCount |
-            Format-Table -AutoSize
-
-        $result.TestResult |
-            Sort-Object -Property 'Time' -Descending |
-            Select-Object -First $itCount |
-            Format-Table -AutoSize -Property 'Describe','Name','Time'
-    }
-
-
-    do
+    if( $Argument.ContainsKey('OutputFile') )
     {
-        # There's a bug where Write-Host output gets duplicated by Receive-Job if $InformationPreference is set to "Continue".
-        # Since Pester uses Write-Host, this is a workaround to avoid seeing duplicate Pester output.
-        $job | Receive-Job -InformationAction SilentlyContinue
+        $outputFile = $Argument['OutputFile']
     }
-    while( -not ($job | Wait-Job -Timeout 1) )
+    else
+    {
+        $outputFileRoot = Resolve-Path -Path $TaskContext.OutputDirectory -Relative
+        $outputFile = Join-Path -Path $outputFileRoot -ChildPath ('pester+{0}.xml' -f [IO.Path]::GetRandomFileName())
+        $Argument['OutputFile'] = $outputFile
+    }
 
-    $job | Receive-Job -InformationAction SilentlyContinue
+    if( -not $Argument.ContainsKey('OutputFormat') )
+    {
+        $Argument['OutputFormat'] = 'NUnitXml'
+    }
+
+    $Argument | Write-WhiskeyObject -Context $context -Level Verbose -Verbose
+
+    $args = @(
+        (Get-Location).Path,
+        $pesterManifestPath,
+        $Argument,
+        @{
+            'VerbosePreference' = $VerbosePreference;
+            'DebugPreference' = $DebugPreference;
+            'ProgressPreference' = $ProgressPreference;
+            'WarningPreference' = $WarningPreference;
+            'ErrorActionPreference' = $ErrorActionPreference;
+        }
+    )
+
+    $cmdName = 'Start-Job'
+    if( $NoJob )
+    {
+        $cmdName = 'Invoke-Command'
+    }
+
+    $result = & $cmdName -ArgumentList $args -ScriptBlock {
+        param(
+            [String]$WorkingDirectory,
+            [String]$PesterManifestPath,
+            [hashtable]$Parameter,
+            [hashtable]$Preference
+        )
+
+        Set-Location -Path $WorkingDirectory
+
+        $VerbosePreference = 'SilentlyContinue'
+        Import-Module -Name $PesterManifestPath -Verbose:$false -WarningAction Ignore
+
+        $VerbosePreference = $Preference['VerbosePreference']
+        $DebugPreference = $Preference['DebugPreference']
+        $ProgressPreference = $Preference['ProgressPreference']
+        $WarningPreference = $Preference['WarningPreference']
+        $ErrorActionPreference = $Preference['ErrorActionPreference']
+
+        Invoke-Pester @Parameter
+    }
+    
+    if( -not $NoJob )
+    {
+        $result = $result | Receive-Job -Wait -AutoRemoveJob -InformationAction Ignore
+    }
+
+    $result.TestResult |
+        Group-Object 'Describe' |
+        ForEach-Object {
+            $totalTime = [TimeSpan]::Zero
+            $_.Group | ForEach-Object { $totalTime += $_.Time }
+            [pscustomobject]@{
+                                Describe = $_.Name;
+                                Duration = $totalTime
+                            }
+        } | Sort-Object -Property 'Duration' -Descending |
+        Select-Object -First $DescribeDurationReportCount |
+        Format-Table -AutoSize
+
+    $result.TestResult |
+        Sort-Object -Property 'Time' -Descending |
+        Select-Object -First $ItDurationReportCount |
+        Format-Table -AutoSize -Property 'Describe','Name','Time'
 
     Publish-WhiskeyPesterTestResult -Path $outputFile
 
-    $result = [xml](Get-Content -Path $outputFile -Raw)
+    $outputFileContent = Get-Content -Path $outputFile -Raw
+    $outputFileContent | Write-WhiskeyDebug
+    $result = [xml]$outputFileContent
 
     if( -not $result )
     {
-        throw ('Unable to parse Pester output XML report ''{0}''.' -f $outputFile)
+        Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Unable to parse Pester output XML report "{0}".' -f $outputFile)
+        return
     }
 
-    if( $result.'test-results'.errors -ne '0' -or $result.'test-results'.failures -ne '0' )
+    if( $result.DocumentElement.errors -ne '0' -or $result.DocumentElement.failures -ne '0' )
     {
-        throw ('Pester tests failed.')
+        Stop-WhiskeyTask -TaskContext $TaskContext -Message ('Pester tests failed.')
+        return
     }
 }

--- a/Whiskey/Tasks/Pester4.ps1
+++ b/Whiskey/Tasks/Pester4.ps1
@@ -74,7 +74,7 @@ function Invoke-WhiskeyPester4Task
         $Argument['OutputFormat'] = 'NUnitXml'
     }
 
-    $Argument | Write-WhiskeyObject -Context $context -Level Verbose -Verbose
+    $Argument | Write-WhiskeyObject -Context $context -Level Verbose
 
     $args = @(
         (Get-Location).Path,

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -115,6 +115,7 @@
                             'Write-WhiskeyDebug',
                             'Write-WhiskeyError',
                             'Write-WhiskeyInfo',
+                            'Write-WhiskeyObject',
                             'Write-WhiskeyVerbose',
                             'Write-WhiskeyWarning'
                          );
@@ -165,6 +166,8 @@
 * Fixed: Whiskey fails to fail a build when certain PowerShell terminating errors are thrown (i.e. strict mode violations, command not found error, etc.).
 * Breaking change: Whiskey's default version number is now `0.0.0` instead of using the current date. If you care about your version number, make sure you have a `Version` task defined in your whiskey.yml file.
 * Removed all support for old "VersionFrom", "PrereleaseMap", and "Version" properties in the root of your whiskey.yml file. Use Whiskey's `Version` task instead.
+* Added support to the `Pester4` task for passing arbitrary parameters to Invoke-Pester. Pass the parameters as named properties via the new `Argument` property.
+* Created `Write-WhiskeyObject` function for writing objects in sensible ways. Currently, only hashtables/dictionaries are supported. Keys/values are printed so they align and are recognizable. Other objects are passed to PowerShell's `Out-String` for formatting.
 '@
         } # End of PSData hashtable
 


### PR DESCRIPTION
* Use named parameters instead of the TaskParameter hashtable.
* Give users the option to *not* run tests in a background job. Some
testing tools don't like that.
* Allow users to pass custom arguments to Pester via an `Arguments`
property.

I tried to get Pester4 to run tests not in a background job by default,
but there was too much weirdness. Plus, it makes sense that tests should
run in an isolated process. In trying to get the Pester4 task to run
tests in scope, I made some changes to test fixtures that are
beneficial, so I'm keeping them.

Created a new `Write-WhiskeyObject` function so tasks can more-easily
write objects to the output in a recognizable format.