### PR TITLE
Build fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+# 0.53.3
+
+Fixed: MSBuild task throws an unhelpful internal error when given a `NuGetVersion` that does not exist.
+
 # 0.53.2
 
 Fixed: PublishBitbucketServerTag task fails when building a pull request in Jenkins. When building PRs, Jenkins merges

--- a/Test/Install-WhiskeyTool.Tests.ps1
+++ b/Test/Install-WhiskeyTool.Tests.ps1
@@ -70,7 +70,7 @@ function Invoke-NuGetInstall
         {
             $result | Should -Not -Exist
         }
-        # $Error has nuget.exe's STDERR depending on your console. 
+        # $Error has nuget.exe's STDERR depending on your console.
         $Global:Error.Count | Should -BeLessThan 9
         if( $ExpectedError )
         {
@@ -113,7 +113,7 @@ if( $IsWindows )
     Describe 'Install-WhiskeyTool.when NuGet pack Version is bad' {
         It 'should fail' {
             Init
-            Invoke-NugetInstall -package 'Nunit.Runners' -version '0.0.0' -invalidPackage -ErrorAction silentlyContinue
+            Invoke-NugetInstall -package 'Nunit.Runners' -version '0.0.0' -invalidPackage -ExpectedError 'NuGet package Nunit.Runners 0.0.0 does not exist or search request failed.' -ErrorAction silentlyContinue
         }
     }
 
@@ -450,8 +450,8 @@ Describe 'Install-WhiskeyTool.when installing a PowerShell module and task needs
         $attr.ModuleInfoParameterName = 'ZipModuleInfo'
         $attr.Version = '0.2.0'
         $attr.SkipImport = $true
-        WhenInstallingTool -FromAttribute $attr 
-        $assertMockParams = @{ 
+        WhenInstallingTool -FromAttribute $attr
+        $assertMockParams = @{
             'CommandName' = 'Install-WhiskeyPowerShellModule';
             'ModuleName' = 'Whiskey';
         }
@@ -472,8 +472,8 @@ Describe 'Install-WhiskeyTool.when installing a PowerShell module and task doesn
         $attr = New-Object 'Whiskey.RequiresPowerShellModuleAttribute' -ArgumentList 'Zip'
         $attr.Version = '0.2.0'
         $attr.SkipImport = $true
-        WhenInstallingTool -FromAttribute $attr 
-        $assertMockParams = @{ 
+        WhenInstallingTool -FromAttribute $attr
+        $assertMockParams = @{
             'CommandName' = 'Install-WhiskeyPowerShellModule';
             'ModuleName' = 'Whiskey';
         }

--- a/Test/Install-WhiskeyTool.Tests.ps1
+++ b/Test/Install-WhiskeyTool.Tests.ps1
@@ -93,7 +93,7 @@ if( $IsWindows )
             Init
             Invoke-NuGetInstall -package 'NUnit.Console' -version '3.15.0' -WithDependencies @(
                 'NUnit.Console.3.15.0',
-                'NUnit.ConsoleRunner.3.15.*',
+                'NUnit.ConsoleRunner.3.*',
                 'NUnit.Extension.NUnitProjectLoader.3.7.1',
                 'NUnit.Extension.NUnitV2Driver.3.9.0',
                 'NUnit.Extension.NUnitV2ResultWriter.3.7.0',

--- a/Test/MSBuild.Tests.ps1
+++ b/Test/MSBuild.Tests.ps1
@@ -198,7 +198,7 @@ function WhenRunningTask
     $Global:Error.Clear()
     try
     {
-        $script:output = Invoke-WhiskeyTask -TaskContext $context -Parameter $WithParameter -Name 'MSBuild' 
+        $script:output = Invoke-WhiskeyTask -TaskContext $context -Parameter $WithParameter -Name 'MSBuild'
         $output | Write-WhiskeyDebug
     }
     catch
@@ -724,7 +724,7 @@ Describe 'MSBuild.when run by developer using a specific version of NuGet' {
     It 'should use that version of NuGet' {
         Init
         GivenProjectsThatCompile
-        GivenNuGetVersion '4.5.0'
+        GivenNuGetVersion '5.9.3'
         WhenRunningTask -AsDeveloper
         ThenSpecificNuGetVersionInstalled
         ThenNuGetPackagesRestored

--- a/Test/NuGetPack.Tests.ps1
+++ b/Test/NuGetPack.Tests.ps1
@@ -75,7 +75,7 @@ function GivenABuiltLibrary
     <Compile Include="NoOp.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
@@ -111,7 +111,7 @@ Build:
     }
 
     Initialize-WhiskeyTestPSModule -Name 'VSSetup' -BuildRoot $testRoot
-    $context = New-WhiskeyContext -Environment 'Verification' -ConfigurationPath $whiskeyYmlPath 
+    $context = New-WhiskeyContext -Environment 'Verification' -ConfigurationPath $whiskeyYmlPath
     if( $InReleaseMode )
     {
         $context.RunBy = [Whiskey.RunBy]::BuildServer
@@ -131,7 +131,7 @@ function GivenFile
         $Content
     )
 
-    $Content | Set-Content -Path (Join-Path -Path $testRoot -ChildPath $Name) 
+    $Content | Set-Content -Path (Join-Path -Path $testRoot -ChildPath $Name)
 }
 
 function GivenRunByBuildServer
@@ -158,7 +158,7 @@ function GivenVersion
     param(
         $version
     )
-    
+
     $script:version = $version
 }
 
@@ -184,9 +184,9 @@ function WhenRunningNuGetPackTask
     {
         $byItDepends['ForDeveloper'] = $true
     }
-            
+
     $script:context = New-WhiskeyTestContext -ForVersion '1.2.3+buildstuff' -ForBuildRoot $testRoot @byItDepends
-    
+
     Get-ChildItem -Path $context.OutputDirectory | Remove-Item -Recurse -Force
 
     $taskParameter = @{ }
@@ -200,7 +200,7 @@ function WhenRunningNuGetPackTask
     {
         $taskParameter['Symbols'] = $true
     }
-    
+
     if( $version )
     {
         $taskParameter['Version'] = $version
@@ -366,7 +366,7 @@ Describe 'NuGetPack.when creating multiple packages for publishing' {
         InitTest
         GivenABuiltLibrary
         GivenPath @( $projectName, $projectName )
-        WhenRunningNugetPackTask 
+        WhenRunningNugetPackTask
         ThenPackageCreated
         ThenTaskSucceeds
     }
@@ -376,7 +376,7 @@ Describe 'NuGetPack.when creating a package using a specifc version of NuGet' {
     It 'should download and use that version of NuGet' {
         InitTest
         GivenABuiltLibrary
-        GivenVersion '4.5.0'
+        GivenVersion '5.9.3'
         WhenRunningNuGetPackTask
         ThenSpecificNuGetVersionInstalled
         ThenTaskSucceeds

--- a/Whiskey/Functions/Install-WhiskeyNuGetPackage.ps1
+++ b/Whiskey/Functions/Install-WhiskeyNuGetPackage.ps1
@@ -39,6 +39,11 @@ function Install-WhiskeyNuGetPackage
         $waitMilliseconds = $waitMilliseconds + 2
     }
 
+    if( $Version )
+    {
+        $pkgVersions = $pkgVersions | Where-Object 'Version' -Like $Version
+    }
+
     if( -not $pkgVersions )
     {
         $pkgMgmtErrors | Write-Error
@@ -51,11 +56,6 @@ function Install-WhiskeyNuGetPackage
     for( $idx = 0; $idx -lt $Global:Error.Count - $numErrors; ++$idx )
     {
         $Global:Error.RemoveAt(0)
-    }
-
-    if( $Version )
-    {
-        $pkgVersions = $pkgVersions | Where-Object 'Version' -Like $Version
     }
 
     $pkg = $pkgVersions | Select-Object -First 1

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Whiskey.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.53.2'
+    ModuleVersion = '0.53.3'
 
     # ID used to uniquely identify this module
     GUID = '93bd40f1-dee5-45f7-ba98-cb38b7f5b897'


### PR DESCRIPTION
- Fixed: MSBuild task throws an unhelpful internal error when given a `NuGetVersion` that does not exist.
- NuGet.CommandLine 4.5.0 doesn't seem to exist anymore
- Update version and add to changelog