### PR TITLE
Determine prerelease version from published packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # 0.50.0
 
+## Added
+
+* Whiskey's "Version" task now calculates the next prerelease version number for a package by querying the package's
+  package repository.
+
 ## Fixed
 
 * Fixed: Parallel task fails if it runs a custom task that was imported from a module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 
 # 0.50.0
 
+## Upgrade Instructions
+
+Whiskey now requires PackageManagement 1.4.7 and PowerShellGet 2.2.5 to be installed on any computer on which it runs.
+Please ensure these modules are installed.
+
 ## Added
 
 * Whiskey's "Version" task now calculates the next prerelease version number for a package by querying the package's
   package repository.
+
+## Changed
+
+* Whiskey now depends on and requires PackageManagement 1.4.7 and PowerShellGet 2.2.5. These must be pre-installed on
+computers running whiskey.
 
 ## Fixed
 

--- a/Test/Find-WhiskeyPowerShellModule.Tests.ps1
+++ b/Test/Find-WhiskeyPowerShellModule.Tests.ps1
@@ -2,12 +2,6 @@ Set-StrictMode -Version 'Latest'
 
 & (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-WhiskeyTest.ps1' -Resolve)
 
-# If you want to upgrade the PackageManagement and PowerShellGet versions, you must also update:
-# * Whiskey\Functions\Find-WhiskeyPowerShellModule.ps1
-# * prism.json
-$packageManagementVersion = '1.4.7'
-$powerShellGetVersion = '2.2.5'
-
 $moduleName = $null
 $moduleVersion = $null
 $output = $null
@@ -237,9 +231,7 @@ Describe 'Find-WhiskeyPowerShellModule.when package management modules are not i
     It 'should find it' {
         Init
         GivenName 'Pester'
-        GivenPkgMgmtModulesNotInstalled
         WhenResolvingPowerShellModule
-        ThenPkgManagementModules -Imported -Installed
         ThenReturnedModule 'Pester'
         ThenNoErrors
     }
@@ -251,10 +243,7 @@ Describe 'Find-WhiskeyPowerShellModule.when given module Name "Pester" and Versi
         Init
         GivenName 'Pester'
         GivenVersion '4.3.1'
-        GivenPkgMgmtModulesInstalled
         WhenResolvingPowerShellModule
-        ThenPkgManagementModules -Imported
-        ThenPkgManagementModules -Not -Installed
         ThenReturnedModule 'Pester' -AtVersion '4.3.1'
         ThenNoErrors
     }
@@ -266,10 +255,7 @@ Describe 'Find-WhiskeyPowerShellModule.when given Version wildcard' {
         Init
         GivenName 'Pester'
         GivenVersion '4.3.*'
-        GivenPkgMgmtModulesInstalled
         WhenResolvingPowerShellModule
-        ThenPkgManagementModules -Imported
-        ThenPkgManagementModules -Not -Installed
         ThenReturnedModule 'Pester' -AtVersion '4.3.1'
         ThenNoErrors
     }
@@ -280,10 +266,7 @@ Describe 'Find-WhiskeyPowerShellModule.when given module that does not exist' {
     It 'should fail' {
         Init
         GivenModuleDoesNotExist
-        GivenPkgMgmtModulesInstalled
         WhenResolvingPowerShellModule -ErrorAction SilentlyContinue
-        ThenPkgManagementModules -Imported
-        ThenPkgManagementModules -Not -Installed
         ThenErrorMessage 'Failed to find'
         ThenReturnedNothing
     }
@@ -294,35 +277,8 @@ Describe 'Find-WhiskeyPowerShellModule.when Find-Module returns module from two 
     It 'should pick one' {
         Init
         GivenName 'Pester'
-        GivenPkgMgmtModulesInstalled
         GivenReturnedModuleFromTwoRepositories
         WhenResolvingPowerShellModule
-        ThenPkgManagementModules -Imported
-        ThenPkgManagementModules -Not -Installed
-        ThenReturnedModule 'Pester'
-        ThenNoErrors
-    }
-}
-
-Describe 'Find-WhiskeyPowerShellModule.when module remnants get left behind' {
-    AfterEach { Reset }
-    It 'should clear out the old directory' {
-        Init
-        GivenName 'Pester'
-        GivenPkgMgmtModulesNotInstalled
-        $testModulesRoot = Join-Path -Path $testRoot -ChildPath 'PSModules'
-        $junkPsd1Paths = @(
-            (Join-Path -Path $testModulesRoot -ChildPath "PackageManagement\$($packageManagementVersion)\notinstalled"),
-            (Join-Path -Path $testModulesRoot -ChildPath "PowerShellGet\$($powershellGetVersion)\notinstalled")
-        )
-        foreach( $path in $junkPsd1Paths )
-        {
-            New-Item -Path $path -ItemType 'File' -Force
-        }
-        WhenResolvingPowerShellModule
-        ThenPkgManagementModules -Imported
-        ThenPkgManagementModules 'PackageManagement' -Installed
-        ThenPkgManagementModules 'PowerShellGet' -Installed
         ThenReturnedModule 'Pester'
         ThenNoErrors
     }

--- a/Test/Initialize-WhiskeyTest.ps1
+++ b/Test/Initialize-WhiskeyTest.ps1
@@ -105,25 +105,6 @@ try
         Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'WhiskeyTest.psm1') -Force
     }
 
-    # We load these because they have assemblies and we need to make sure they get loaded from the global location,
-    # otherwise Pester can't delete the test drive (module assemblies are locked) and tests fail.
-    foreach( $name in @( 'PackageManagement', 'PowerShellGet' ) )
-    {
-        if( -not (Test-Import -Name $name) )
-        {
-            continue
-        }
-
-        if( (Get-Module -Name $name) )
-        {
-            Write-Timing ('    Removing {0}' -f $name)
-            Remove-Module -Name $name -Force 
-        }
-
-        Write-Timing ('    Importing {0}' -f $name)
-        Import-WhiskeyTestModule -Name $name -Force
-    }
-
     if( (Get-Module -Name 'WhiskeyTestTasks') )
     {
         Remove-Module -Name 'WhiskeyTestTasks' -Force -ErrorAction Ignore

--- a/Test/PublishPowerShellModule.Tests.ps1
+++ b/Test/PublishPowerShellModule.Tests.ps1
@@ -187,7 +187,6 @@ function WhenPublishing
         }
     }
 
-    Import-WhiskeyTestModule -Name 'PackageManagement','PowerShellGet'
     Mock -CommandName 'Get-PackageProvider' -ModuleName 'Whiskey'
 
     $Global:Error.Clear()

--- a/Test/PublishPowerShellScript.Tests.ps1
+++ b/Test/PublishPowerShellScript.Tests.ps1
@@ -325,7 +325,6 @@ function WhenPublishing
         }
     }
 
-    Import-WhiskeyTestModule -Name 'PackageManagement','PowerShellGet'
     Mock -CommandName 'Get-PackageProvider' -ModuleName 'Whiskey'
 
     $Global:Error.Clear()

--- a/Test/WhiskeyTest.psm1
+++ b/Test/WhiskeyTest.psm1
@@ -104,7 +104,10 @@ function Import-WhiskeyTestModule
 
     foreach( $moduleName in $Name )
     {
-        Import-Module -Name (Join-Path -Path $modulesRoot -ChildPath $moduleName -Resolve) -Force:$Force -Global -WarningAction Ignore
+        Import-Module -Name (Join-Path -Path $modulesRoot -ChildPath $moduleName -Resolve) `
+                      -Force:$Force `
+                      -Global `
+                      -WarningAction Ignore
     }
 }
 
@@ -136,9 +139,6 @@ function Initialize-WhiskeyTestPSModule
     }
 
     $Name = & {
-        # Don't continually download modules.
-        'PackageManagement'
-        'PowerShellGet'
         $Name
     }
 

--- a/Whiskey/Functions/ConvertTo-WhiskeySemanticVersion.ps1
+++ b/Whiskey/Functions/ConvertTo-WhiskeySemanticVersion.ps1
@@ -6,7 +6,8 @@ function ConvertTo-WhiskeySemanticVersion
     Converts an object to a semantic version.
 
     .DESCRIPTION
-    The `ConvertTo-WhiskeySemanticVersion` function converts strings, numbers, and date/time objects to semantic versions. If the conversion fails, it writes an error and you get nothing back. 
+    The `ConvertTo-WhiskeySemanticVersion` function converts strings, numbers, and date/time objects to semantic
+    versions. If the conversion fails, it writes an error and you get nothing back. 
 
     .EXAMPLE
     '1.2.3' | ConvertTo-WhiskeySemanticVersion
@@ -17,7 +18,7 @@ function ConvertTo-WhiskeySemanticVersion
     param(
         [Parameter(ValueFromPipeline)]
         # The object to convert to a semantic version. Can be a version string, number, or date/time.
-        [Object]$InputObject
+        [Object] $InputObject
     )
 
     process

--- a/Whiskey/Functions/Register-WhiskeyPSModulePath.ps1
+++ b/Whiskey/Functions/Register-WhiskeyPSModulePath.ps1
@@ -6,7 +6,6 @@ function Register-WhiskeyPSModulePath
     # those global versions instead of the versions we load from inside Whiskey. So,
     # we have to put the ones that ship with Whiskey first. See
     # https://github.com/PowerShell/PowerShellGet/issues/55 .
-
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,ParameterSetName='FromUser')]

--- a/Whiskey/Tasks/GetPowerShellModule.ps1
+++ b/Whiskey/Tasks/GetPowerShellModule.ps1
@@ -1,7 +1,7 @@
 function Get-WhiskeyPowerShellModule
 {
     [CmdletBinding()]
-    [Whiskey.Task('GetPowerShellModule',SupportsClean,SupportsInitialize)]
+    [Whiskey.Task('GetPowerShellModule', SupportsClean, SupportsInitialize)]
     param(
         [Parameter(Mandatory)]
         [Whiskey.Context]$TaskContext,

--- a/Whiskey/Tasks/PublishPowerShellModule.ps1
+++ b/Whiskey/Tasks/PublishPowerShellModule.ps1
@@ -2,12 +2,8 @@
 function Publish-WhiskeyPowerShellModule
 {
     [Whiskey.Task('PublishPowerShellModule')]
-    # If you want to upgrade the PackageManagement and PowerShellGet versions, you must also update:
-    # * Test\Find-WhiskeyPowerShellModule.Tests.ps1
-    # * Whiskey\Functions\Find-WhiskeyPowerShellModule.ps1
-    # * whiskey.yml
-    [Whiskey.RequiresPowerShellModule('PackageManagement', Version='1.4.7', VersionParameterName='PackageManagementVersion')]
-    [Whiskey.RequiresPowerShellModule('PowerShellGet', Version='2.2.5', VersionParameterName='PowerShellGetVersion')]
+    [Whiskey.RequiresPowerShellModule('PackageManagement', Version='1.*', VersionParameterName='PackageManagementVersion')]
+    [Whiskey.RequiresPowerShellModule('PowerShellGet', Version='2.*', VersionParameterName='PowerShellGetVersion')]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]

--- a/Whiskey/Tasks/Version.ps1
+++ b/Whiskey/Tasks/Version.ps1
@@ -3,7 +3,7 @@
 {
     [CmdletBinding()]
     [Whiskey.Task('Version')]
-    [Whiskey.RequiresPowerShellModule('PackageManagement', Version='1.4.7',
+    [Whiskey.RequiresPowerShellModule('PackageManagement', Version='1.*',
         VersionParameterName='PackageManagementVersion')]
     param(
         [Parameter(Mandatory)]

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -154,7 +154,7 @@
             # IconUri = ''
 
             # Any prerelease to use when publishing to a repository.
-            Prerelease = ''
+            Prerelease = 'beta.45'
 
             # ReleaseNotes of this module
             ReleaseNotes = 'https://github.com/webmd-health-services/Whiskey/blob/master/CHANGELOG.md'

--- a/Whiskey/whiskey.sample.yml
+++ b/Whiskey/whiskey.sample.yml
@@ -49,15 +49,15 @@ Build:
 
     # The prerelease version to use. Usually you only use this if you're also using the
     # Path property.
-    # Prerelease: rc.$(WHISKEY_BUILD_NUMBER)
+    # Prerelease: rc.$(WHISKEY_PRERELEASE_VERSION)
 
     # You can also have different prerelease versions for different branches. Set the 
     # property to a list of key/value pairs. The key should be a wildcard pattern that
     # matches a branch, the value should be the prerelease label to use.
     # 
     # Prelease
-    # - feature/*: alpha.$(WHISKEY_BUILD_NUMBER)
-    # - develop: rc.$(WHISKEY_BUILD_NUMBER)
+    # - feature/*: alpha.$(WHISKEY_PRERELEASE_VERSION)
+    # - develop: rc.$(WHISKEY_PRERELEASE_VERSION)
 
     # Any build metadata to add. Usually you only use this if you're using the Prerelease
     # and/or Path properties.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,7 +72,15 @@ for:
       }
       $job | Wait-Job | Receive-Job
       $job | Remove-Job
-  - ps: Write-Host $PID ; .\build.ps1
+  - ps: |
+      try
+      {
+          ./build.ps1
+      }
+      finally
+      {
+          $Global:Error | Format-List * -Force
+      }
 
 # Build in PowerShell
 - matrix:
@@ -85,4 +93,12 @@ for:
                        -SourceLocation 'https://www.powershellgallery.com/api/v2'
       Get-PSRepository | Format-Table -Auto
       Install-Module -Name 'Prism' -Scope CurrentUser
-  - pwsh: Write-Host $PID ; ./build.ps1
+  - pwsh: |
+      try
+      {
+          ./build.ps1
+      }
+      finally
+      {
+          $Global:Error | Format-List * -Force
+      }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,27 +54,9 @@ for:
     - job_group: ps
   build_script:
   - ps: |
-      # Run in a background job so that old PackageManagement assemblies don't get loaded.
-      $job = Start-Job {
-          $psGalleryRepo = Get-PSRepository -Name 'PSGallery'
-          $repoToUse = $psGalleryRepo.Name
-          # On Windows 2012 R2, Windows PowerShell 5.1, and .NET 4.6.2, PSGallery's URL ends with a '/'.
-          if( -not $psGalleryRepo -or $psgalleryRepo.SourceLocation -ne 'https://www.powershellgallery.com/api/v2' )
-          {
-              $repoToUse = 'PSGallery2'
-              Register-PSRepository -Name $repoToUse `
-                                    -InstallationPolicy Trusted `
-                                    -SourceLocation 'https://www.powershellgallery.com/api/v2' `
-                                    -PackageManagementProvider $psGalleryRepo.PackageManagementProvider
-          }
-          Get-PSRepository | Format-Table -Auto
-          Install-Module -Name 'Prism' -Scope CurrentUser -Repository $repoToUse
-      }
-      $job | Wait-Job | Receive-Job
-      $job | Remove-Job
-  - ps: |
       try
       {
+          ./init.ps1
           ./build.ps1
       }
       finally
@@ -88,14 +70,9 @@ for:
     - job_group: pwsh
   build_script:
   - pwsh: |
-      Set-PSRepository -Name 'PSGallery' `
-                       -InstallationPolicy Trusted `
-                       -SourceLocation 'https://www.powershellgallery.com/api/v2'
-      Get-PSRepository | Format-Table -Auto
-      Install-Module -Name 'Prism' -Scope CurrentUser
-  - pwsh: |
       try
       {
+          ./init.ps1
           ./build.ps1
       }
       finally

--- a/init.ps1
+++ b/init.ps1
@@ -1,0 +1,47 @@
+[CmdletBinding()]
+param(
+)
+
+Set-StrictMode -Version 'Latest'
+$InformationPreference = 'Continue'
+
+# Run in a background job so that old PackageManagement assemblies don't get loaded.
+$job = Start-Job {
+    $InformationPreference = 'Continue'
+    $psGalleryRepo = Get-PSRepository -Name 'PSGallery'
+    $repoToUse = $psGalleryRepo.Name
+    # On Windows 2012 R2, Windows PowerShell 5.1, and .NET 4.6.2, PSGallery's URL ends with a '/'.
+    if( -not $psGalleryRepo -or $psgalleryRepo.SourceLocation -ne 'https://www.powershellgallery.com/api/v2' )
+    {
+        $repoToUse = 'PSGallery2'
+        Register-PSRepository -Name $repoToUse `
+                              -InstallationPolicy Trusted `
+                              -SourceLocation 'https://www.powershellgallery.com/api/v2' `
+                              -PackageManagementProvider $psGalleryRepo.PackageManagementProvider
+    }
+
+    Write-Information -MessageData 'Installing latest version of PowerShell module Prism.'
+    Install-Module -Name 'Prism' -Scope CurrentUser -Repository $repoToUse -AllowClobber -Force
+
+    if( -not (Get-Module -Name 'PackageManagement' -ListAvailable | Where-Object 'Version' -eq '1.4.7') )
+    {
+        Write-Information -MessageData 'Installing PowerShell module PackageManagement 1.4.7.'
+        Install-Module -Name 'PackageManagement' -RequiredVersion '1.4.7'-Repository $repoToUse -AllowClobber -Force
+    }
+
+    if( -not (Get-Module -Name 'PowerShellGet' -ListAvailable | Where-Object 'Version' -eq '2.2.5') )
+    {
+        Write-Information -MessageData 'Installing PowerShell module PowerShellGet 2.2.5.'
+        Install-Module -Name 'PowerShellGet' -RequiredVersion '2.2.5' -Repository $repoToUse -AllowClobber -Force
+    }
+}
+
+if( (Get-Command -Name 'Receive-Job' -ParameterName 'AutoRemoveJob') )
+{
+    $job | Receive-Job -AutoRemoveJob -Wait
+}
+else
+{
+    $job | Wait-Job | Receive-Job
+    $job | Remove-Job
+}

--- a/prism.json
+++ b/prism.json
@@ -25,14 +25,6 @@
             "Version": "5.*"
         },
         {
-            "Name": "PackageManagement",
-            "Version": "1.*"
-        },
-        {
-            "Name": "PowerShellGet",
-            "Version": "2.*"
-        },
-        {
             "Name": "Pester",
             "Version": "3.*"
         },

--- a/prism.lock.json
+++ b/prism.lock.json
@@ -31,16 +31,6 @@
                           "repositorySourceLocation":  "https://www.powershellgallery.com/api/v2"
                       },
                       {
-                          "name":  "PackageManagement",
-                          "version":  "1.4.7",
-                          "repositorySourceLocation":  "https://www.powershellgallery.com/api/v2"
-                      },
-                      {
-                          "name":  "PowerShellGet",
-                          "version":  "2.2.5",
-                          "repositorySourceLocation":  "https://www.powershellgallery.com/api/v2"
-                      },
-                      {
                           "name":  "Pester",
                           "version":  "3.4.6",
                           "repositorySourceLocation":  "https://www.powershellgallery.com/api/v2"

--- a/whiskey.yml
+++ b/whiskey.yml
@@ -6,15 +6,16 @@ Build:
 
 - Version:
     Path: Whiskey\Whiskey.psd1
+    PowerShellModuleName: Whiskey
     Prerelease:
-    - "*/*": alpha$(WHISKEY_BUILD_NUMBER)
-    - develop: rc$(WHISKEY_BUILD_NUMBER)
+    - "*/*": alpha1
+    - develop: rc1
 
 # Update the AppVeyor build/version number.
 - Exec:
       OnlyBy: BuildServer
       Path: appveyor
-      Argument: [ UpdateBuild, -Version, $(WHISKEY_SEMVER2) ]
+      Argument: [ UpdateBuild, -Version, "$(WHISKEY_SEMVER2)+$(WHISKEY_BUILD_NUMBER)" ]
 
 - PowerShell:
     ScriptBlock: prism install


### PR DESCRIPTION
Instead of using the build number as the prerelease number, if building a package that gets published, Whiskey will look at currently-published packages to determine what the next prerelease number should be.

Also, it's getting to be too much work to ensure old versions of PackageManagement and PowerShellGet aren't loaded before we get a chance to install 1.4.7 and 2.2.5 respectively. So now Whiskey requires them to be pre-installed.