### PR TITLE
Fixed: Version task fails when Chef cookbook metadata file uses LF line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,8 @@ The `Uri` property on the `NuGetPush`, `PublishBitbucketServerTag`, and `Publish
   task is run. The proper way for a task to fail a build is to throw a terminating error by calling `Stop-WhiskeyError`.
 * `TaskDefaults` task fails to set default properties using task aliases.
 * Debug output wasn't disabled when the `.Debug` property is set to `false` on a task.
+* `Version` task fails to resolve version from a Chef cookbook `metadata.rb` file when that file uses line feed (LF)
+  line endings.
 
 ### Removed
 

--- a/Test/Version.Tests.ps1
+++ b/Test/Version.Tests.ps1
@@ -709,6 +709,14 @@ description 'Installs/Configures cookbook_name'
         ThenErrorIs ([regex]::Escape('Unable to locate property "version ''x.x.x''" in metadata.rb file'))
     }
 
+    It 'should read version from a Chef cookbook metadata file with LF line endings' {
+        GivenFile 'metadata.rb' "name 'cookbook_name'`n`nversion '1.0.0'`n"
+        WhenRunningTask -WithProperties @{ Path = 'metadata.rb' }
+        ThenVersionIs '1.0.0'
+        ThenSemVer1Is '1.0.0'
+        ThenSemVer2Is '1.0.0'
+    }
+
     It 'should use source branch name for prerelease branch matching when building a pull request' {
         GivenCurrentVersion '1.0.0'
         GivenBranch 'one'

--- a/Whiskey/Tasks/Version.ps1
+++ b/Whiskey/Tasks/Version.ps1
@@ -301,10 +301,10 @@ function Set-WhiskeyVersion
                     }
                 }
             }
-            elseif( $fileInfo.Name -eq 'metadata.rb' )
+            elseif($fileInfo.Name -eq 'metadata.rb')
             {
-                $metadataContent = Get-Content -Path $Path -Raw
-                $metadataContent = $metadataContent.Split([Environment]::NewLine) | Where-Object { $_ -ne '' }
+                $metadataContent = Get-Content -Path $Path
+                $metadataContent = $metadataContent | Where-Object { $_ }
 
                 $rawVersion = $null
                 foreach( $line in $metadataContent )


### PR DESCRIPTION
* `Version` task fails to resolve version from a Chef cookbook `metadata.rb` file when that file uses line feed (LF)
  line endings.