### PR TITLE
Publish On-Demand via AppVeyor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 ## Added
 
 * Added a `NoLog` parameter to the `DotNet` task to turn off logging.
+* Whiskey now supports publishing PowerShell modules with AppVeyor deployments instead of directly from/by Whiskey. Use
+the `PublishPowerShellModule` to publish a .nupkg file of your module, then use AppVeyor to publish that module to the
+PowerShell Gallery, or other PowerShell NuGet-based feed.
+
+## Changed
+
+* The `PublishPowerShellModule` task's default behavior is now to publish a module to a .nupkg file in the current
+build's output directory. This allows another tool/process to publish the module (i.e. you can remove your deploy logic
+from your build).
+* Renamed the `PublishPowerShellModule` task's `RepositoryUri` property to `RepositoryLocation`, since
+`Publish-Module` allows publishing to the file system.
+* `PublishPowerShellModule` task ignores the `RepositoryName` property if the `RepositoryLocation` property is given. If
+a repository exists whose publish location is `RepositoryLocation`, that repository is used. Otherwise, a temp
+repository is registered that publishes to `RepositoryLocation` to publish the module, and then unregistered after
+publishing.
+* The `PublishPowerShellModule` task will fail if no repository with the same name as the `RepositoryName` property
+exists and the `RepositoryLocation` property doesn't have a value.
 
 ## Deprecated
 
@@ -22,6 +39,9 @@ validating parameters.
 ## Removed
 
 * Warnings written by `Import-Module` are now hidden.
+* The `PublishPowerShellModule` no longer registers permanent PowerShell repositories. If no repository exists that
+matches either of the `RepositoryName` or `RepositoryLocation` properties, the task registers a repository that
+publishes to `RepositoryLocation`, publishes to it, then unregisters the repository.
 
 
 # 0.48.3

--- a/Test/PublishPowerShellModule.Tests.ps1
+++ b/Test/PublishPowerShellModule.Tests.ps1
@@ -3,16 +3,23 @@ Set-StrictMode -Version 'Latest'
 & (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-WhiskeyTest.ps1' -Resolve)
 
 $testRoot = $null
-$apikey = $null
-$apikeyID = $null
-$repositoryName = $null
-$repositoryUri = $null
-$prerelease = $null
 $context = $null
-$credentials = @{ }
+$credentials = @{}
 $failed = $false
-$publishError = $null
-$registerError = $null
+$publishRoot = $null
+$testModuleName = 'MyModule'
+$repoToUnregister = $null
+
+function Get-TestRepositoryFullPath
+{
+    param(
+        [Parameter(Mandatory)]
+        [String] $Name
+    )
+
+    return Join-Path -Path $testRoot -ChildPath $Name
+
+}
 
 function GivenCredential
 {
@@ -25,21 +32,6 @@ function GivenCredential
     )
 
     $credentials[$WithID] = $Credential
-}
-
-function GivenNoApiKey
-{
-    $script:apikey = $null
-    $script:apikeyID = $null
-}
-
-function GivenPrerelease
-{
-    param(
-        $Prerelease
-    )
-
-    $script:prerelease = $Prerelease
 }
 
 function GivenPublishingFails
@@ -66,63 +58,69 @@ function GivenRepository
 {
     param(
         $Named,
-        $Uri
+        $At
     )
 
-    $script:repositoryName = $Named
-    $script:repositoryUri = $Uri
+    if( -not $At )
+    {
+        $At = Get-TestRepositoryFullPath -Name $Named
+    }
+
+    if( -not ([IO.Path]::IsPathRooted($At)) )
+    {
+        $At = Join-Path -Path $script:testRoot -ChildPath $At
+    }
+
+    New-Item -Path $At -ItemType 'Directory' -Force | Out-Null
+    $script:publishRoot = $At
+
+    Register-PSRepository -Name $Named -PublishLocation $At -SourceLocation $At
+    $script:repoToUnregister = $Named
 }
 
-function Initialize-Test
+function Init
 {
     param(
     )
 
-    $script:apikey = 'fubar:snauf'
-    $script:apikeyID = 'PowerShellExampleCom'
-    $script:repositoryName = $null
-    $script:repositoryUri = $null
-    $script:prerelease = $null
     $script:context = $null
     $script:credentials = @{ }
     $script:failed = $false
-    $script:publishError = $null
-    $script:registerError = $null
-
+    $script:repoToUnregister = $null
+    $script:publishRoot = $null
     $script:testRoot = New-WhiskeyTestRoot
 }
 
-function Invoke-Publish
+function WhenPublishing
 {
     [CmdletBinding()]
     param(
-        [switch]$withoutRegisteredRepo,
+        [String] $ToRepo,
 
-        [String]$ForRepositoryNamed,
+        [String] $RepoAt,
 
-        [String]$RepoAtUri,
+        [String] $ForManifestPath,
 
-        [String]$ForManifestPath,
+        [switch] $WithInvalidPath,
 
-        [switch]$WithNoRepositoryName,
+        [switch] $WithNonExistentPath,
 
-        [switch]$withNoProgetURI,
+        [switch] $WithoutPathParameter,
 
-        [switch]$WithInvalidPath,
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '')]
+        [String] $WithCredentialID,
 
-        [switch]$WithNonExistentPath,
+        [switch] $WithNoPrereleasePropertyInManifest,
 
-        [switch]$WithoutPathParameter,
+        [String] $WithPrerelease,
 
-        [String]$WithCredentialID,
-
-        [switch]$WithNoPrereleaseProperty
+        [String] $WithApiKey
     )
     
     $version = '1.2.3'
-    if( $prerelease )
+    if( $WithPrerelease )
     {
-        $version = '1.2.3-{0}' -f $prerelease
+        $version = '1.2.3-{0}' -f $WithPrerelease
     }
 
     $script:context = New-WhiskeyTestContext -ForBuildServer `
@@ -132,43 +130,50 @@ function Invoke-Publish
     
     $TaskParameter = @{ }
 
-    if( $ForRepositoryNamed )
+    if( $ToRepo )
     {
-        $TaskParameter['RepositoryName'] = $ForRepositoryNamed;
+        $TaskParameter['RepositoryName'] = $ToRepo
     }
 
     if( $WithInvalidPath )
     {
-        $TaskParameter.Add( 'Path', 'MyModule.ps1' )
-        New-Item -Path $testRoot -ItemType 'file' -Name 'MyModule.ps1'
+        $TaskParameter.Add( 'Path', "$($testModuleName).ps1" )
+        New-Item -Path $testRoot -ItemType 'file' -Name $TaskParameter['Path']
     }
     elseif( $WithNonExistentPath )
     {
-        $TaskParameter.Add( 'Path', 'MyModule.ps1' )
+        $TaskParameter.Add( 'Path', 'NopeISureDoNotExist.psd1' )
     }
     elseif( -not $WithoutPathParameter )
     {
-        $TaskParameter.Add( 'Path', 'MyModule' )
-        New-Item -Path $testRoot -ItemType 'directory' -Name 'MyModule' 
-        $module = Join-Path -Path $testRoot -ChildPath 'MyModule'
+        $TaskParameter.Add( 'Path', $testModuleName )
+        New-Item -Path $testRoot -ItemType 'directory' -Name $testModuleName
+        $module = Join-Path -Path $testRoot -ChildPath $testModuleName
         if( -not $ForManifestPath )
-        {            
+        {
             $prereleaseProperty = "Prerelease = '';"
-            if( $WithNoPrereleaseProperty )
+            if( $WithNoPrereleasePropertyInManifest )
             {
                 $prereleaseProperty = ''
             }
-            New-Item -Path $module -ItemType 'file' -Name 'MyModule.psd1' -Value @"
+
+            New-item -Path $module -ItemType 'File' -Name "$($testModuleName).psm1"
+            New-Item -Path $module -ItemType 'file' -Name "$($testModuleName).psd1" -Value @"
 @{
+    RootModule = '$($testModuleName).psm1';
+
+    Description = '$($testModuleName)';
+
+    Author = '$([Environment]::UserName)';
+
     # Version number of this module.
-    ModuleVersion = '0.2.0'
+    ModuleVersion = '0.2.0';
 
     PrivateData = @{
         PSData = @{
             $($prereleaseProperty)
         }
     }
-    
 }
 "@
         }
@@ -181,59 +186,12 @@ function Invoke-Publish
     Import-WhiskeyTestModule -Name 'PackageManagement','PowerShellGet'
     Mock -CommandName 'Get-PackageProvider' -ModuleName 'Whiskey'
 
-    $repoName = $script:repositoryName
-    $repoUri = $script:repositoryUri
-
-    Mock -CommandName 'Get-PSRepository' -ModuleName 'Whiskey' -MockWith {
-        return [pscustomobject]@{
-            'Name' = $repoName;
-            'SourceLocation' = $repoUri;
-        }
-    }.GetNewClosure()
-
-    Add-Type -AssemblyName System.Net.Http
-
-    $mock = { }
-    if( $publishError )
-    {
-        $message = $publishError
-        $mock = { 
-                    [CmdletBinding()]
-                    param(
-                        $NuGetApiKey,
-                        $Repository,
-                        $Path,
-                        [switch]$Force
-                    ) 
-                    Write-Error -Message $message
-                }.GetNewClosure()
-    }
-    Mock -CommandName 'Publish-Module' -ModuleName 'Whiskey' -MockWith $mock
-
-    $mock = { }
-    if( $registerError )
-    {
-        $message = $registerError
-        $mock = { 
-                    [CmdletBinding()]
-                    param(
-                        $InstallationPolicy,
-                        $SourceLocation,
-                        $PackageManagementProvider,
-                        $Name,
-                        $PublishLocation
-                    ) 
-                    Write-Error -Message $message
-                }.GetNewClosure()
-    }
-    Mock -CommandName 'Register-PSRepository' -ModuleName 'Whiskey' -MockWith $mock
-    
     $Global:Error.Clear()
     $script:failed = $False
 
-    if( $RepoAtUri )
+    if( $RepoAt )
     {
-        $TaskParameter['RepositoryUri'] = $RepoAtUri
+        $TaskParameter['RepositoryLocation'] = $RepoAt
     }
 
     if( $WithCredentialID )
@@ -241,17 +199,23 @@ function Invoke-Publish
         $TaskParameter['CredentialID'] = $WithCredentialID
     }
 
-    if( $apikeyID )
+    if( $WithApiKey )
     {
-        $TaskParameter['ApiKeyID'] = $apikeyID
-        Add-WhiskeyApiKey -Context $context -ID $apikeyID -Value $apikey
+        $TaskParameter['ApiKeyID'] = [Guid]::NewGuid().ToString()
+        Add-WhiskeyApiKey -Context $context -ID $TaskParameter['ApiKeyID'] -Value $WithApiKey
     }
 
     foreach( $key in $credentials.Keys )
     {
         Add-WhiskeyCredential -Context $context -ID $key -Credential $credentials[$key]
     }
-    
+
+    if( $script:repoToUnregister )
+    {
+        Mock -CommandName 'Register-PSRepository' -ModuleName 'Whiskey'
+    }
+
+    Mock -CommandName 'Unregister-PSRepository' -ModuleName 'Whiskey'
     try
     {
         Invoke-WhiskeyTask -TaskContext $context -Parameter $TaskParameter -Name 'PublishPowerShellModule'
@@ -259,14 +223,20 @@ function Invoke-Publish
     catch
     {
         $script:failed = $true
-        Write-Error -ErrorRecord $_
+        Write-Error -ErrorRecord $_ -ErrorAction $ErrorActionPreference
     }
 }
 
 function Reset
 {
     Reset-WhiskeyTestPSModule
+    Get-PSRepository | Where-Object 'Name' -Like 'Whiskey*' | Unregister-PSRepository
+    if( $script:repoToUnregister )
+    {
+        Unregister-PSRepository -Name $script:repoToUnregister
+    }
 }
+Reset
 
 function ThenFailed
 {
@@ -280,127 +250,77 @@ function ThenFailed
 }
 
 function ThenModuleNotPublished
-{    
-    Assert-MockCalled -CommandName 'Publish-Module' -ModuleName 'Whiskey' -Times 0
-}
-
-function ThenRepositoryChecked
 {
-    Assert-MockCalled -CommandName 'Get-PSRepository' -ModuleName 'Whiskey' -Times 1
+    Join-Path -Path $script:publishRoot -ChildPath '*.nupkg' | Should -Not -Exist
 }
 
-function ThenRepositoryNotChecked
-{
-    Assert-MockCalled -CommandName 'Get-PSRepository' -ModuleName 'Whiskey' -Times 0
-}
-
-function ThenRepositoryNotRegistered
-{
-    Assert-MockCalled -CommandName 'Register-PSRepository' -ModuleName 'Whiskey' -Times 0
-}
-
-function ThenRepositoryRegistered
+function ThenRepository
 {
     param(
         [Parameter(Mandatory)]
-        [String]$Named,
+        [String] $Named,
 
-        [Parameter(Mandatory)]
-        [String]$AtUri,
+        [switch] $Exists,
 
-        [pscredential]$WithCredential
+        [switch] $NotExists,
+
+        [switch] $NotRegistered,
+
+        [switch] $NotUnregistered
     )
 
-    Assert-MockCalled -CommandName 'Register-PSRepository' -ModuleName 'Whiskey' -Times 1 -ParameterFilter {
-        #$DebugPreference = 'Continue'
-        Write-WhiskeyDebug -Message ('Repository Name                 expected {0}' -f $Named)
-        Write-WhiskeyDebug -Message ('                                actual   {0}' -f $Name)
-        $Name -eq $Named
-    }
-    Assert-MockCalled -CommandName 'Register-PSRepository' -ModuleName 'Whiskey' -Times 1 -ParameterFilter {
-        #$DebugPreference = 'Continue'
-        Write-WhiskeyDebug -Message ('Source Location                 expected {0}' -f $AtUri)
-        Write-WhiskeyDebug -Message ('                                actual   {0}' -f $SourceLocation)
-        $AtUri -eq $SourceLocation
-    }
-    Assert-MockCalled -CommandName 'Register-PSRepository' -ModuleName 'Whiskey' -Times 1 -ParameterFilter {
-        #$DebugPreference = 'Continue'
-        Write-WhiskeyDebug -Message ('Publish Location                expected {0}' -f $AtUri)
-        Write-WhiskeyDebug -Message ('                                actual   {0}' -f $PublishLocation)
-        $AtUri -eq $PublishLocation
-    }
-    Assert-MockCalled -CommandName 'Register-PSRepository' -ModuleName 'Whiskey' -Times 1 -ParameterFilter { $InstallationPolicy -eq 'Trusted' }
-    Assert-MockCalled -CommandName 'Register-PSRepository' -ModuleName 'Whiskey' -Times 1 -ParameterFilter { $PackageManagementPRovider -eq 'NuGet' }
-
-    if( $WithCredential )
+    if( $NotRegistered )
     {
-        Assert-MockCalled -CommandName 'Register-PSRepository' -ModuleName 'Whiskey' -Times 1 -ParameterFilter { $Credential.UserName -eq $WithCredential.UserName }
-        Assert-MockCalled -CommandName 'Register-PSRepository' -ModuleName 'Whiskey' -Times 1 -ParameterFilter { $Credential.GetNetworkCredential().Password -eq $WithCredential.GetNetworkCredential().Password }
+        Assert-MockCalled -CommandName 'Register-PSRepository' -ModuleName 'Whiskey' -Times 0
+    }
+
+    if( $Exists )
+    {
+        Get-PSRepository |
+            Where-Object 'Name' -EQ $Named |
+            Where-Object 'PublishLocation' -EQ $script:publishRoot |
+            Should -Not -BeNullOrEmpty
+    }
+
+    if( $NotExists )
+    {
+        Get-PSRepository |
+            Where-Object 'Name' -EQ $Named |
+            Should -BeNullOrEmpty
+    }
+
+    if( $NotUnregistered )
+    {
+        Assert-MockCalled -CommandName 'Unregister-PSRepository' -ModuleName 'Whiskey' -Times 0
     }
 }
 
 function ThenModulePublished
 {
     param(
-        [Parameter(Mandatory)]
-        [String]$ToRepositoryNamed,
-
-        [String]$ExpectedPathName = (Join-Path -Path '.' -ChildPath 'MyModule'),
-
-        [switch]$WithNoRepositoryName
+        $To = $script:context.OutputDirectory.FullName,
+        $WithPrerelease = ''
     )
     
-    Assert-MockCalled -CommandName 'Get-PackageProvider' -ModuleName 'Whiskey' -ParameterFilter { $Name -eq 'NuGet' }
-    Assert-MockCalled -CommandName 'Get-PackageProvider' -ModuleName 'Whiskey' -ParameterFilter { $ForceBootstrap }
-    $expectedApiKey = $apikey
-    Assert-MockCalled -CommandName 'Publish-Module' -ModuleName 'Whiskey' -Times 1 -ParameterFilter {
-        #$DebugPreference = 'Continue'
-        Write-WhiskeyDebug -Message ('Path Name                       expected {0}' -f $ExpectedPathName)
-        Write-WhiskeyDebug -Message ('                                actual   {0}' -f $Path)
-        
-        $Path -eq $ExpectedPathName
+    if( -not [IO.Path]::IsPathRooted($To) )
+    {
+        $To = Join-Path -Path $script:testRoot -ChildPath $To
     }
-    Assert-MockCalled -CommandName 'Publish-Module' -ModuleName 'Whiskey' -Times 1 -ParameterFilter {
-        #$DebugPreference = 'Continue'
-        Write-WhiskeyDebug -Message ('Repository Name                 expected {0}' -f $ToRepositoryNamed)
-        Write-WhiskeyDebug -Message ('                                actual   {0}' -f $Repository)
-        $Repository -eq $ToRepositoryNamed
-    }
-    Assert-MockCalled -CommandName 'Publish-Module' -ModuleName 'Whiskey' -Times 1 -ParameterFilter {
-        #$DebugPreference = 'Continue'
-        Write-WhiskeyDebug -Message ('ApiKey                          expected {0}' -f $expectedApiKey)
-        Write-WhiskeyDebug -Message ('                                actual   {0}' -f $NuGetApiKey)
-        $NuGetApiKey -eq $expectedApiKey
-    }
-    Assert-MockCalled -CommandName 'Publish-Module' -ModuleName 'Whiskey' -Times 1 -ParameterFilter { $Force }
+
+    Join-Path -Path $To -ChildPath "$($testModuleName).*.*.*$($WithPrerelease).nupkg" | Should -Exist
 }
 
 function ThenManifest
 {
     param(
-        [String]$ManifestPath = (Join-Path -Path $testRoot -ChildPath 'MyModule\MyModule.psd1'),
-
-        [String]$AtVersion,
+        [String]$ManifestPath = (Join-Path -Path $testRoot -ChildPath "$($testModuleName)\$($testModuleName).psd1"),
 
         [String]$HasPrerelease
     )
 
-    if( -not $AtVersion )
-    {
-        $AtVersion = '{0}.{1}.{2}' -f $context.Version.SemVer2.Major, $context.Version.SemVer2.Minor, $context.Version.SemVer2.Patch
-    }
-
-    $manifest = Test-ModuleManifest -Path $ManifestPath
-
-    $manifest.Version | Should -Be $AtVersion
-    if( $HasPrerelease )
-    {
-        $manifest.PrivateData.PSData.Prerelease | Should -Be $HasPrerelease
-    }
-    else
-    {
-        $manifest.PrivateData.PSData.Prerelease | Should -BeNullOrEmpty
-    }
+    Test-ModuleManifest -Path $ManifestPath | Should -Not -BeNullOrEmpty
+    # Test-ModuleManifest caches manifests if they have a RootModule property.
+    Get-Content -Raw -Path $ManifestPath | Should -Match ([regex]::Escape("Prerelease = '$($HasPrerelease)'"))
 }
 
 function ThenSucceeded
@@ -415,44 +335,41 @@ function Get-Error
     param(
     )
 
+    # PackageManagement and PowerShellGet leave handled errors in Global:Error so we need to filter those errors out.
     $Global:Error |
-        Where-Object {
-            if( -not $_.TargetObject -or -not $_.ScriptStackTrace )
-            {
-                return $true
-            }
-
-            # These errors are internal and can be ignored.
-            $fromGetPackageSource = $_.TargetObject.ToString() -eq 'Microsoft.PowerShell.PackageManagement.Cmdlets.GetPackageSource'
-            $fromResolvingDynamicParams = $_.ScriptStackTrace -match '\bGet-DynamicParameters\b'
-            return -not ( $fromGetPackageSource -and $fromResolvingDynamicParams )
-        }
+        Where-Object 'ScriptStackTrace' -NotMatch '\bPowerShellGet\b' -ErrorAction Ignore |
+        Where-Object 'ScriptStackTrace' -NotMatch '\bPackageManagement\b' -ErrorAction Ignore
 }
 
-Describe 'PublishPowerShellModule.when publishing new module' {
+Describe 'PublishPowerShellModule.when publishing to repository that already exists' {
     AfterEach { Reset }
-    It 'should publish the module' {
-        Initialize-Test
-        GivenRepository 'FubarSnafu'
-        Invoke-Publish -ForRepositoryNamed 'FubarSnafu'
+    It 'should publish the module wihtout registering the repository' {
+        Init
+        GivenRepository 'R1'
+        WhenPublishing -ToRepo 'R1'
         ThenSucceeded
-        ThenRepositoryChecked
-        ThenRepositoryNotRegistered
-        ThenModulePublished -ToRepositoryNamed 'FubarSnafu'
+        ThenModulePublished -To 'R1'
+        ThenRepository 'R1' -Exists -NotRegistered
+    }
+}
+
+Describe 'PublishPowerShellModule.when publishing to repository that does not exist' {
+    AfterEach { Reset }
+    It 'should fail' {
+        Init
+        WhenPublishing -ToRepo 'R2' -ErrorAction Silently
+        ThenFailed 'a repository with that name doesn''t exist'
+        ThenRepository 'R2' -NotExists -NotUnregistered
     }
 }
 
 Describe 'PublishPowerShellModule.when publishing prerelease module' {
     AfterEach { Reset }
     It 'should succeed' {
-        Initialize-Test
-        GivenRepository 'SomeRepo'
-        GivenPrerelease 'beta1'
-        Invoke-Publish -ForRepositoryNamed 'SomeRepo'
+        Init
+        WhenPublishing -WithPrerelease 'beta1'
         ThenSucceeded
-        ThenRepositoryChecked
-        ThenRepositoryNotRegistered
-        ThenModulePublished -ToRepositoryNamed 'SomeRepo'
+        ThenModulePublished -WithPrerelease '-beta1'
         ThenManifest -HasPrerelease 'beta1'
     }
 }
@@ -460,170 +377,82 @@ Describe 'PublishPowerShellModule.when publishing prerelease module' {
 Describe 'PublishPowerShellModule.when publishing prerelease module but module manifest is missing Prerelease element' {
     AfterEach { Reset }
     It 'should fail' {
-        Initialize-Test
-        GivenPrerelease 'rc5'
-        GivenRepository 'SomeRepo'
-        Invoke-Publish -ForRepositoryNamed 'SomeRepo' -WithNoPrereleaseProperty -ErrorAction SilentlyContinue
+        Init
+        WhenPublishing -WithPrerelease 'rc5' -WithNoPrereleasePropertyInManifest -ErrorAction SilentlyContinue
         ThenFailed 'missing a "Prerelease" property'
-        ThenRepositoryNotChecked
-        ThenRepositoryNotRegistered
-        ThenModuleNotPublished
     }
 }
 
-Describe 'PublishPowerShellModule.when publishing with no repository name' {
+Describe 'PublishPowerShellModule.when publishing with no repository name or repository location' {
     AfterEach { Reset }
-    It 'should fail' {
-        Initialize-Test
-        Invoke-Publish -ErrorAction SilentlyContinue
-        ThenFailed -WithError 'Property\ "RepositoryName"\ is mandatory'
-        ThenRepositoryNotChecked
-        ThenRepositoryNotRegistered
-        ThenModuleNotPublished
-    }
-}
-
-Describe 'PublishPowerShellModule.when publishing fails' {
-    AfterEach { Reset }
-    It 'should fail' {
-        Initialize-Test
-        GivenRepository 'FubarSnafu'
-        GivenPublishingFails -WithError 'something went wrong!'
-        Invoke-Publish -ForRepositoryNamed 'FubarSnafu' -ErrorAction SilentlyContinue
-        ThenFailed -WithError 'something\ went\ wrong\!'
-    }
-}
-
-Describe 'PublishPowerShellModule.when publishing to a new repository' {
-    AfterEach { Reset }
-    It 'should succeed' {
-        Initialize-Test
-        Invoke-Publish -ForRepositoryName 'ANewRepo' -RepoAtUri 'https://example.com' 
-        ThenRepositoryChecked
-        ThenRepositoryRegistered 'ANewRepo' -AtUri 'https://example.com/'
-        ThenModulePublished -ToRepositoryNamed 'ANewRepo'
+    It 'should publish to build output directory' {
+        Init
+        WhenPublishing
         ThenSucceeded
+        ThenRepository 'Whiskey*' -NotExists
+        ThenModulePublished -To $context.OutputDirectory
     }
 }
 
-Describe 'PublishPowerShellModule.when publishing to a new repository that requires a credential' {
+Describe 'PublishPowerShellModule.when given an API key' {
     AfterEach { Reset }
-    It 'should succeed' {
-        Initialize-Test
-        $cred = New-Object 'pscredential' ('fubar',(ConvertTo-SecureString -String 'snafu' -AsPlainText -Force))
-        GivenCredential $cred -WithID 'somecred'
-        Invoke-Publish -ForRepositoryName 'ANewRepo' -RepoAtUri 'https://example.com' -WithCredentialID 'somecred'
+    It 'should fail' {
+        Init
+        Mock -CommandName 'Publish-Module' `
+             -ModuleName 'Whiskey' `
+             -ParameterFilter { $NuGetApiKey -eq 'API6' } `
+             -Verifiable
+        WhenPublishing -WithApiKey 'API6'
         ThenSucceeded
-        ThenRepositoryChecked
-        ThenRepositoryRegistered 'ANewRepo' -AtUri 'https://example.com/' -WithCredential $cred
-        ThenModulePublished -ToRepositoryNamed 'ANewRepo'
-    }
-}
-
-Describe 'PublishPowerShellModule.when publishing to a new repository but its URI is not given' {
-    AfterEach { Reset }
-    It 'should fail' {
-        Initialize-Test 
-        Invoke-Publish -ForRepositoryNamed 'Fubar' -ErrorAction SilentlyContinue
-        ThenFailed -WithError 'Property\ "RepositoryUri"\ is\ mandatory'
-        ThenRepositoryChecked
-        ThenRepositoryNotRegistered
-        ThenModuleNotPublished
-    }
-}
-
-Describe 'PublishPowerShellModule.when registering a repository fails' {
-    AfterEach { Reset }
-    It 'should fail' {
-        Initialize-Test
-        GivenRegisteringFails -WithError 'something went wrong!'
-        Invoke-Publish -ForRepositoryNamed 'FubarSnafu' -RepoAtUri 'https://example.com' -ErrorAction SilentlyContinue
-        ThenFailed -WithError 'something\ went\ wrong\!'
-    }
-}
-
-Describe 'PublishPowerShellModule.when no API key' {
-    AfterEach { Reset }
-    It 'should fail' {
-        Initialize-Test
-        GivenNoApiKey
-        GivenRepository 'Fubar'
-        Invoke-Publish -ForRepositoryNamed 'Fubar'  -ErrorAction SilentlyContinue
-        ThenFailed -WithError 'Property\ "ApiKeyID"\ is\ mandatory'
-        ThenRepositoryNotChecked
-        ThenRepositoryNotRegistered
-        ThenModuleNotPublished
+        Assert-VerifiableMock
     }
 }
 
 Describe 'PublishPowerShellModule.when path parameter is not included' {
     AfterEach { Reset }
     It 'should fail' {
-        Initialize-Test
-        GivenRepository 'Fubar'
-        Invoke-Publish -ForRepositoryNamed 'Fubar' -WithoutPathParameter -ErrorAction SilentlyContinue
+        Init
+        WhenPublishing -WithoutPathParameter -ErrorAction SilentlyContinue
         ThenFailed -WithError '"Path\b.*\bis mandatory'
-        ThenRepositoryNotChecked
-        ThenRepositoryNotRegistered
-        ThenModuleNotPublished
     }
 }
 
-Describe 'PublishPowerShellModule.when non-existent path parameter' {
+Describe 'PublishPowerShellModule.when path does not exist' {
     AfterEach { Reset }
     It 'should fail' {
-        Initialize-Test
-        GivenRepository 'Fubar'
-        Invoke-Publish -ForRepositoryNamed 'Fubar' -WithNonExistentPath -ErrorAction SilentlyContinue
+        Init
+        WhenPublishing -WithNonExistentPath -ErrorAction SilentlyContinue
         ThenFailed -WithError 'does\ not\ exist'
-        ThenModuleNotPublished
     }
 }
 
-Describe 'PublishPowerShellModule.when non-directory path parameter' {
+Describe 'PublishPowerShellModule.when path is not a directory' {
     AfterEach { Reset }
     It 'should fail' {
-        Initialize-Test
-        GivenRepository 'Fubar'
-        Invoke-Publish -ForRepositoryNamed 'Fubar' -WithInvalidPath  -ErrorAction SilentlyContinue
+        Init
+        WhenPublishing -WithInvalidPath  -ErrorAction SilentlyContinue
         ThenFailed -WithError 'should resolve to a directory'
-        ThenModuleNotPublished
     }
 }
 
-Describe 'PublishPowerShellModule.when invalid manifest' {
+Describe 'PublishPowerShellModule.when module manifest is invalid' {
     AfterEach { Reset }
     It 'should fail' {
-        Initialize-Test
-        GivenRepository 'Fubar'
-        Invoke-Publish -ForRepositoryNamed 'Fubar' -withoutRegisteredRepo -ForManifestPath 'fubar' -ErrorAction SilentlyContinue
-        ThenFailed -WithError 'path\ "fubar"\ either\ does\ not\ exist'
-        ThenModuleNotPublished
+        Init
+        WhenPublishing -ForManifestPath 'fubar' -ErrorAction SilentlyContinue
+        ThenFailed -WithError '"fubar"\ does\ not\ exist'
     }
 }
 
-Describe 'PublishPowerShellModule.when registering an existing PSRepository under a different name' {
+Describe 'PublishPowerShellModule.when given repository by location and by name' {
     AfterEach { Reset }
-    It 'should use already registered PSRepository' {
-        Initialize-Test
-        GivenRepository -Named 'FirstRepo' -Uri 'https://example.com'
-        Invoke-Publish -ForRepositoryNamed 'ImposterRepo' -RepoAtUri 'https://example.com'
+    It 'should use repository registered by location' {
+        Init
+        GivenRepository -Named 'R7' -At 'R7'
+        WhenPublishing -ToRepo 'R8' -RepoAt $script:publishRoot
         ThenSucceeded
-        ThenRepositoryNotRegistered
-        ThenRepositoryChecked
-        ThenModulePublished -ToRepositoryNamed 'FirstRepo'
-    }
-}
-
-Describe 'PublishPowerShellModule.when re-registering an existing PSRepository under the same name' {
-    AfterEach { Reset }
-    It 'should succeed' {
-        Initialize-Test
-        GivenRepository -Named 'FirstRepo' -Uri 'https://example.com'
-        Invoke-Publish -ForRepositoryNamed 'FirstRepo' -RepoAtUri 'https://example.com'
-        ThenSucceeded
-        ThenRepositoryChecked
-        ThenRepositoryNotRegistered
-        ThenModulePublished -ToRepositoryNamed 'FirstRepo'
+        ThenRepository 'R8' -NotRegistered -NotExists
+        ThenRepository 'R7' -NotRegistered -Exists
+        ThenModulePublished -To 'R7'
     }
 }

--- a/Test/Version.Tests.ps1
+++ b/Test/Version.Tests.ps1
@@ -1,4 +1,7 @@
 
+#Requires -Version 5.1
+Set-StrictMode -Version 'Latest'
+
 & (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-WhiskeyTest.ps1' -Resolve)
 
 [Whiskey.Context]$context = $null

--- a/Test/WhiskeyTest.psm1
+++ b/Test/WhiskeyTest.psm1
@@ -532,6 +532,11 @@ function Remove-DotNet
 
 function Reset-WhiskeyTestPSModule
 {
+    if( -not (Test-Path -Path 'variable:TestDrive') )
+    {
+        return
+    }
+
     Get-Module |
         Where-Object { $_.Path -like ('{0}*' -f $TestDrive.FullName) } |
         Remove-Module -Force
@@ -540,6 +545,11 @@ function Reset-WhiskeyTestPSModule
 
 function Reset-WhiskeyPSModulePath
 {
+    if( -not (Test-Path -Path 'variable:TestDrive') )
+    {
+        return
+    }
+
     $whiskeyPSModulesPath = Join-Path -Path $PSScriptRoot -ChildPath '..\PSModules' -Resolve
     $pesterTestDriveRoot = $TestDrive.Fullname | Split-Path
     $pesterTestDriveRoot.TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Whiskey.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.48.4'
+    ModuleVersion = '0.49.0'
 
     # ID used to uniquely identify this module
     GUID = '93bd40f1-dee5-45f7-ba98-cb38b7f5b897'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,9 +39,17 @@ environment:
     job_group: pwsh
     appveyor_build_worker_image: Ubuntu
 
-  - job_name: PowerShell 7.1 on Windows with Deploy
-    job_group: pwsh_deploy
+  - job_name: PowerShell 7.1 on Windows
+    job_group: pwsh
     appveyor_build_worker_image: Visual Studio 2019
+
+
+artifacts:
+- path: .output\*.zip
+  name: GitHub
+- path: .output\*.nupkg
+  name: PowerShellGallery
+- path: .output\*
 
 
 
@@ -60,11 +68,3 @@ for:
   build_script:
   - pwsh: ./build.ps1
 
-# Build and Deploy
-- matrix:
-    only:
-    - job_group: pwsh_deploy
-  environment:
-    PUBLISH: True
-  build_script:
-  - pwsh: .\build.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,74 +1,62 @@
-image:
-- Visual Studio 2013
-- Visual Studio 2019
+version: 0.0.0+{build}
 
-# environment:
-#   matrix:
-#     - PSCMD: ps
-#     - PSCMD: pwsh
+skip_tags: true
+
+skip_branch_with_pr: true
+
+build:
+  verbosity: minimal
+
+test: off
+
+environment:
+  matrix:
+  # TODO: Get builds working on PowerShell 7.2 on Windows.
+  # - job_name: PowerShell 7.2 on Windows
+  #   job_group: pwsh
+  #   appveyor_build_worker_image: Visual Studio 2022
+
+  # TODO: Get builds working on macOS.
+  # - job_name: PowerShell 7.1 on macOS
+  #   job_group: pwsh
+  #   appveyor_build_worker_image: macOS
+
+  - job_name: Windows PowerShell 5.1/.NET 4.6.2
+    job_group: ps
+    appveyor_build_worker_image: Visual Studio 2013
+
+  - job_name: Windows PowerShell 5.1/.NET 4.8
+    job_group: ps
+    appveyor_build_worker_image: Visual Studio 2019
+
+  - job_name: PowerShell 6.2 on Windows
+    job_group: pwsh
+    appveyor_build_worker_image: Visual Studio 2015
+
+  - job_name: PowerShell 7.2 on Ubuntu
+    job_group: pwsh
+    appveyor_build_worker_image: Ubuntu
+
+  - job_name: PowerShell 7.1 on Windows
+    job_group: pwsh
+    appveyor_build_worker_image: Visual Studio 2019
+
+
+artifacts:
+- path: .output\*
+
 
 for:
+# Build in Windows PowerShell
 - matrix:
     only:
-      - image: Visual Studio 2013
+    - job_group: ps
   build_script:
-    - ps: $PSVersionTable
-
-- matrix:
-    only:
-      - image: Visual Studio 2013
-  build_script:
-    - pwsh: $PSVersionTable
-  # exclude:
-  #   - image: Visual Studio 2013
-  #     PSEXE: pwsh
-
-# version: 0.0.0+{build}
-
-# skip_tags: true
-
-# skip_branch_with_pr: true
-
-# build:
-#   verbosity: minimal
-
-# test: off
-
-# image:
-# # TODO: Get builds working on these images.
-# - macOS
-# - Ubuntu
-# - Visual Studio 2013
-# - Visual Studio 2015
-# - Visual Studio 2019
-# - Visual Studio 2022
-
-# environment:
-#   matrix:
-#   - EDITION: ps
-#   - EDITION: pwsh
-
-# artifacts:
-# - path: .output\*.zip
-#   name: GitHub
-# - path: .output\*.nupkg
-#   name: PowerShellGallery
-# - path: .output\*
-
-# for:
-# # Build in Windows PowerShell
-# - matrix:
-#     only:
-#     - image: Visual Studio 2013
-#     - image: Visual Studio 2019
-#   build_script:
-#   - ps: $PSVersionTable
-
+  - ps: .\build.ps1
 
 # Build in PowerShell
-# - matrix:
-#     except:
-#     - image: Visual Studio 2013
-#   build_script:
-#   - pwsh: $PSVersionTable
-
+- matrix:
+    only:
+    - job_group: pwsh
+  build_script:
+  - pwsh: ./build.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,68 +1,74 @@
+image:
+- Visual Studio 2013
+- Visual Studio 2019
 
-version: 0.0.0+{build}
-
-skip_tags: true
-
-skip_branch_with_pr: true
-
-build:
-  verbosity: minimal
-
-test: off
-
-environment:
-  matrix:
-  # TODO: Get builds working on PowerShell 7.2 on Windows.
-  # - job_name: PowerShell 7.2 on Windows
-  #   job_group: pwsh
-  #   appveyor_build_worker_image: Visual Studio 2022
-
-  # TODO: Get builds working on macOS.
-  # - job_name: PowerShell 7.1 on macOS
-  #   job_group: pwsh
-  #   appveyor_build_worker_image: macOS
-
-  - job_name: Windows PowerShell 5.1/.NET 4.6.2
-    job_group: ps
-    appveyor_build_worker_image: Visual Studio 2013
-
-  - job_name: Windows PowerShell 5.1/.NET 4.8
-    job_group: ps
-    appveyor_build_worker_image: Visual Studio 2019
-
-  - job_name: PowerShell 6.2 on Windows
-    job_group: pwsh
-    appveyor_build_worker_image: Visual Studio 2015
-
-  - job_name: PowerShell 7.2 on Ubuntu
-    job_group: pwsh
-    appveyor_build_worker_image: Ubuntu
-
-  - job_name: PowerShell 7.1 on Windows
-    job_group: pwsh
-    appveyor_build_worker_image: Visual Studio 2019
-
-
-artifacts:
-- path: .output\*.zip
-  name: GitHub
-- path: .output\*.nupkg
-  name: PowerShellGallery
-- path: .output\*
-
+# environment:
+#   matrix:
+#     - PSCMD: ps
+#     - PSCMD: pwsh
 
 for:
-# Build in Windows PowerShell
 - matrix:
     only:
-    - job_group: ps
+      - image: Visual Studio 2013
   build_script:
-  - ps: .\build.ps1
+    - ps: $PSVersionTable
+
+- matrix:
+    only:
+      - image: Visual Studio 2013
+  build_script:
+    - pwsh: $PSVersionTable
+  # exclude:
+  #   - image: Visual Studio 2013
+  #     PSEXE: pwsh
+
+# version: 0.0.0+{build}
+
+# skip_tags: true
+
+# skip_branch_with_pr: true
+
+# build:
+#   verbosity: minimal
+
+# test: off
+
+# image:
+# # TODO: Get builds working on these images.
+# - macOS
+# - Ubuntu
+# - Visual Studio 2013
+# - Visual Studio 2015
+# - Visual Studio 2019
+# - Visual Studio 2022
+
+# environment:
+#   matrix:
+#   - EDITION: ps
+#   - EDITION: pwsh
+
+# artifacts:
+# - path: .output\*.zip
+#   name: GitHub
+# - path: .output\*.nupkg
+#   name: PowerShellGallery
+# - path: .output\*
+
+# for:
+# # Build in Windows PowerShell
+# - matrix:
+#     only:
+#     - image: Visual Studio 2013
+#     - image: Visual Studio 2019
+#   build_script:
+#   - ps: $PSVersionTable
+
 
 # Build in PowerShell
-- matrix:
-    only:
-    - job_group: pwsh
-  build_script:
-  - pwsh: ./build.ps1
+# - matrix:
+#     except:
+#     - image: Visual Studio 2013
+#   build_script:
+#   - pwsh: $PSVersionTable
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+
 version: 0.0.0+{build}
 
 skip_tags: true
@@ -10,8 +11,6 @@ build:
 test: off
 
 environment:
-  global:
-    PUBLISH: False
   matrix:
   # TODO: Get builds working on PowerShell 7.2 on Windows.
   # - job_name: PowerShell 7.2 on Windows
@@ -50,7 +49,6 @@ artifacts:
 - path: .output\*.nupkg
   name: PowerShellGallery
 - path: .output\*
-
 
 
 for:

--- a/whiskey.yml
+++ b/whiskey.yml
@@ -63,6 +63,35 @@ Build:
     - README.md
     DestinationDirectory: Whiskey
 
+- Zip:
+    ArchivePath: .output\Whiskey-$(WHISKEY_SEMVER2).zip
+    Path: 
+    - Whiskey
+    Exclude:
+    - "*.pdb"
+    - "*.orig"
+
+- Exec:
+    OnlyBy: BuildServer
+    Path: appveyor
+    Argument: [ 'PushArtifact', '.output/Whiskey-$(WHISKEY_SEMVER2).zip', '-DeploymentName', 'GitHub' ]
+
+- PublishPowerShellModule:
+    Path: Whiskey
+
+- PowerShell:
+    ScriptBlock: Get-ChildItem -Path '$(WHISKEY_OUTPUT_DIRECTORY)'
+
+- Exec:
+    OnlyBy: BuildServer
+    Path: appveyor
+    Argument: [
+        'PushArtifact',
+        '.output/Whiskey.$(WHISKEY_SEMVER2_NO_BUILD_METADATA).nupkg',
+        '-DeploymentName',
+        'PowerShellGallery'
+    ]
+
 # Testing performance is different between Linux and Windows so we run tests
 # a little differently. Running things in parallel is actually a little slower
 # on Linux (at least under AppVeyor), so we run fewer background jobs. Having
@@ -227,14 +256,3 @@ Build:
     Argument:
         Path: ./.output/pester*.xml
         QueueDuration: "00:10:00"
-
-- Zip:
-    ArchivePath: .output\Whiskey-$(WHISKEY_SEMVER2).zip
-    Path: 
-    - Whiskey
-    Exclude:
-    - "*.pdb"
-    - "*.orig"
-
-- PublishPowerShellModule:
-    Path: Whiskey

--- a/whiskey.yml
+++ b/whiskey.yml
@@ -1,6 +1,3 @@
-PublishOn:
-- master
-- prerelease
 
 Build:
 - TaskDefaults:
@@ -10,7 +7,8 @@ Build:
 - Version:
     Path: Whiskey\Whiskey.psd1
     Prerelease:
-    - prerelease: beta$(WHISKEY_BUILD_NUMBER)
+    - "*/*": alpha.$(WHISKEY_BUILD_NUMBER)
+    - develop: rc.$(WHISKEY_BUILD_NUMBER)
 
 - GetPowerShellModule:
     Name: BuildMasterAutomation
@@ -235,45 +233,9 @@ Build:
         QueueDuration: "00:10:00"
 
 - Zip:
-    ArchivePath: .output\Whiskey.zip
+    ArchivePath: .output\Whiskey-$(WHISKEY_SEMVER2).zip
     Path: 
     - Whiskey
     Exclude:
     - "*.pdb"
     - "*.orig"
-
-Publish:
-- AppVeyorWaitForBuildJobs:
-    UnlessExists: env:APPVEYOR_PULL_REQUEST_NUMBER
-    IfExists: env:WHS_APPVEYOR_BEARER_TOKEN
-    OnlyOnPlatform: Windows
-    ApiKeyID: AppVeyor
-- PublishPowerShellModule:
-    OnlyOnPlatform: Windows
-    UnlessExists: env:APPVEYOR_PULL_REQUEST_NUMBER
-    RepositoryName: PSGallery
-    RepositoryUri: https://powershellgallery.com/api/v2/
-    Path: Whiskey
-    ApiKeyID: PowerShellGallery
-- SetVariableFromPowerShellDataFile:
-    Path: Whiskey\Whiskey.psd1
-    Variables:
-        PrivateData:
-            PSData:
-                ReleaseNotes: RELEASE_NOTES
-- GitHubRelease:
-    OnlyOnPlatform: Windows
-    UnlessExists: env:APPVEYOR_PULL_REQUEST_NUMBER
-    RepositoryName: webmd-health-services/Whiskey
-    ApiKeyID: github.com
-    Tag: $(WHISKEY_SEMVER2_NO_BUILD_METADATA)
-    Commitish: $(WHISKEY_SCM_COMMIT_ID)
-    Name: $(WHISKEY_SEMVER2_NO_BUILD_METADATA)
-    Description: $(RELEASE_NOTES)
-    Assets:
-    - Path: .output\Whiskey.zip
-      ContentType: application/zip
-      Name: Whiskey-$(WHISKEY_SEMVER2_NO_BUILD_METADATA).zip
-    - Path: Whiskey\build.ps1
-      ContentType: text/plain
-      Name: build.ps1

--- a/whiskey.yml
+++ b/whiskey.yml
@@ -7,8 +7,8 @@ Build:
 - Version:
     Path: Whiskey\Whiskey.psd1
     Prerelease:
-    - "*/*": alpha.$(WHISKEY_BUILD_NUMBER)
-    - develop: rc.$(WHISKEY_BUILD_NUMBER)
+    - "*/*": alpha$(WHISKEY_BUILD_NUMBER)
+    - develop: rc$(WHISKEY_BUILD_NUMBER)
 
 - GetPowerShellModule:
     Name: BuildMasterAutomation
@@ -41,10 +41,6 @@ Build:
 - GetPowerShellModule:
     Name: PowerShellGet
     Version: 2.2.5
-
-- GetPowerShellModule:
-    Name: Pester
-    Version: 3.*
 
 - GetPowerShellModule:
     Name: Glob
@@ -239,3 +235,6 @@ Build:
     Exclude:
     - "*.pdb"
     - "*.orig"
+
+- PublishPowerShellModule:
+    Path: Whiskey


### PR DESCRIPTION
Made the changes necessary to allow developers to publish PowerShell modules in AppVeyor from any build artifact. This allows developers to publish prerelease versions without having to merge changes to a specific branch.

I've also changed Whiskey's publishing process to no longer deploy during a build on the master branch. Instead, a master build creates artifacts without prerelease metadata, that are suitable for release to the PowerShell Gallery and GitHub.

The release notes in GitHub are taken from the commit message merging into the master branch. So, we'll have to make sure we update the GitHub release with the release notes from CHANGELOG.md. AppVeyor doesn't currently have a way to set the release description from build artifacts.