### PR TITLE
Fixed: Ignore is not allowed as a value in the $ErrorActionPreference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+# 0.52.2
+
+* Fixed: `Ignore` is not allowed as a value in the `$ErrorActionPreference` variable when running `node.exe` executable
+  directly from filepath.
+
+
 # 0.52.1
 
 * Fixed: typo in command name. Mis-typed `Convert-Path` as `ConvertPath`.

--- a/Whiskey/Functions/Invoke-WhiskeyNpmCommand.ps1
+++ b/Whiskey/Functions/Invoke-WhiskeyNpmCommand.ps1
@@ -81,7 +81,7 @@ function Invoke-WhiskeyNpmCommand
             # The ISE bails if processes write anything to STDERR. Node writes notices and warnings to
             # STDERR. We only want to stop a build if the command actually fails.
             $originalEap = $ErrorActionPreference
-            if( $ErrorActionPreference -ne 'SilentlyContinue' -and $ErrorActionPreference -ne 'Ignore' )
+            if( $ErrorActionPreference -ne 'SilentlyContinue' )
             {
                 $ErrorActionPreference = 'Continue'
             }

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Whiskey.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.52.1'
+    ModuleVersion = '0.52.2'
 
     # ID used to uniquely identify this module
     GUID = '93bd40f1-dee5-45f7-ba98-cb38b7f5b897'


### PR DESCRIPTION
 Ignore is not allowed as a value in the $ErrorActionPreference variable when running node.exe directly from filepath.