### PR TITLE
Version task updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,21 @@
 <!--markdownlint-disable MD012 no-multiple-blanks -->
 <!--markdownlint-disable MD024 no-duplicate-heading/no-duplicate-header -->
 
+# 0.60.0
+
+> Released 03 Oct 2023
+
+* The `Version` task will no longer retrieve the next patch and prerelease versions by default. The
+`IncrementPatchVersion` and `IncrementPrereleaseVersion` parameters can be passed to this task to retrieve their
+respective versions.
+
+
 # 0.59.0
 
 > Released 21 Apr 2023
 
 * Updated Whiskey to use ProGetAutomation `2.*` by default.
 * Fixed: arguments aren't passed to nested tasks.
-
 
 
 # 0.58.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 # 0.60.0
 
-> Released 03 Oct 2023
+> Released 09 Oct 2023
 
 * The `Version` task will no longer retrieve the next patch and prerelease versions by default. The
 `IncrementPatchVersion` and `IncrementPrereleaseVersion` parameters can be passed to this task to retrieve their

--- a/Test/NodeLicenseChecker.Tests.ps1
+++ b/Test/NodeLicenseChecker.Tests.ps1
@@ -89,7 +89,7 @@ function ThenTaskFailedWithMessage
 function ThenTaskSucceeded
 {
     # filter out the NPM Warn messages out of the error record
-    $TaskErrors = $Global:Error | Where-Object { $_ -notmatch 'npm WARN' }
+    $TaskErrors = $Global:Error | Where-Object { $_ -match 'npm ERR!' }
     $TaskErrors | Should -BeNullOrEmpty
     $failed | Should -BeFalse
 }

--- a/Test/Version.Tests.ps1
+++ b/Test/Version.Tests.ps1
@@ -408,6 +408,15 @@ Describe 'Version' {
         ThenSemVer2Is '0.41.1-beta.1035' # The last beta version was 0.41.1-beta1034, so next one should be beta1035.
     }
 
+    It 'should not increment prerelease when the increment prerelease switch is false' {
+        GivenFile 'Whiskey.psd1' '@{ ModuleVersion = ''0.41.1'' ; PrivateData = @{ PSData = @{ Prerelease = ''beta.1'' } } }'
+        GivenProperty @{ Path = 'Whiskey.psd1'; IncrementPrereleaseVersion = $false; }
+        WhenRunningTask
+        ThenVersionIs '0.41.1'
+        ThenSemVer1Is '0.41.1-beta1'
+        ThenSemVer2Is '0.41.1-beta.1'
+    }
+
     It 'should read version from packageJson file' {
         GivenFile 'package.json' '{ "Version": "4.2.3-rc.1" }'
         GivenProperty @{ Path = 'package.json' }

--- a/Test/Version.Tests.ps1
+++ b/Test/Version.Tests.ps1
@@ -401,7 +401,7 @@ Describe 'Version' {
 
     It 'should use prerelease version from the PowerShell Gallery' {
         GivenFile 'Whiskey.psd1' '@{ ModuleVersion = ''0.41.1'' ; PrivateData = @{ PSData = @{ Prerelease = ''beta.1'' } } }'
-        GivenProperty @{ Path = 'Whiskey.psd1' }
+        GivenProperty @{ Path = 'Whiskey.psd1'; IncrementPrereleaseVersion = $true; }
         WhenRunningTask
         ThenVersionIs '0.41.1'
         ThenSemVer1Is '0.41.1-beta1035'
@@ -421,7 +421,7 @@ Describe 'Version' {
         Invoke-WhiskeyPrivateCommand -Name 'Install-WhiskeyNode' `
                                      -Parameter @{ InstallRootPath = $testRoot ; OutFileRootPath = $testRoot }
         GivenFile 'package.json' '{ "name": "react-native", "version": "0.68.0-rc.0" }'
-        GivenProperty @{ Path = 'package.json' }
+        GivenProperty @{ Path = 'package.json'; IncrementPrereleaseVersion = $true; }
         WhenRunningTask
         ThenVersionIs '0.68.0'
         ThenSemVer1Is '0.68.0-rc5'
@@ -477,7 +477,7 @@ Describe 'Version' {
   </PropertyGroup>
 </Project>
 '@
-        GivenProperty @{ Path = 'lib.csproj' }
+        GivenProperty @{ Path = 'lib.csproj'; IncrementPrereleaseVersion = $true;  }
         WhenRunningTask
         ThenVersionIs '3.0.0'
         if( Get-PackageSource -ProviderName 'NuGet' )
@@ -493,7 +493,7 @@ Describe 'Version' {
     }
 
     It 'should use next prerelease version based on what is in NuGet' {
-        GivenProperty @{ Version = '3.0.0-alpha-0' ; NuGetPackageID = 'NUnit' }
+        GivenProperty @{ Version = '3.0.0-alpha-0' ; NuGetPackageID = 'NUnit'; IncrementPrereleaseVersion = $true;  }
         WhenRunningTask
         ThenVersionIs '3.0.0'
         if( Get-PackageSource -ProviderName 'NuGet' )
@@ -604,7 +604,7 @@ Describe 'Version' {
     Context 'by build server' {
         It 'should set prerelease metadata' {
             GivenFile 'Whiskey.psd1' '@{ ModuleVersion = ''0.41.1'' }'
-            GivenProperty @{ 'Path' = 'Whiskey.psd1'; Prerelease = @( @{ 'alpha/*' = 'alpha.1' } ), @( @{ 'beta/*' = 'beta.2' } ) }
+            GivenProperty @{ 'Path' = 'Whiskey.psd1'; Prerelease = @( @{ 'alpha/*' = 'alpha.1' } ), @( @{ 'beta/*' = 'beta.2' } ); IncrementPrereleaseVersion = $true; }
             GivenBranch 'beta/some-feature'
             WhenRunningTask
             ThenVersionIs '0.41.1'
@@ -738,6 +738,7 @@ description 'Installs/Configures cookbook_name'
             UPackName = 'Fu bar';
             ProGetUrl = 'https://example.com:3344';
             UPackFeedName = 'Apps';
+            IncrementPrereleaseVersion = $true;
         }
         ThenVersionIs '1.0.0'
         ThenSemVer1Is '1.0.0-rc6'
@@ -753,6 +754,7 @@ description 'Installs/Configures cookbook_name'
         GivenCurrentVersion '1.0.0-rc.1'
         GivenUniversalPackageVersions @()
         WhenRunningTask -WithProperties @{
+            IncrementPrereleaseVersion = $true;
             UPackName = 'snafu';
             ProGetUrl = 'https://example.com';
             UPackFeedName = 'Apps';
@@ -883,6 +885,7 @@ Build:
     Path: Module.psd1
     Prerelease:
     - "*": "rc.1"
+    IncrementPrereleaseVersion: true
 "@
         WhenRunningTask -WithYaml $yaml -ForPSModule 'Module' -At $sourceLocation -WithVersion @(
             '4.9.0-rc1',

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Whiskey.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.59.0'
+    ModuleVersion = '0.60.0'
 
     # ID used to uniquely identify this module
     GUID = '93bd40f1-dee5-45f7-ba98-cb38b7f5b897'


### PR DESCRIPTION
* The `Version` task will no longer retrieve the next patch and prerelease versions by default. The
`IncrementPatchVersion` and `IncrementPrereleaseVersion` parameters can be passed to this task to retrieve their
respective versions.