### PR TITLE
Version task fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 <!--markdownlint-disable MD012 no-multiple-blanks -->
 <!--markdownlint-disable MD024 no-duplicate-heading/no-duplicate-header -->
 
+# 0.60.1
+
+> Released 11 Oct 2023
+
+Fixed: The `Version` task incremments the prerelease version even though a prerelease label doesn't exist.
+
+
 # 0.60.0
 
 > Released 09 Oct 2023

--- a/Test/Version.Tests.ps1
+++ b/Test/Version.Tests.ps1
@@ -417,6 +417,15 @@ Describe 'Version' {
         ThenSemVer2Is '0.41.1-beta.1'
     }
 
+    It 'should not increment prerelease version when the prerelease tag doesn''t exist' {
+        GivenFile 'Whiskey.psd1' '@{ ModuleVersion = ''0.41.1'' }'
+        GivenProperty @{ Path = 'Whiskey.psd1'; IncrementPrereleaseVersion = $true; }
+        WhenRunningTask
+        ThenVersionIs '0.41.1'
+        ThenSemVer1Is '0.41.1'
+        ThenSemVer2Is '0.41.1'
+    }
+
     It 'should read version from packageJson file' {
         GivenFile 'package.json' '{ "Version": "4.2.3-rc.1" }'
         GivenProperty @{ Path = 'package.json' }

--- a/Whiskey/Tasks/Version.ps1
+++ b/Whiskey/Tasks/Version.ps1
@@ -126,6 +126,11 @@ function Set-WhiskeyVersion
                 {
                     $rawVersion = "$($rawVersion)-$($nextPrerelease)"
                 }
+                
+                if (-not $nextPrerelease -and -not $TaskParameter['Prerelease'])
+                {
+                    $IncrementPrereleaseVersion = $false
+                }
 
                 $msg = "Read version ""$($rawVersion)"" from PowerShell module manifest ""$($Path)""."
                 Write-WhiskeyVerbose -Context $TaskContext -Message $msg

--- a/Whiskey/Whiskey.psd1
+++ b/Whiskey/Whiskey.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Whiskey.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.60.0'
+    ModuleVersion = '0.60.1'
 
     # ID used to uniquely identify this module
     GUID = '93bd40f1-dee5-45f7-ba98-cb38b7f5b897'


### PR DESCRIPTION
Fixed: The `Version` task incremments the prerelease version even though a prerelease label doesn't exist.